### PR TITLE
fix(tui): resolve login screen freeze during browser authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,7 @@ dependencies = [
  "cortex-tui-components",
  "crossterm",
  "dirs 6.0.0",
+ "futures",
  "hostname",
  "libc",
  "ratatui",

--- a/src/cortex-tui/Cargo.toml
+++ b/src/cortex-tui/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["full", "sync", "time", "macros"] }
 tokio-stream = { workspace = true }
 async-channel = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
 
 # Serialization
 serde = { workspace = true }


### PR DESCRIPTION
## Problem

The TUI login screen would freeze at "Waiting for browser authentication" after accepting the device code, making it impossible to quit the application.

## Root Cause

The original implementation used synchronous `event::poll()` and `event::read()` which blocked the async runtime, preventing proper processing of async messages from the token polling background task.

## Solution

Replaced blocking synchronous event handling with an async-first architecture:

- **EventStream**: Use crossterm's async `EventStream` for non-blocking keyboard input
- **tokio::select!**: Concurrently wait for terminal events, async token messages, and render ticks  
- **Proper cancellation**: Drop async receiver when user cancels (Esc) to signal background tasks
- **Better UX**: Added 'q' key to exit from waiting screen
- **Observability**: Added tracing logs for auth flow debugging

## Changes

- `src/cortex-tui/src/runner/login_screen.rs`: Refactored event loop to use `tokio::select!`
- `src/cortex-tui/Cargo.toml`: Added `futures` dependency for `StreamExt`
- `Cargo.lock`: Updated dependencies

## Testing

- `cargo check -p cortex-tui` passes
- Manual testing of login flow: keyboard remains responsive during authentication wait