### PR TITLE
Display backend error messages in red

### DIFF
--- a/src/cortex-core/src/style.rs
+++ b/src/cortex-core/src/style.rs
@@ -362,9 +362,17 @@ impl CortexStyle {
         Style::default().fg(SKY_BLUE)
     }
 
-    /// System message style: error red italic text for backend error messages
+    /// System message style: muted italic text for informational system messages
     #[inline]
     pub fn system_message() -> Style {
+        Style::default()
+            .fg(TEXT_MUTED)
+            .add_modifier(Modifier::ITALIC)
+    }
+
+    /// Error message style: red italic text for backend error messages
+    #[inline]
+    pub fn error_message() -> Style {
         Style::default().fg(ERROR).add_modifier(Modifier::ITALIC)
     }
 
@@ -528,6 +536,7 @@ mod tests {
         let _ = CortexStyle::user_message();
         let _ = CortexStyle::assistant_message();
         let _ = CortexStyle::system_message();
+        let _ = CortexStyle::error_message();
         let _ = CortexStyle::code();
         let _ = CortexStyle::border();
         let _ = CortexStyle::border_focused();

--- a/src/cortex-core/src/style.rs
+++ b/src/cortex-core/src/style.rs
@@ -362,12 +362,10 @@ impl CortexStyle {
         Style::default().fg(SKY_BLUE)
     }
 
-    /// System message style: muted italic text
+    /// System message style: error red italic text for backend error messages
     #[inline]
     pub fn system_message() -> Style {
-        Style::default()
-            .fg(TEXT_MUTED)
-            .add_modifier(Modifier::ITALIC)
+        Style::default().fg(ERROR).add_modifier(Modifier::ITALIC)
     }
 
     /// Code style: electric blue text on surface background


### PR DESCRIPTION


### Changes
- Modified `system_message()` style in `cortex-core/src/style.rs`
- Changed color from `TEXT_MUTED` (gray #486581) to `ERROR` (red #FF6B6B)
- Backend JSON error messages will now be displayed in red instead of muted gray

### Visual Impact
All system messages (including backend errors) will now appear in red with italic styling.
