### PR TITLE
feat(chutes): add Chutes provider with dynamic TEE model validation

### DIFF
--- a/src/cortex-common/src/model_presets/mod.rs
+++ b/src/cortex-common/src/model_presets/mod.rs
@@ -18,7 +18,10 @@ pub use types::{ModelAlias, ModelPreset, ModelResolution};
 pub use constants::{DEFAULT_MODEL, DEFAULT_MODELS, DEFAULT_PROVIDER};
 
 // Re-export preset data and helpers
-pub use presets::{MODEL_PRESETS, get_model_preset, get_models_for_provider};
+pub use presets::{
+    DEFAULT_CHUTES_MODEL, MODEL_PRESETS, get_model_preset, get_models_for_provider,
+    provider_allows_custom_models, validate_chutes_model,
+};
 
 // Re-export alias data and helpers
 pub use aliases::{MODEL_ALIASES, list_model_aliases, resolve_model_alias};

--- a/src/cortex-tui/src/modal/providers.rs
+++ b/src/cortex-tui/src/modal/providers.rs
@@ -70,7 +70,10 @@ impl ProviderInfo {
 
 /// Returns the list of known providers with their default information.
 pub fn known_providers() -> Vec<ProviderInfo> {
-    vec![ProviderInfo::new("cortex", "Cortex").with_description("Cortex AI Gateway")]
+    vec![
+        ProviderInfo::new("cortex", "Cortex").with_description("Cortex AI Gateway"),
+        ProviderInfo::new("chutes", "Chutes (TEE)").with_description("TEE-secured models only"),
+    ]
 }
 
 // ============================================================================
@@ -395,15 +398,16 @@ mod tests {
         let modal = ProvidersModal::with_known_providers(Some("cortex".to_string()));
 
         assert_eq!(modal.title(), "Providers");
-        assert_eq!(modal.providers.len(), 1);
+        assert_eq!(modal.providers.len(), 2);
     }
 
     #[test]
     fn test_known_providers() {
         let providers = known_providers();
 
-        assert_eq!(providers.len(), 1);
+        assert_eq!(providers.len(), 2);
         assert!(providers.iter().any(|p| p.id == "cortex"));
+        assert!(providers.iter().any(|p| p.id == "chutes"));
     }
 
     #[test]

--- a/src/cortex-tui/src/providers/config.rs
+++ b/src/cortex-tui/src/providers/config.rs
@@ -27,14 +27,23 @@ pub const CONFIG_FILE: &str = "config.json";
 /// Sessions directory name
 pub const SESSIONS_DIR: &str = "sessions";
 
-/// Single provider - Cortex Backend (for compatibility with old code)
-pub const PROVIDERS: &[ProviderInfo] = &[ProviderInfo {
-    id: "cortex",
-    name: "Cortex",
-    env_var: "CORTEX_AUTH_TOKEN",
-    base_url: "https://api.cortex.foundation",
-    requires_key: true,
-}];
+/// Supported providers
+pub const PROVIDERS: &[ProviderInfo] = &[
+    ProviderInfo {
+        id: "cortex",
+        name: "Cortex",
+        env_var: "CORTEX_AUTH_TOKEN",
+        base_url: "https://api.cortex.foundation",
+        requires_key: true,
+    },
+    ProviderInfo {
+        id: "chutes",
+        name: "Chutes (TEE)",
+        env_var: "CHUTES_API_KEY",
+        base_url: "https://llm.chutes.ai",
+        requires_key: true,
+    },
+];
 
 // ============================================================
 // TYPES


### PR DESCRIPTION
## Summary

Adds Chutes as a new AI provider with Trusted Execution Environment (TEE) security requirements. **Any model ending with '-TEE' suffix is accepted**, enabling custom model support via `--model` flag.

## Changes

### Provider Configuration
- **ID**: `chutes`
- **Name**: `Chutes (TEE)`
- **Environment Variable**: `CHUTES_API_KEY`
- **Base URL**: `https://llm.chutes.ai`

### Dynamic TEE Model Validation
- Validates any model with `-TEE` suffix (case-insensitive)
- Users can specify custom models: `chutes:{model-name}-TEE` via `--model` flag
- Default model: `moonshotai/Kimi-K2.5-TEE`

### Security Enforcement (Defense-in-Depth)
All validation bypass vulnerabilities have been closed:

1. **`validate_chutes_model()`**: Dynamic -TEE suffix check (case-insensitive)
2. **Input sanitization**: Rejects null bytes, control characters, Unicode homoglyphs
3. **Character whitelist**: Only alphanumeric, hyphen, underscore, dot, forward slash allowed
4. **`ProviderManager::new()`**: Validates TEE model when loading from config
5. **`ProviderManager::set_provider()`**: Validates current model when switching TO Chutes
6. **`ProviderManager::set_model()`**: Uses case-insensitive provider check
7. **`ProviderManager::ensure_client()`**: Defense-in-depth validation before API calls
8. **Modal handlers**: Check `set_model()` result and show error toasts on validation failure
9. **`handle_set_value()`**: Properly validates and handles errors
10. **`handle_interactive_selection()`**: Validates SetModel and SetProvider actions

## Usage

```bash
# Use default TEE model
cortex --provider chutes

# Use custom TEE model
cortex --provider chutes --model "custom-provider/my-model-TEE"
```

## Files Modified
- `src/cortex-tui/src/providers/config.rs` - Added Chutes provider to PROVIDERS array
- `src/cortex-tui/src/providers/manager.rs` - Comprehensive validation at all entry points
- `src/cortex-tui/src/modal/providers.rs` - Added Chutes to known_providers()
- `src/cortex-common/src/model_presets/presets.rs` - Model preset, validation functions with tests
- `src/cortex-common/src/model_presets/mod.rs` - Added re-exports for new functions
- `src/cortex-tui/src/runner/event_loop/modal.rs` - Validation checks in modal handlers
- `src/cortex-tui/src/runner/event_loop/commands.rs` - Validation checks in command handlers

## Testing
- `cargo check -p cortex-common -p cortex-tui`: Passed
- `cargo test -p cortex-common`: All tests passed (204 tests)
- Security tests: Null byte injection, control characters, Unicode attacks all blocked