### PR TITLE
fix(notifications): use safe UTF-8 slicing for session IDs

### DIFF
--- a/src/cortex-cli/src/utils/notification.rs
+++ b/src/cortex-cli/src/utils/notification.rs
@@ -63,7 +63,14 @@ pub fn send_task_notification(session_id: &str, success: bool) -> Result<()> {
         "Cortex Task Failed"
     };
 
-    let short_id = &session_id[..8.min(session_id.len())];
+    // Use safe UTF-8 slicing - find the last valid char boundary at or before position 8
+    let short_id = session_id
+        .char_indices()
+        .take_while(|(idx, _)| *idx < 8)
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .last()
+        .and_then(|end| session_id.get(..end))
+        .unwrap_or(session_id);
     let body = format!("Session: {}", short_id);
 
     let urgency = if success {


### PR DESCRIPTION
## Summary

Fixes #5274 - Notification session ID slicing panics on multi-byte UTF-8.

## Problem

Session ID string handling uses byte-based slicing which can panic on multi-byte UTF-8 characters when the slice boundary falls in the middle of a character.

## Solution

Used safe string slicing with char boundaries - iterates through character indices to find the last valid UTF-8 boundary at or before position 8, then uses `.get()` for safe slicing.