### PR TITLE
feat(commands): consolidate /model into /models and persist model selection

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -111,7 +111,7 @@ Within an interactive session, you can use slash commands:
 |---------|-------------|
 | `/help` | Show available commands |
 | `/clear` | Clear the conversation |
-| `/model <name>` | Switch AI model |
+| `/models <name>` | Switch AI model |
 | `/export` | Export the session |
 | `/quit` or `/exit` | Exit Cortex |
 
@@ -182,7 +182,7 @@ cortex -m claude-3-opus
 cortex exec -m gpt-4-turbo "your prompt"
 
 # During session (slash command)
-/model claude-3-sonnet
+/models claude-3-sonnet
 ```
 
 ### Model Recommendations

--- a/src/cortex-batch/src/batch_ops.rs
+++ b/src/cortex-batch/src/batch_ops.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-batch/src/multi_edit.rs
+++ b/src/cortex-batch/src/multi_edit.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-engine/src/commands/mod.rs
+++ b/src/cortex-engine/src/commands/mod.rs
@@ -13,7 +13,7 @@
 //! - /compact - Compact conversation context
 //! - /undo - Undo last action
 //! - /config - Show/edit configuration
-//! - /model - Change model
+//! - /models - List or switch models
 //! - /cost - Show token usage and cost
 
 mod configuration;

--- a/src/cortex-engine/src/commands/navigation.rs
+++ b/src/cortex-engine/src/commands/navigation.rs
@@ -39,7 +39,7 @@ Navigation & Control:
 Information:
   /skills           - List available skills
   /plugins          - List installed plugins
-  /model [name]     - Show or change current model
+  /models [name]    - Show or change current model
   /cost             - Show token usage and estimated cost
   /config           - Show configuration
 

--- a/src/cortex-engine/src/commands/types.rs
+++ b/src/cortex-engine/src/commands/types.rs
@@ -326,8 +326,8 @@ mod tests {
         assert_eq!(inv.name, "help");
         assert!(inv.args.is_empty());
 
-        let inv = CommandInvocation::parse("/model gpt-4").unwrap();
-        assert_eq!(inv.name, "model");
+        let inv = CommandInvocation::parse("/models gpt-4").unwrap();
+        assert_eq!(inv.name, "models");
         assert_eq!(inv.arg(0), Some("gpt-4"));
 
         let inv = CommandInvocation::parse("/config --edit").unwrap();

--- a/src/cortex-plugins/src/hooks/completion_hooks.rs
+++ b/src/cortex-plugins/src/hooks/completion_hooks.rs
@@ -531,17 +531,17 @@ mod tests {
     #[test]
     fn test_completion_context() {
         let context = CompletionContext {
-            input: "/model claude".to_string(),
-            cursor_position: 13,
+            input: "/models claude".to_string(),
+            cursor_position: 14,
             word: Some("claude".to_string()),
-            command: Some("model".to_string()),
+            command: Some("models".to_string()),
             arg_index: Some(0),
             previous_args: vec![],
             manual_trigger: false,
             trigger_character: None,
         };
 
-        assert_eq!(context.command, Some("model".to_string()));
+        assert_eq!(context.command, Some("models".to_string()));
         assert_eq!(context.arg_index, Some(0));
     }
 }

--- a/src/cortex-tui-capture/src/screenshot_generator/mocks/input.rs
+++ b/src/cortex-tui-capture/src/screenshot_generator/mocks/input.rs
@@ -87,8 +87,7 @@ fn mock_input_command() -> String {
 │ > /mod_                                                                     │
 │                                                                             │
 │   ┌─ Commands ──────────────────────────────────────────────────────────┐   │
-│   │ > /model     - Switch to a model                                    │   │
-│   │   /models    - List available models                                │   │
+│   │ > /models    - List available models or switch to a model           │   │
 │   └─────────────────────────────────────────────────────────────────────┘   │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │ Tab to complete · Enter to select                                           │

--- a/src/cortex-tui-capture/src/screenshot_generator/mocks/widgets.rs
+++ b/src/cortex-tui-capture/src/screenshot_generator/mocks/widgets.rs
@@ -38,8 +38,7 @@ fn mock_autocomplete_commands() -> String {
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ ┌─ Commands ──────────────────────────────────────────────────────┐         │
 │ │ > /help      - Show help information                            │         │
-│ │   /model     - Switch to a model                                │         │
-│ │   /models    - List available models                            │         │
+│ │   /models    - List available models or switch to a model       │         │
 │ │   /new       - Start a new session                              │         │
 │ │   /clear     - Clear current conversation                       │         │
 │ │   /session   - Show current session info                        │         │
@@ -57,14 +56,13 @@ fn mock_autocomplete_filtered() -> String {
     r#"
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ ┌─ Commands ──────────────────────────────────────────────────────┐         │
-│ │ > /model     - Switch to a model                                │         │
-│ │   /models    - List available models                            │         │
+│ │ > /models    - List available models or switch to a model       │         │
 │ └─────────────────────────────────────────────────────────────────┘         │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │ > /mod_                                                                     │
 ╰─────────────────────────────────────────────────────────────────────────────╯
 
-Filtering: "mod" matches 2 commands
+Filtering: "mod" matches 1 command
 "#
     .to_string()
 }
@@ -93,8 +91,7 @@ fn mock_autocomplete_scroll() -> String {
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ ┌─ Commands ──────────────────────────────────────────────────────┐         │
 │ │ > /help      - Show help information                           │█│       │
-│ │   /model     - Switch to a model                               │ │       │
-│ │   /models    - List available models                           │ │       │
+│ │   /models    - List available models or switch to a model      │ │       │
 │ │   /new       - Start a new session                             │ │       │
 │ │   /clear     - Clear current conversation                      │ │       │
 │ │   /session   - Show current session info                       │ │       │
@@ -114,8 +111,7 @@ fn mock_autocomplete_selected() -> String {
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ ┌─ Commands ──────────────────────────────────────────────────────┐         │
 │ │   /help      - Show help information                            │         │
-│ │   /model     - Switch to a model                                │         │
-│ │ █ /models    - List available models                 [SELECTED] │         │
+│ │ █ /models    - List available models or switch       [SELECTED] │         │
 │ │   /new       - Start a new session                              │         │
 │ │   /clear     - Clear current conversation                       │         │
 │ └─────────────────────────────────────────────────────────────────┘         │
@@ -162,14 +158,14 @@ fn mock_command_palette() -> String {
 │                  │  > _                                  │                  │
 │                  │                                       │                  │
 │                  │  Recent:                              │                  │
-│                  │    /model gpt-4                       │                  │
+│                  │    /models gpt-4                      │                  │
 │                  │    /clear                             │                  │
 │                  │    /help commands                     │                  │
 │                  │                                       │                  │
 │                  │  All Commands:                        │                  │
 │                  │    /help       Show help              │                  │
 │                  │    /new        New session            │                  │
-│                  │    /model      Switch model           │                  │
+│                  │    /models     Switch model           │                  │
 │                  │    /export     Export session         │                  │
 │                  │    ...                                │                  │
 │                  │                                       │                  │

--- a/src/cortex-tui/src/cards/help.rs
+++ b/src/cortex-tui/src/cards/help.rs
@@ -120,7 +120,7 @@ impl HelpCard {
             HelpSection::new(
                 "Slash Commands",
                 vec![
-                    HelpItem::new("/model", "Change AI model"),
+                    HelpItem::new("/models", "List or switch AI models"),
                     HelpItem::new("/mcp", "Manage MCP servers"),
                     HelpItem::new("/sessions", "View sessions"),
                     HelpItem::new("/settings", "Open settings"),

--- a/src/cortex-tui/src/commands/executor/dispatch.rs
+++ b/src/cortex-tui/src/commands/executor/dispatch.rs
@@ -84,10 +84,7 @@ impl CommandExecutor {
             "context" | "ctx" => CommandResult::Async("context".to_string()),
 
             // ============ MODEL ============
-            "model" | "m" => self.cmd_model(cmd),
-            "models" | "lm" | "list-models" => {
-                CommandResult::Async("models:fetch-and-pick".to_string())
-            }
+            "models" | "m" | "lm" | "list-models" => self.cmd_models(cmd),
             "approval" | "approve" => self.cmd_approval(cmd),
             "sandbox" | "sb" => self.cmd_sandbox(cmd),
             "auto" | "autopilot" => self.cmd_auto(cmd),

--- a/src/cortex-tui/src/commands/executor/model.rs
+++ b/src/cortex-tui/src/commands/executor/model.rs
@@ -4,10 +4,10 @@ use super::CommandExecutor;
 use crate::commands::types::{CommandResult, ModalType, ParsedCommand};
 
 impl CommandExecutor {
-    pub(super) fn cmd_model(&self, cmd: &ParsedCommand) -> CommandResult {
+    pub(super) fn cmd_models(&self, cmd: &ParsedCommand) -> CommandResult {
         match cmd.first_arg() {
             Some(model) => CommandResult::SetValue("model".to_string(), model.to_string()),
-            None => CommandResult::OpenModal(ModalType::ModelPicker),
+            None => CommandResult::Async("models:fetch-and-pick".to_string()),
         }
     }
 
@@ -61,7 +61,7 @@ impl CommandExecutor {
         CommandResult::Message(
             "Warning: The /provider command is deprecated.\n\n\
              Cortex is now a unified platform - all model access goes through the Cortex backend.\n\
-             Use /model to switch between available models instead."
+             Use /models to switch between available models instead."
                 .to_string(),
         )
     }

--- a/src/cortex-tui/src/commands/executor/tests.rs
+++ b/src/cortex-tui/src/commands/executor/tests.rs
@@ -76,24 +76,24 @@ fn test_execute_str_invalid() {
 }
 
 #[test]
-fn test_model_with_arg() {
+fn test_models_with_arg() {
     let executor = CommandExecutor::new();
-    let result = executor.execute_str("/model gpt-4");
+    let result = executor.execute_str("/models gpt-4");
     if let CommandResult::SetValue(key, value) = result {
         assert_eq!(key, "model");
         assert_eq!(value, "gpt-4");
     } else {
-        panic!("Expected SetValue");
+        panic!("Expected SetValue, got {:?}", result);
     }
 }
 
 #[test]
-fn test_model_without_arg() {
+fn test_models_without_arg() {
     let executor = CommandExecutor::new();
-    let result = executor.execute_str("/model");
+    let result = executor.execute_str("/models");
     assert!(matches!(
         result,
-        CommandResult::OpenModal(ModalType::ModelPicker)
+        CommandResult::Async(ref s) if s == "models:fetch-and-pick"
     ));
 }
 

--- a/src/cortex-tui/src/commands/forms.rs
+++ b/src/cortex-tui/src/commands/forms.rs
@@ -245,9 +245,9 @@ impl FormRegistry {
                 ],
             )),
 
-            "model" => Some(FormState::new(
+            "models" => Some(FormState::new(
                 "Set Model",
-                "model",
+                "models",
                 vec![
                     FormField::text("model", "Model Name")
                         .required()
@@ -434,7 +434,7 @@ impl FormRegistry {
             "sandbox",
             "auto",
             "provider",
-            "model",
+            "models",
             "theme",
             // MCP commands
             "mcp",
@@ -497,7 +497,7 @@ mod tests {
         assert!(registry.has_form("sandbox"));
         assert!(registry.has_form("auto"));
         assert!(registry.has_form("provider"));
-        assert!(registry.has_form("model"));
+        assert!(registry.has_form("models"));
         assert!(registry.has_form("theme"));
     }
 

--- a/src/cortex-tui/src/commands/mod.rs
+++ b/src/cortex-tui/src/commands/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! Commands are entered with a leading `/` character:
 //! - `/help` - Show help
-//! - `/model claude-sonnet-4-20250514` - Switch model
+//! - `/models claude-sonnet-4-20250514` - Switch model
 //! - `/search "hello world"` - Search with quoted argument
 //!
 //! # Example

--- a/src/cortex-tui/src/commands/registry/builtin.rs
+++ b/src/cortex-tui/src/commands/registry/builtin.rs
@@ -506,21 +506,12 @@ pub fn register_builtin_commands(registry: &mut CommandRegistry) {
     // ========================================
 
     registry.register(CommandDef::new(
-        "model",
-        &["m"],
-        "Switch to a model",
-        "/model <name>",
+        "models",
+        &["m", "lm", "list-models"],
+        "List available models or switch to a model",
+        "/models [name]",
         CommandCategory::Model,
         true,
-    ));
-
-    registry.register(CommandDef::new(
-        "models",
-        &["lm", "list-models"],
-        "List available models",
-        "/models",
-        CommandCategory::Model,
-        false,
     ));
 
     registry.register(CommandDef::new(

--- a/src/cortex-tui/src/commands/registry/mod.rs
+++ b/src/cortex-tui/src/commands/registry/mod.rs
@@ -184,8 +184,8 @@ mod tests {
         assert!(registry.exists("mention"));
         assert!(registry.exists("images"));
 
-        // Model
-        assert!(registry.exists("model"));
+        // Model (note: "model" command was removed, use "models" instead)
+        assert!(!registry.exists("model"));
         assert!(registry.exists("models"));
         assert!(registry.exists("approval"));
         assert!(registry.exists("sandbox"));

--- a/src/cortex-tui/src/modal/help.rs
+++ b/src/cortex-tui/src/modal/help.rs
@@ -129,7 +129,7 @@ impl HelpModal {
             "commands" | "slash" => vec![HelpSection::new(
                 "Slash Commands",
                 vec![
-                    HelpItem::new("/model", "Change AI model"),
+                    HelpItem::new("/models", "List or switch AI models"),
                     HelpItem::new("/mcp", "Manage MCP servers"),
                     HelpItem::new("/sessions", "View sessions"),
                     HelpItem::new("/settings", "Open settings"),
@@ -173,7 +173,7 @@ impl HelpModal {
             HelpSection::new(
                 "Slash Commands",
                 vec![
-                    HelpItem::new("/model", "Change AI model"),
+                    HelpItem::new("/models", "List or switch AI models"),
                     HelpItem::new("/mcp", "Manage MCP servers"),
                     HelpItem::new("/sessions", "View sessions"),
                     HelpItem::new("/settings", "Open settings"),

--- a/src/cortex-tui/src/runner/event_loop/commands.rs
+++ b/src/cortex-tui/src/runner/event_loop/commands.rs
@@ -588,6 +588,11 @@ impl EventLoop {
                 self.app_state.model = value.to_string();
                 self.update_session_model(value);
                 self.add_system_message(&format!("Model set to: {}", value));
+
+                // Persist model selection to config
+                if let Ok(mut config) = crate::providers::config::CortexConfig::load() {
+                    let _ = config.save_last_model(&self.app_state.provider, value);
+                }
             }
             "provider" => {
                 // Check validation result first, storing any error and new model

--- a/src/cortex-tui/src/runner/event_loop/modal.rs
+++ b/src/cortex-tui/src/runner/event_loop/modal.rs
@@ -168,7 +168,7 @@ impl EventLoop {
             "model" => {
                 let name = get("model");
                 if !name.is_empty() {
-                    format!("/model {}", name)
+                    format!("/models {}", name)
                 } else {
                     return;
                 }
@@ -538,6 +538,10 @@ impl EventLoop {
                         return false;
                     }
                     self.app_state.model = item_id.clone();
+                }
+                // Persist model selection to config
+                if let Ok(mut config) = crate::providers::config::CortexConfig::load() {
+                    let _ = config.save_last_model(&self.app_state.provider, &item_id);
                 }
                 self.update_session_model(&item_id);
                 return false;

--- a/src/cortex-tui/src/runner/handlers/command.rs
+++ b/src/cortex-tui/src/runner/handlers/command.rs
@@ -12,7 +12,7 @@ impl<'a> ActionHandler<'a> {
     /// Supported commands:
     /// - `/help` - Show help
     /// - `/clear` - Clear messages
-    /// - `/model <name>` - Switch model
+    /// - `/models <name>` - Switch model
     /// - `/quit` - Quit application
     pub(crate) async fn handle_slash_command(&mut self, cmd: &str) -> Result<bool> {
         tracing::debug!("Slash command: {}", cmd);

--- a/src/cortex-tui/src/widgets/command_palette/state.rs
+++ b/src/cortex-tui/src/widgets/command_palette/state.rs
@@ -13,7 +13,7 @@ fn get_command_shortcut(name: &str) -> Option<String> {
     match name {
         "help" => Some("[?]".to_string()),
         "settings" => Some("[Ctrl+,]".to_string()),
-        "model" => Some("[Ctrl+M]".to_string()),
+        "models" => Some("[Ctrl+M]".to_string()),
         "palette" => Some("[Ctrl+P]".to_string()),
         "quit" => Some("[Ctrl+Q]".to_string()),
         "new" => Some("[Ctrl+N]".to_string()),
@@ -420,8 +420,8 @@ mod tests {
                 category: CommandCategory::General,
             },
             PaletteItem::Command {
-                name: "model".to_string(),
-                description: "Model".to_string(),
+                name: "models".to_string(),
+                description: "Models".to_string(),
                 shortcut: None,
                 category: CommandCategory::Model,
             },
@@ -465,7 +465,7 @@ mod tests {
                 category: CommandCategory::Navigation,
             },
             PaletteItem::Command {
-                name: "model".to_string(),
+                name: "models".to_string(),
                 description: "Switch model".to_string(),
                 shortcut: None,
                 category: CommandCategory::Model,
@@ -572,7 +572,7 @@ mod tests {
             get_command_shortcut("settings"),
             Some("[Ctrl+,]".to_string())
         );
-        assert_eq!(get_command_shortcut("model"), Some("[Ctrl+M]".to_string()));
+        assert_eq!(get_command_shortcut("models"), Some("[Ctrl+M]".to_string()));
         assert_eq!(get_command_shortcut("unknown"), None);
     }
 }

--- a/src/cortex-tui/src/widgets/help_browser/content.rs
+++ b/src/cortex-tui/src/widgets/help_browser/content.rs
@@ -207,20 +207,15 @@ pub fn get_help_sections() -> Vec<HelpSection> {
             HelpContent::Separator,
             HelpContent::Title("Model Commands".to_string()),
             HelpContent::Command {
-                name: "/model".to_string(),
-                description: "Switch model".to_string(),
-                usage: "/model <name>".to_string(),
-            },
-            HelpContent::Command {
                 name: "/models".to_string(),
-                description: "List models".to_string(),
-                usage: "/models".to_string(),
+                description: "List available models or switch model".to_string(),
+                usage: "/models [name]".to_string(),
             },
         ]),
         HelpSection::new("models", "Models").with_content(vec![
             HelpContent::Title("Available Models".to_string()),
             HelpContent::Paragraph(
-                "Use /models to see available models or /model <name> to switch.".to_string(),
+                "Use /models to see available models or /models <name> to switch.".to_string(),
             ),
             HelpContent::Separator,
             HelpContent::Title("Anthropic".to_string()),
@@ -303,7 +298,7 @@ pub fn get_help_sections() -> Vec<HelpSection> {
             HelpContent::Separator,
             HelpContent::Title("How do I switch models?".to_string()),
             HelpContent::Paragraph(
-                "Use /model <name> or press Ctrl+M to open the model picker.".to_string(),
+                "Use /models <name> or press Ctrl+M to open the model picker.".to_string(),
             ),
             HelpContent::Separator,
             HelpContent::Title("How do I save my session?".to_string()),


### PR DESCRIPTION
## Summary
This PR consolidates the `/model` and `/models` commands into a single `/models` command and adds model persistence to config.

## Changes

### Model Command Consolidation
- **Removed** `/model` command entirely
- **Updated** `/models` to accept an optional argument:
  - `/models` - Opens the model picker modal (same as before)
  - `/models <name>` - Directly switches to specified model (was `/model <name>`)
- Added `m` alias to `/models` (previously on `/model`)

### Model Persistence
- When using `/models <name>` command, the model selection is now saved to `config.json`
- Uses `save_last_model()` to persist `last_model` and `last_provider` fields
- Consistent with model picker modal behavior which already persists

### Files Modified
- `builtin.rs` - Removed `/model` registration, updated `/models` to accept optional arg with aliases
- `dispatch.rs` - Removed `model` handler, updated `models` to handle both cases
- `model.rs` - Renamed `cmd_model` to `cmd_models`, returns SetValue if arg provided
- `commands.rs` - Added config persistence after setting model
- `help.rs`, `cards/help.rs`, `content.rs` - Updated help text references
- `tests.rs` - Updated test names and expected results
- `forms.rs`, `state.rs`, `mod.rs` - Updated references from `model` to `models`
- Mock files in `cortex-tui-capture` - Updated UI mockups

## Testing
- `cargo check -p cortex-tui -p cortex-engine -p cortex-tui-capture` passes
- Unit tests updated for new command structure

## Acceptance Criteria
- [x] Model selection via /models picker persists to config.json
- [x] Model selection via /models <name> command persists to config.json
- [x] /model command is removed from the command registry
- [x] /models command works both with and without arguments
- [x] Help text and documentation updated to remove /model references
