### PR TITLE
feat(tui): remove toast notifications

### DIFF
--- a/src/cortex-batch/src/batch_ops.rs
+++ b/src/cortex-batch/src/batch_ops.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-batch/src/multi_edit.rs
+++ b/src/cortex-batch/src/multi_edit.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-tui-components/src/toast.rs
+++ b/src/cortex-tui-components/src/toast.rs
@@ -275,7 +275,7 @@ impl ToastManager {
     }
 
     /// Adds a toast to the manager and returns its ID.
-    pub fn push(&mut self, mut toast: Toast) -> u64 {
+    pub fn push(&mut self, toast: Toast) -> u64 {
         // Toast notifications disabled
         let _ = toast;
         0
@@ -616,21 +616,26 @@ mod tests {
 
     #[test]
     fn test_toast_manager_push() {
+        // Toast notifications are disabled - verifying no-op behavior
         let mut manager = ToastManager::new();
         let id1 = manager.success("First");
         let id2 = manager.info("Second");
-        assert_eq!(manager.len(), 2);
-        assert_ne!(id1, id2);
+        assert_eq!(manager.len(), 0);
+        assert!(manager.is_empty());
+        assert_eq!(id1, 0);
+        assert_eq!(id2, 0);
     }
 
     #[test]
     fn test_toast_manager_visible_limit() {
+        // Toast notifications are disabled - verifying no-op behavior
         let mut manager = ToastManager::new().with_max_visible(2);
         manager.success("First");
         manager.info("Second");
         manager.warning("Third");
         let visible = manager.visible();
-        assert_eq!(visible.len(), 2);
+        assert_eq!(visible.len(), 0);
+        assert!(manager.is_empty());
     }
 
     #[test]

--- a/src/cortex-tui-components/src/toast.rs
+++ b/src/cortex-tui-components/src/toast.rs
@@ -234,8 +234,6 @@ pub enum ToastPosition {
 pub struct ToastManager {
     /// Active toasts (newest first)
     toasts: Vec<Toast>,
-    /// Counter for generating unique toast IDs
-    next_id: u64,
     /// Maximum number of toasts to display at once
     max_visible: usize,
     /// Screen position for toast display
@@ -251,7 +249,6 @@ impl ToastManager {
     pub fn new() -> Self {
         Self {
             toasts: Vec::new(),
-            next_id: 1,
             max_visible: 5,
             position: ToastPosition::TopRight,
         }

--- a/src/cortex-tui-components/src/toast.rs
+++ b/src/cortex-tui-components/src/toast.rs
@@ -276,31 +276,37 @@ impl ToastManager {
 
     /// Adds a toast to the manager and returns its ID.
     pub fn push(&mut self, mut toast: Toast) -> u64 {
-        let id = self.next_id;
-        self.next_id += 1;
-        toast.id = id;
-        self.toasts.insert(0, toast);
-        id
+        // Toast notifications disabled
+        let _ = toast;
+        0
     }
 
     /// Adds a success toast and returns its ID.
     pub fn success(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::success(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Adds an info toast and returns its ID.
     pub fn info(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::info(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Adds a warning toast and returns its ID.
     pub fn warning(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::warning(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Adds an error toast and returns its ID.
     pub fn error(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::error(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Removes a specific toast by ID.

--- a/src/cortex-tui/src/runner/event_loop/rendering.rs
+++ b/src/cortex-tui/src/runner/event_loop/rendering.rs
@@ -119,12 +119,12 @@ impl EventLoop {
             // Apply selection highlight
             self.apply_selection_highlight(frame.buffer_mut());
 
-            // Render toast notifications
-            if !self.app_state.toasts.is_empty() {
-                let toast_widget = crate::widgets::ToastWidget::new(&self.app_state.toasts)
-                    .terminal_size(area.width, area.height);
-                toast_widget.render(area, frame.buffer_mut());
-            }
+            // Toast notifications disabled
+            // if !self.app_state.toasts.is_empty() {
+            //     let toast_widget = crate::widgets::ToastWidget::new(&self.app_state.toasts)
+            //         .terminal_size(area.width, area.height);
+            //     toast_widget.render(area, frame.buffer_mut());
+            // }
         })?;
 
         // Capture frame for TUI debugging

--- a/src/cortex-tui/src/widgets/toast.rs
+++ b/src/cortex-tui/src/widgets/toast.rs
@@ -274,7 +274,7 @@ impl ToastManager {
     }
 
     /// Adds a toast to the manager and returns its ID.
-    pub fn push(&mut self, mut toast: Toast) -> u64 {
+    pub fn push(&mut self, toast: Toast) -> u64 {
         // Toast notifications disabled
         let _ = toast;
         0
@@ -641,24 +641,25 @@ mod tests {
 
     #[test]
     fn test_toast_manager_push() {
+        // Toast notifications are disabled - verifying no-op behavior
         let mut manager = ToastManager::new();
 
         let id1 = manager.success("First");
         let id2 = manager.info("Second");
         let id3 = manager.warning("Third");
 
-        assert_eq!(manager.len(), 3);
-        assert!(!manager.is_empty());
+        assert_eq!(manager.len(), 0);
+        assert!(manager.is_empty());
 
-        // IDs should be unique and incrementing
-        assert_ne!(id1, id2);
-        assert_ne!(id2, id3);
-        assert!(id2 > id1);
-        assert!(id3 > id2);
+        // All IDs should be 0 (no-op)
+        assert_eq!(id1, 0);
+        assert_eq!(id2, 0);
+        assert_eq!(id3, 0);
     }
 
     #[test]
     fn test_toast_manager_dismiss() {
+        // Toast notifications are disabled - verifying no-op behavior
         let mut manager = ToastManager::new();
 
         let id1 = manager.success("First");
@@ -667,34 +668,37 @@ mod tests {
 
         manager.dismiss(id2);
 
-        assert_eq!(manager.len(), 2);
-
-        // Check remaining toasts
-        let visible = manager.visible();
-        let ids: Vec<u64> = visible.iter().map(|t| t.id).collect();
-        assert!(!ids.contains(&id2));
-        assert!(ids.contains(&id1));
-        assert!(ids.contains(&id3));
+        // No toasts stored, so nothing to dismiss
+        assert_eq!(manager.len(), 0);
+        assert!(manager.is_empty());
+        assert_eq!(id1, 0);
+        assert_eq!(id2, 0);
+        assert_eq!(id3, 0);
     }
 
     #[test]
     fn test_toast_manager_clear() {
+        // Toast notifications are disabled - verifying no-op behavior
         let mut manager = ToastManager::new();
 
         manager.success("First");
         manager.info("Second");
         manager.warning("Third");
 
-        assert_eq!(manager.len(), 3);
+        // No toasts stored (disabled)
+        assert_eq!(manager.len(), 0);
+        assert!(manager.is_empty());
 
         manager.clear();
 
+        // Still empty after clear
         assert!(manager.is_empty());
         assert_eq!(manager.len(), 0);
     }
 
     #[test]
     fn test_toast_manager_visible_limit() {
+        // Toast notifications are disabled - verifying no-op behavior
         let mut manager = ToastManager::new().with_max_visible(2);
 
         manager.success("First");
@@ -702,15 +706,13 @@ mod tests {
         manager.warning("Third");
 
         let visible = manager.visible();
-        assert_eq!(visible.len(), 2);
-
-        // Should be newest first
-        assert_eq!(visible[0].message, "Third");
-        assert_eq!(visible[1].message, "Second");
+        assert_eq!(visible.len(), 0);
+        assert!(manager.is_empty());
     }
 
     #[test]
     fn test_toast_manager_newest_first() {
+        // Toast notifications are disabled - verifying no-op behavior
         let mut manager = ToastManager::new();
 
         manager.success("First");
@@ -718,9 +720,8 @@ mod tests {
         manager.warning("Third");
 
         let visible = manager.visible();
-        assert_eq!(visible[0].message, "Third");
-        assert_eq!(visible[1].message, "Second");
-        assert_eq!(visible[2].message, "First");
+        assert_eq!(visible.len(), 0);
+        assert!(manager.is_empty());
     }
 
     #[test]

--- a/src/cortex-tui/src/widgets/toast.rs
+++ b/src/cortex-tui/src/widgets/toast.rs
@@ -275,32 +275,37 @@ impl ToastManager {
 
     /// Adds a toast to the manager and returns its ID.
     pub fn push(&mut self, mut toast: Toast) -> u64 {
-        let id = self.next_id;
-        self.next_id += 1;
-        toast.id = id;
-        // Insert at the beginning (newest first)
-        self.toasts.insert(0, toast);
-        id
+        // Toast notifications disabled
+        let _ = toast;
+        0
     }
 
     /// Adds a success toast and returns its ID.
     pub fn success(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::success(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Adds an info toast and returns its ID.
     pub fn info(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::info(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Adds a warning toast and returns its ID.
     pub fn warning(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::warning(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Adds an error toast and returns its ID.
     pub fn error(&mut self, message: impl Into<String>) -> u64 {
-        self.push(Toast::error(message))
+        // Toast notifications disabled
+        let _ = message;
+        0
     }
 
     /// Removes a specific toast by ID.

--- a/src/cortex-tui/src/widgets/toast.rs
+++ b/src/cortex-tui/src/widgets/toast.rs
@@ -233,8 +233,6 @@ pub enum ToastPosition {
 pub struct ToastManager {
     /// Active toasts (newest first)
     toasts: Vec<Toast>,
-    /// Counter for generating unique toast IDs
-    next_id: u64,
     /// Maximum number of toasts to display at once
     max_visible: usize,
     /// Screen position for toast display
@@ -250,7 +248,6 @@ impl ToastManager {
     pub fn new() -> Self {
         Self {
             toasts: Vec::new(),
-            next_id: 1,
             max_visible: 5,
             position: ToastPosition::TopRight,
         }


### PR DESCRIPTION
## Summary
This PR disables all toast notifications in the TUI application.

## Changes
- Modified `ToastManager` methods (`push`, `success`, `info`, `warning`, `error`) to be no-ops (return 0 immediately)
- Commented out toast rendering in `rendering.rs`
- Updated toast tests to verify the new no-op behavior
- Toast module files are preserved (not deleted) for potential future re-enablement

## Files Modified
- `src/cortex-tui/src/widgets/toast.rs`
- `src/cortex-tui/src/runner/event_loop/rendering.rs`
- `src/cortex-tui-components/src/toast.rs`

## Testing
- ✅ `cargo check -p cortex-tui -p cortex-tui-components` passes
- ✅ Tests updated to verify no-op behavior

**Note:** Do NOT merge this PR - for review only.