### PR TITLE
fix(readme): update Discord badge to static badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/CortexLM/cortex/releases"><img src="https://img.shields.io/github/v/release/CortexLM/cortex?style=flat-square&color=blue" alt="Release"></a>
-  <a href="https://discord.gg/cortexfoundation"><img src="https://img.shields.io/discord/1234567890?style=flat-square&logo=discord&logoColor=white&color=5865F2" alt="Discord"></a>
+  <a href="https://discord.gg/cortexfoundation"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://twitter.com/CortexLM"><img src="https://img.shields.io/twitter/follow/CortexLM?style=flat-square&logo=twitter&color=1DA1F2" alt="Twitter"></a>
 </p>
 


### PR DESCRIPTION
## Changes

- Replace dynamic Discord member count badge with static badge
- The previous badge used a placeholder server ID (1234567890) which didn't display correctly
- All links remain correct:
  - Discord: discord.gg/cortexfoundation ✅
  - Releases: https://github.com/CortexLM/cortex/releases ✅

## Before
The Discord badge showed invalid/broken member count due to fake server ID.

## After
Static Discord badge that displays correctly and links to the correct Discord server.