### PR TITLE
fix(session): increase default session timeout to 1 week

### DIFF
--- a/src/cortex-app-server/src/config.rs
+++ b/src/cortex-app-server/src/config.rs
@@ -331,7 +331,7 @@ fn default_max_sessions() -> usize {
 }
 
 fn default_session_timeout() -> u64 {
-    3600 // 1 hour
+    604800 // 1 week
 }
 
 fn default_max_messages() -> usize {

--- a/src/cortex-batch/src/batch_ops.rs
+++ b/src/cortex-batch/src/batch_ops.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-batch/src/multi_edit.rs
+++ b/src/cortex-batch/src/multi_edit.rs
@@ -65,7 +65,7 @@ async fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
 
         match fs::rename(&temp_path, path).await {
             Ok(()) => break,
-            Err(e) if retries > 0 => {
+            Err(_) if retries > 0 => {
                 retries -= 1;
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                 continue;

--- a/src/cortex-engine/src/state/mod.rs
+++ b/src/cortex-engine/src/state/mod.rs
@@ -69,7 +69,7 @@ impl Default for StateConfig {
     fn default() -> Self {
         Self {
             max_sessions: 100,
-            session_timeout: Duration::from_secs(3600),
+            session_timeout: Duration::from_secs(604800), // 1 week
             turn_timeout: Duration::from_secs(300),
             persist: false,
             persist_dir: None,


### PR DESCRIPTION
## Summary
Increases the default session timeout from 1 hour to 1 week (604800 seconds).

## Changes
- Updated `default_session_timeout()` in `cortex-app-server/src/config.rs`
- Updated `StateConfig::default()` in `cortex-engine/src/state/mod.rs`

## Testing
- Verified code compiles with `cargo check`
- Both locations use the same value (604800 seconds = 1 week)