### PR TITLE
fix(tui): prevent usize to u16 overflow in interactive renderer

### DIFF
--- a/src/cortex-tui/src/interactive/renderer.rs
+++ b/src/cortex-tui/src/interactive/renderer.rs
@@ -109,7 +109,13 @@ impl<'a> InteractiveWidget<'a> {
         let hints_height = 1;
         let border_height = 2;
 
-        (items_count as u16) + header_height + search_height + hints_height + border_height
+        // Use saturating conversion to prevent overflow when items_count exceeds u16::MAX
+        let items_height = u16::try_from(items_count).unwrap_or(u16::MAX);
+        items_height
+            .saturating_add(header_height)
+            .saturating_add(search_height)
+            .saturating_add(hints_height)
+            .saturating_add(border_height)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #5296 - InteractiveRenderer required_height usize to u16 cast overflow.

## Problem

Unchecked cast from usize to u16 can silently truncate values exceeding 65535.

## Solution

Used saturating conversion with u16::MAX cap to prevent overflow.