### PR TITLE
fix(tui): display user-friendly error for insufficient balance (402)

### DIFF
--- a/src/cortex-tui/src/runner/event_loop/streaming.rs
+++ b/src/cortex-tui/src/runner/event_loop/streaming.rs
@@ -467,6 +467,26 @@ impl EventLoop {
             return;
         }
 
+        // Check if this is an insufficient balance error (402 Payment Required)
+        if error_lower.contains("402")
+            || error_lower.contains("insufficient_balance")
+            || error_lower.contains("insufficient token balance")
+            || error_lower.contains("payment required")
+        {
+            self.add_system_message(
+                "Error: Insufficient token balance to continue the conversation.\n\n\
+                 Please recharge your account at: https://app.cortex.foundation\n\n\
+                 Once recharged, you can continue your conversation.",
+            );
+            self.app_state
+                .toasts
+                .error("Insufficient balance. Please recharge at app.cortex.foundation");
+            self.stream_controller.reset();
+            self.streaming_rx = None;
+            self.streaming_task = None;
+            return;
+        }
+
         // Check if this is a rate limit / usage limit error
         if error_lower.contains("rate limit")
             || error_lower.contains("usage limit")


### PR DESCRIPTION
## Summary
When a **402 Payment Required / INSUFFICIENT_BALANCE** error is received from the backend, the TUI now displays a clear, actionable error message instead of the raw JSON error.

## Changes
- Added detection for 402 / INSUFFICIENT_BALANCE errors in `streaming.rs`
- Display a user-friendly system message explaining the issue
- Show a red toast notification (ToastLevel::Error) with a call-to-action
- Direct users to recharge at `app.cortex.foundation`

## Before
```
[i] Backend error: API error 402 Payment Required: {"code":"INSUFFICIENT_BALANCE","message":"Insufficient token balance: required 447, available 0","details":{"available":0,"required":447}}
```

## After
**System message:**
```
Error: Insufficient token balance to continue the conversation.

Please recharge your account at: https://app.cortex.foundation

Once recharged, you can continue your conversation.
```

**Toast notification (in red):**
```
Insufficient balance. Please recharge at app.cortex.foundation
```

## Testing
- `cargo check -p cortex-tui` passes ✅

## Note
This PR should **NOT** be merged without review.