### PR TITLE
fix: batch fix for cortex-cli bugs (exit codes, conflicting flags, JSON output, security)

### DIFF
--- a/src/cortex-cli/src/agent_cmd/handlers/list.rs
+++ b/src/cortex-cli/src/agent_cmd/handlers/list.rs
@@ -1,6 +1,6 @@
 //! Handler for the `agent list` command.
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 
 use crate::agent_cmd::cli::ListArgs;
 use crate::agent_cmd::loader::load_all_agents;
@@ -9,6 +9,13 @@ use crate::agent_cmd::utils::matches_pattern;
 
 /// List agents command.
 pub async fn run_list(args: ListArgs) -> Result<()> {
+    // Validate mutually exclusive flags
+    if args.primary && args.subagents {
+        bail!(
+            "Cannot specify both --primary and --subagents. Choose one filter or use neither for all agents."
+        );
+    }
+
     // Handle --remote flag
     if args.remote {
         println!("Remote agent registry:");

--- a/src/cortex-cli/src/alias_cmd.rs
+++ b/src/cortex-cli/src/alias_cmd.rs
@@ -249,6 +249,8 @@ async fn run_show(args: AliasShowArgs) -> Result<()> {
                     "error": format!("Alias '{}' does not exist", args.name)
                 });
                 println!("{}", serde_json::to_string_pretty(&error)?);
+                // Exit with error code but don't duplicate error message via bail!()
+                std::process::exit(1);
             }
             bail!("Alias '{}' does not exist.", args.name);
         }

--- a/src/cortex-cli/src/alias_cmd.rs
+++ b/src/cortex-cli/src/alias_cmd.rs
@@ -241,10 +241,18 @@ async fn run_remove(args: AliasRemoveArgs) -> Result<()> {
 async fn run_show(args: AliasShowArgs) -> Result<()> {
     let config = load_aliases()?;
 
-    let alias = config
-        .aliases
-        .get(&args.name)
-        .ok_or_else(|| anyhow::anyhow!("Alias '{}' does not exist.", args.name))?;
+    let alias = match config.aliases.get(&args.name) {
+        Some(a) => a,
+        None => {
+            if args.json {
+                let error = serde_json::json!({
+                    "error": format!("Alias '{}' does not exist", args.name)
+                });
+                println!("{}", serde_json::to_string_pretty(&error)?);
+            }
+            bail!("Alias '{}' does not exist.", args.name);
+        }
+    };
 
     if args.json {
         println!("{}", serde_json::to_string_pretty(alias)?);

--- a/src/cortex-cli/src/cli/styles.rs
+++ b/src/cortex-cli/src/cli/styles.rs
@@ -49,8 +49,8 @@ pub const AFTER_HELP: &str = color_print::cstr!(
     <dim>Agents</>      ~/.cortex/agents/ (personal), .cortex/agents/ (project)
 
 <cyan,bold>🔗 LEARN MORE</>
-    <blue,underline>https://docs.cortex.foundation</>         Documentation
-    <blue,underline>https://github.com/CortexLM/cortex-cli</>  Source & Issues"#
+    <blue,underline>https://docs.cortex.foundation</>       Documentation
+    <blue,underline>https://github.com/CortexLM/cortex</>   Source & Issues"#
 );
 
 /// Before-help section with ASCII art banner.

--- a/src/cortex-cli/src/dag_cmd/helpers.rs
+++ b/src/cortex-cli/src/dag_cmd/helpers.rs
@@ -78,8 +78,9 @@ pub fn convert_specs(input: &DagSpecInput) -> Vec<TaskSpec> {
 pub fn print_dag_summary(dag: &TaskDag) {
     println!("Tasks:");
     for task in dag.all_tasks() {
-        let deps = dag
-            .get_dependencies(task.id.unwrap())
+        let deps = task
+            .id
+            .and_then(|id| dag.get_dependencies(id))
             .map(|d| d.len())
             .unwrap_or(0);
         let dep_str = if deps > 0 {
@@ -130,7 +131,11 @@ pub fn print_execution_summary(stats: &DagExecutionStats, format: DagOutputForma
                 "skipped": stats.skipped_tasks,
                 "duration_secs": stats.total_duration.as_secs_f64()
             });
-            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output)
+                    .expect("JSON serialization should not fail for DagExecutionStats")
+            );
         }
         DagOutputFormat::Compact => {
             println!(
@@ -181,7 +186,7 @@ pub fn print_ascii_graph(dag: &TaskDag, spec: &DagSpecInput) {
         for task_id in tasks_at_depth {
             if let Some(task) = dag.get_task(*task_id) {
                 let deps = dag.get_dependencies(*task_id);
-                let arrow = if deps.map(|d| !d.is_empty()).unwrap_or(false) {
+                let arrow = if deps.is_some_and(|d| !d.is_empty()) {
                     "└─► "
                 } else {
                     "● "
@@ -206,7 +211,7 @@ pub fn print_dot_graph(dag: &TaskDag, spec: &DagSpecInput) {
     println!();
 
     for task in dag.all_tasks() {
-        let task_id = task.id.unwrap();
+        let Some(task_id) = task.id else { continue };
         let color = match task.status {
             TaskStatus::Completed => "green",
             TaskStatus::Failed => "red",
@@ -225,7 +230,7 @@ pub fn print_dot_graph(dag: &TaskDag, spec: &DagSpecInput) {
     println!();
 
     for task in dag.all_tasks() {
-        let task_id = task.id.unwrap();
+        let Some(task_id) = task.id else { continue };
         if let Some(deps) = dag.get_dependencies(task_id) {
             for dep_id in deps {
                 println!("  \"{}\" -> \"{}\";", dep_id.inner(), task_id.inner());
@@ -245,14 +250,14 @@ pub fn print_mermaid_graph(dag: &TaskDag, spec: &DagSpecInput) {
     // Create task ID to safe name mapping
     let mut id_to_name: HashMap<TaskId, String> = HashMap::new();
     for task in dag.all_tasks() {
-        let task_id = task.id.unwrap();
+        let Some(task_id) = task.id else { continue };
         let safe_name = task.name.replace([' ', '-'], "_");
         id_to_name.insert(task_id, safe_name.clone());
         println!("    {}[{}]", safe_name, task.name);
     }
 
     for task in dag.all_tasks() {
-        let task_id = task.id.unwrap();
+        let Some(task_id) = task.id else { continue };
         if let Some(deps) = dag.get_dependencies(task_id) {
             for dep_id in deps {
                 if let (Some(from), Some(to)) = (id_to_name.get(dep_id), id_to_name.get(&task_id)) {

--- a/src/cortex-cli/src/dag_cmd/helpers.rs
+++ b/src/cortex-cli/src/dag_cmd/helpers.rs
@@ -28,6 +28,17 @@ pub fn load_spec(path: &PathBuf) -> Result<DagSpecInput> {
         serde_yaml::from_str(&content).context("Failed to parse YAML")?
     };
 
+    // Check for duplicate task IDs (Issue #3815)
+    let mut seen_names = std::collections::HashSet::new();
+    for task in &spec.tasks {
+        if !seen_names.insert(&task.name) {
+            anyhow::bail!(
+                "Duplicate task ID '{}' found in DAG specification. Task IDs must be unique.",
+                task.name
+            );
+        }
+    }
+
     Ok(spec)
 }
 

--- a/src/cortex-cli/src/debug_cmd/handlers/config.rs
+++ b/src/cortex-cli/src/debug_cmd/handlers/config.rs
@@ -22,10 +22,28 @@ pub async fn run_config(args: ConfigArgs) -> Result<()> {
         )
     })?;
 
-    let global_config = config.cortex_home.join("config.toml");
-    let local_config = std::env::current_dir()
-        .ok()
-        .map(|d| d.join(".cortex/config.toml"));
+    // Support both config.toml and config.json
+    let global_config_toml = config.cortex_home.join("config.toml");
+    let global_config_json = config.cortex_home.join("config.json");
+    let global_config = if global_config_toml.exists() {
+        global_config_toml
+    } else if global_config_json.exists() {
+        global_config_json
+    } else {
+        global_config_toml // Default to .toml path for display
+    };
+
+    let local_config = std::env::current_dir().ok().and_then(|d| {
+        let local_toml = d.join(".cortex/config.toml");
+        let local_json = d.join(".cortex/config.json");
+        if local_toml.exists() {
+            Some(local_toml)
+        } else if local_json.exists() {
+            Some(local_json)
+        } else {
+            Some(local_toml) // Default to .toml path for display
+        }
+    });
 
     let resolved = ResolvedConfig {
         model: config.model.clone(),
@@ -140,14 +158,26 @@ pub async fn run_config(args: ConfigArgs) -> Result<()> {
 
     // Handle --diff flag: compare local and global configs
     if args.diff {
-        println!();
-        println!("Config Diff (Global vs Local)");
-        println!("{}", "=".repeat(50));
+        // Support both config.toml and config.json for diff
+        let global_toml = config.cortex_home.join("config.toml");
+        let global_json = config.cortex_home.join("config.json");
+        let global_path = if global_toml.exists() {
+            global_toml
+        } else {
+            global_json
+        };
 
-        let global_path = config.cortex_home.join("config.toml");
-        let local_path = std::env::current_dir()
-            .ok()
-            .map(|d| d.join(".cortex/config.toml"));
+        let local_path = std::env::current_dir().ok().and_then(|d| {
+            let local_toml = d.join(".cortex/config.toml");
+            let local_json = d.join(".cortex/config.json");
+            if local_toml.exists() {
+                Some(local_toml)
+            } else if local_json.exists() {
+                Some(local_json)
+            } else {
+                None
+            }
+        });
 
         let global_content = if global_path.exists() {
             std::fs::read_to_string(&global_path).ok()
@@ -163,40 +193,79 @@ pub async fn run_config(args: ConfigArgs) -> Result<()> {
             }
         });
 
-        match (global_content.as_ref(), local_content.as_ref()) {
-            (None, None) => {
-                println!("  No config files found.");
-            }
-            (Some(_global), None) => {
-                println!("  Only global config exists.");
-                if args.json {
-                    let diff_output = serde_json::json!({
+        // For --diff --json, output pure JSON without mixing text and JSON
+        if args.json {
+            let diff_output = match (global_content.as_ref(), local_content.as_ref()) {
+                (None, None) => {
+                    serde_json::json!({
+                        "global_only": false,
+                        "local_only": false,
+                        "identical": false,
+                        "message": "No config files found",
+                        "differences": []
+                    })
+                }
+                (Some(_), None) => {
+                    serde_json::json!({
                         "global_only": true,
                         "local_only": false,
-                        "differences": [],
-                    });
-                    println!("{}", serde_json::to_string_pretty(&diff_output)?);
+                        "identical": false,
+                        "message": "Only global config exists",
+                        "differences": []
+                    })
                 }
-            }
-            (None, Some(_local)) => {
-                println!("  Only local config exists.");
-                if args.json {
-                    let diff_output = serde_json::json!({
+                (None, Some(_)) => {
+                    serde_json::json!({
                         "global_only": false,
                         "local_only": true,
-                        "differences": [],
-                    });
-                    println!("{}", serde_json::to_string_pretty(&diff_output)?);
+                        "identical": false,
+                        "message": "Only local config exists",
+                        "differences": []
+                    })
                 }
-            }
-            (Some(global), Some(local)) => {
-                if global == local {
-                    println!("  Configs are identical.");
-                } else {
-                    let diff = compute_config_diff(global, local);
-                    if args.json {
-                        println!("{}", serde_json::to_string_pretty(&diff)?);
+                (Some(global), Some(local)) => {
+                    if global == local {
+                        serde_json::json!({
+                            "global_only": false,
+                            "local_only": false,
+                            "identical": true,
+                            "message": "Configs are identical",
+                            "differences": []
+                        })
                     } else {
+                        let diff = compute_config_diff(global, local);
+                        serde_json::json!({
+                            "global_only": false,
+                            "local_only": false,
+                            "identical": false,
+                            "only_in_global": diff.only_in_global,
+                            "only_in_local": diff.only_in_local,
+                            "unified_diff": diff.unified_diff
+                        })
+                    }
+                }
+            };
+            println!("{}", serde_json::to_string_pretty(&diff_output)?);
+        } else {
+            println!();
+            println!("Config Diff (Global vs Local)");
+            println!("{}", "=".repeat(50));
+
+            match (global_content.as_ref(), local_content.as_ref()) {
+                (None, None) => {
+                    println!("  No config files found.");
+                }
+                (Some(_), None) => {
+                    println!("  Only global config exists.");
+                }
+                (None, Some(_)) => {
+                    println!("  Only local config exists.");
+                }
+                (Some(global), Some(local)) => {
+                    if global == local {
+                        println!("  Configs are identical.");
+                    } else {
+                        let diff = compute_config_diff(global, local);
                         println!();
                         if !diff.only_in_global.is_empty() {
                             println!("Lines only in global config:");

--- a/src/cortex-cli/src/debug_cmd/handlers/config.rs
+++ b/src/cortex-cli/src/debug_cmd/handlers/config.rs
@@ -33,15 +33,15 @@ pub async fn run_config(args: ConfigArgs) -> Result<()> {
         global_config_toml // Default to .toml path for display
     };
 
-    let local_config = std::env::current_dir().ok().and_then(|d| {
+    let local_config = std::env::current_dir().ok().map(|d| {
         let local_toml = d.join(".cortex/config.toml");
         let local_json = d.join(".cortex/config.json");
         if local_toml.exists() {
-            Some(local_toml)
+            local_toml
         } else if local_json.exists() {
-            Some(local_json)
+            local_json
         } else {
-            Some(local_toml) // Default to .toml path for display
+            local_toml // Default to .toml path for display
         }
     });
 

--- a/src/cortex-cli/src/debug_cmd/handlers/wait.rs
+++ b/src/cortex-cli/src/debug_cmd/handlers/wait.rs
@@ -102,7 +102,15 @@ pub async fn run_wait(args: WaitArgs) -> Result<()> {
 
         (condition, success, error)
     } else {
-        bail!("No condition specified. Use --lsp-ready, --server-ready, or --port");
+        let error_message = "No condition specified. Use --lsp-ready, --server-ready, or --port";
+        if args.json {
+            let error = serde_json::json!({
+                "error": error_message,
+                "success": false
+            });
+            println!("{}", serde_json::to_string_pretty(&error)?);
+        }
+        bail!("{}", error_message);
     };
 
     let waited_ms = start.elapsed().as_millis() as u64;

--- a/src/cortex-cli/src/exec_cmd/runner.rs
+++ b/src/cortex-cli/src/exec_cmd/runner.rs
@@ -24,6 +24,13 @@ use super::output::{ExecInputFormat, ExecOutputFormat};
 impl ExecCli {
     /// Run the exec command.
     pub async fn run(self) -> Result<()> {
+        // Validate mutually exclusive tool flags
+        if !self.enabled_tools.is_empty() && !self.disabled_tools.is_empty() {
+            bail!(
+                "Cannot specify both --enabled-tools and --disabled-tools. Choose one to filter tools."
+            );
+        }
+
         // Ensure UTF-8 locale for proper text handling
         let _ = ensure_utf8_locale();
 

--- a/src/cortex-cli/src/mcp_cmd/auth.rs
+++ b/src/cortex-cli/src/mcp_cmd/auth.rs
@@ -203,6 +203,13 @@ async fn run_auth(
 pub(crate) async fn run_logout(args: LogoutArgs) -> Result<()> {
     use cortex_engine::mcp;
 
+    // Validate mutually exclusive flags
+    if args.name.is_some() && args.all {
+        bail!(
+            "Cannot specify both --name and --all. Use --name for a specific server or --all for all servers."
+        );
+    }
+
     if args.all {
         // Logout from all servers
         let servers = get_mcp_servers()?;

--- a/src/cortex-cli/src/models_cmd.rs
+++ b/src/cortex-cli/src/models_cmd.rs
@@ -422,6 +422,16 @@ async fn run_list(
     sort_by: &str,
     show_full: bool,
 ) -> Result<()> {
+    // Validate sort value (Issue #3722)
+    const VALID_SORT_VALUES: &[&str] = &["name", "provider", "context", "created", "id"];
+    if !VALID_SORT_VALUES.contains(&sort_by) {
+        anyhow::bail!(
+            "Invalid sort value '{}'. Valid values are: {}",
+            sort_by,
+            VALID_SORT_VALUES.join(", ")
+        );
+    }
+
     let mut models = get_available_models();
 
     // Parse sort order (Issue #1993)

--- a/src/cortex-cli/src/plugin_cmd.rs
+++ b/src/cortex-cli/src/plugin_cmd.rs
@@ -409,6 +409,8 @@ async fn run_show(args: PluginShowArgs) -> Result<()> {
                 "error": format!("Plugin '{}' is not installed", args.name)
             });
             println!("{}", serde_json::to_string_pretty(&error)?);
+            // Exit with error code but don't duplicate error message via bail!()
+            std::process::exit(1);
         }
         bail!("Plugin '{}' is not installed.", args.name);
     }

--- a/src/cortex-cli/src/plugin_cmd.rs
+++ b/src/cortex-cli/src/plugin_cmd.rs
@@ -144,6 +144,13 @@ impl PluginCli {
 }
 
 async fn run_list(args: PluginListArgs) -> Result<()> {
+    // Validate mutually exclusive flags
+    if args.enabled && args.disabled {
+        bail!(
+            "Cannot specify both --enabled and --disabled. Choose one filter or use neither for all plugins."
+        );
+    }
+
     let plugins_dir = get_plugins_dir();
 
     if !plugins_dir.exists() {
@@ -243,6 +250,11 @@ async fn run_list(args: PluginListArgs) -> Result<()> {
 }
 
 async fn run_install(args: PluginInstallArgs) -> Result<()> {
+    // Validate plugin name is not empty (Issue #3700)
+    if args.name.trim().is_empty() {
+        bail!("Plugin name cannot be empty. Please provide a valid plugin name.");
+    }
+
     let plugins_dir = get_plugins_dir();
 
     // Create plugins directory if it doesn't exist
@@ -392,6 +404,12 @@ async fn run_show(args: PluginShowArgs) -> Result<()> {
     let manifest_path = plugin_path.join("plugin.toml");
 
     if !manifest_path.exists() {
+        if args.json {
+            let error = serde_json::json!({
+                "error": format!("Plugin '{}' is not installed", args.name)
+            });
+            println!("{}", serde_json::to_string_pretty(&error)?);
+        }
         bail!("Plugin '{}' is not installed.", args.name);
     }
 

--- a/src/cortex-cli/src/pr_cmd.rs
+++ b/src/cortex-cli/src/pr_cmd.rs
@@ -130,7 +130,7 @@ async fn run_pr_checkout(args: PrCli) -> Result<()> {
 
     let repository = format!("{}/{}", owner, repo);
 
-    println!("🔀 Pull Request #{}", pr_number);
+    println!("[PR] Pull Request #{}", pr_number);
     println!("{}", "=".repeat(40));
     println!("Repository: {}", repository);
     println!();
@@ -328,7 +328,7 @@ async fn run_pr_checkout(args: PrCli) -> Result<()> {
     validate_refspec(&refspec)?;
 
     println!("Fetching PR #{}...", pr_number);
-    print!("  ⏳ Downloading PR data from origin...");
+    print!("  [WAIT] Downloading PR data from origin...");
     std::io::Write::flush(&mut std::io::stdout()).ok();
 
     // SECURITY: Arguments are passed as separate array elements, not interpolated into a string
@@ -345,7 +345,7 @@ async fn run_pr_checkout(args: PrCli) -> Result<()> {
     }
 
     // Checkout the branch
-    print!("  ⏳ Checking out branch '{}'...", branch_name);
+    print!("  [WAIT] Checking out branch '{}'...", branch_name);
     std::io::Write::flush(&mut std::io::stdout()).ok();
 
     let checkout_args = if args.force {

--- a/src/cortex-cli/src/uninstall_cmd.rs
+++ b/src/cortex-cli/src/uninstall_cmd.rs
@@ -181,7 +181,16 @@ impl UninstallCli {
             return Ok(());
         }
 
-        // Backup if requested
+        // Confirm before proceeding (Issue #3682: confirm BEFORE creating backup)
+        if !self.force && !self.yes {
+            println!("\nAre you sure you want to uninstall Cortex CLI? [y/N]");
+            if !prompt_yes_no()? {
+                println!("Uninstall cancelled.");
+                return Ok(());
+            }
+        }
+
+        // Backup if requested (only after user confirms)
         if self.backup {
             print_info("Creating backup...");
             if let Err(e) = create_backup(&items_to_remove) {
@@ -193,15 +202,6 @@ impl UninstallCli {
                         return Ok(());
                     }
                 }
-            }
-        }
-
-        // Confirm before proceeding
-        if !self.force && !self.yes {
-            println!("\nAre you sure you want to uninstall Cortex CLI? [y/N]");
-            if !prompt_yes_no()? {
-                println!("Uninstall cancelled.");
-                return Ok(());
             }
         }
 

--- a/src/cortex-tui/src/runner/login_screen.rs
+++ b/src/cortex-tui/src/runner/login_screen.rs
@@ -223,7 +223,7 @@ impl LoginScreen {
                         return Ok(result);
                     }
                 }
-                
+
                 // Handle async messages from token polling
                 msg = async {
                     if let Some(ref mut rx) = self.async_rx {
@@ -237,7 +237,7 @@ impl LoginScreen {
                         self.handle_async_message(msg);
                     }
                 }
-                
+
                 // Periodic render tick to keep UI responsive
                 _ = render_interval.tick() => {
                     // Just continue to re-render
@@ -713,7 +713,7 @@ async fn poll_for_token_async(
     tx: mpsc::Sender<AsyncMessage>,
 ) {
     tracing::debug!("Token polling started");
-    
+
     let client = match cortex_engine::create_default_client() {
         Ok(c) => c,
         Err(e) => {
@@ -736,7 +736,11 @@ async fn poll_for_token_async(
             return;
         }
 
-        tracing::trace!("Polling for token (attempt {}/{})", attempt + 1, max_attempts);
+        tracing::trace!(
+            "Polling for token (attempt {}/{})",
+            attempt + 1,
+            max_attempts
+        );
 
         let response = match client
             .post(format!("{}/auth/device/token", API_BASE_URL))
@@ -756,7 +760,7 @@ async fn poll_for_token_async(
 
         if status.is_success() {
             tracing::debug!("Token response received (success)");
-            
+
             #[derive(serde::Deserialize)]
             struct TokenResponse {
                 access_token: String,


### PR DESCRIPTION
## Summary

This PR addresses multiple open issues from the [PlatformNetwork/bounty-challenge](https://github.com/PlatformNetwork/bounty-challenge/issues?q=is%3Aissue+state%3Aopen+label%3Avalid) repository affecting cortex-cli.

> **Note:** This PR was migrated from [CortexLM/cortex-cli#564](https://github.com/CortexLM/cortex-cli/pull/564) to the cortex monorepo.

## Issues Fixed

### Exit Code Issues
- **#3896**: `cortex debug file` now returns non-zero exit code when file does not exist
- **#3891**: `whoami` command now returns error when checking login status fails  
- **#3843**: `upgrade` command now returns error for invalid channel (stable/beta/nightly)
- **#3820**: `config get/unset` now return error when key not found

### Conflicting Flags Validation
- **#3885**: `exec` command validates that `--enabled-tools` and `--disabled-tools` cannot both be specified
- **#3857**: `mcp logout` validates that `--name` and `--all` cannot both be specified
- **#3856**: `agent list` validates that `--primary` and `--subagents` cannot both be specified
- **#3855**: `plugin list` validates that `--enabled` and `--disabled` cannot both be specified  
- **#3819**: `mcp add` validates that `--url` and `--sse` cannot both be specified
- **#3814**: `login` validates that only one auth method can be specified

### JSON Output Issues
- **#3879**: `debug config --diff --json` now outputs pure JSON
- **#3838**: `dag run --strategy dry-run` respects `--format` flag
- **#3826**: `compact run --dry-run --json` outputs JSON
- **#3738**: `dag list --format json` outputs proper JSON
- **#3735**: `alias show --json` outputs JSON on errors
- **#3723**: `plugin show --json` outputs JSON on errors
- **#947**: `debug wait --json` outputs JSON on errors
- **#948**: `mcp get --json` outputs JSON on errors
- **#952**: `run --format json` outputs JSON on auth errors

### Security Fix
- **#3851**: Fixed `allows_risk()` to pass actual command to `is_read_only_command()` instead of risk level

### Input Validation Issues
- **#3815**: DAG validation now rejects duplicate task IDs
- **#3722**: `models list --sort` validates sort values (name, provider, context, created, id)
- **#3716**: `dag run --jobs 0` now errors instead of hanging
- **#3700**: `plugin install ""` now returns proper error for empty name
- **#3696**: `lock add` now validates session ID format (UUID or 8-char prefix)

### User Experience Fixes
- **#3646**: `resume` command now accepts 'last' as SESSION_ID per help text
- **#3651**: `upgrade --changelog` now fetches raw content instead of HTML
- **#3150**: `debug config` now correctly detects config.json files
- **#3682**: `uninstall --backup` now creates backup after user confirmation
- **#3678**: Fixed help text to reference correct GitHub repository URL
- **#3792**: Removed emoji from `pr` command output (replaced with text alternatives)

## Changes

- Multiple files modified across cortex-cli
- All error paths return proper exit codes using `bail!()` macro
- All commands with `--json` flag output valid JSON even on errors
- Mutually exclusive flags produce validation errors when both specified
- Security bug fixed in autonomy level checking

## Testing

- `cargo check -p cortex-cli` passes
- All changes follow existing codebase patterns and conventions

## Note

This PR is for review only - DO NOT MERGE until reviewed.