### PR TITLE
refactor: replace unsafe unwrap() calls with expect() containing context

### DIFF
--- a/src/cortex-batch/src/batch_ops.rs
+++ b/src/cortex-batch/src/batch_ops.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_e) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-batch/src/multi_edit.rs
+++ b/src/cortex-batch/src/multi_edit.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_e) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-exec/src/runner.rs
+++ b/src/cortex-exec/src/runner.rs
@@ -187,7 +187,11 @@ impl ExecRunner {
             self.client = Some(client);
         }
 
-        Ok(self.client.as_ref().unwrap().as_ref())
+        Ok(self
+            .client
+            .as_ref()
+            .expect("ModelClient should be initialized before use")
+            .as_ref())
     }
 
     /// Get filtered tool definitions based on options.


### PR DESCRIPTION
## Summary

This PR improves error handling by replacing unsafe unwrap() calls with expect() containing meaningful context messages. This makes debugging easier when these invariant violations occur in production.

## Changes

- Replace unwrap() with expect() in cortex-exec/src/runner.rs init_client()
- Add meaningful context messages explaining the invariant

## Verification

```bash
cargo check -p cortex-exec
cargo clippy -p cortex-exec
```