### PR TITLE
fix(security): upgrade bytes crate to fix RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ uuid = { version = "1.20", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 futures = "0.3"
-bytes = "1.10"
+bytes = "1.11.1"
 base64 = "0.22"
 rand = "0.9"
 sha2 = "0.10"


### PR DESCRIPTION
## Summary

This PR fixes the security vulnerability RUSTSEC-2026-0007 (integer overflow in `BytesMut::reserve`) by upgrading the `bytes` crate from version 1.11.0 to 1.11.1.

## Changes

- Updated workspace dependency in `Cargo.toml`: `bytes = "1.10"` → `bytes = "1.11.1"`
- Regenerated `Cargo.lock` with bytes 1.11.1

## Security Advisory

- **ID**: RUSTSEC-2026-0007
- **Severity**: Critical
- **Issue**: Integer overflow vulnerability in `BytesMut::reserve`
- **Fix**: Upgrade to bytes >= 1.11.1

## Verification

- [x] `cargo audit` passes with 0 vulnerabilities
- [x] Dependency resolves correctly

## CI Impact

This should fix the failing `actions-rust-lang/audit@v1` step in CI.