### PR TITLE
fix(engine): use saturating casts in git_info to prevent overflow

### DIFF
--- a/src/cortex-engine/src/git_info.rs
+++ b/src/cortex-engine/src/git_info.rs
@@ -67,9 +67,17 @@ impl GitInfo {
         let status = git_command(&root, &["status", "--porcelain"]).unwrap_or_default();
         let is_dirty = !status.is_empty();
 
-        // Count changes
-        let changes = status.lines().filter(|l| !l.starts_with("??")).count() as u32;
-        let untracked = status.lines().filter(|l| l.starts_with("??")).count() as u32;
+        // Count changes (saturating to u32::MAX to prevent truncation)
+        let changes = status
+            .lines()
+            .filter(|l| !l.starts_with("??"))
+            .count()
+            .min(u32::MAX as usize) as u32;
+        let untracked = status
+            .lines()
+            .filter(|l| l.starts_with("??"))
+            .count()
+            .min(u32::MAX as usize) as u32;
 
         // Get tags
         let tags = git_command(&root, &["tag", "--points-at", "HEAD"])
@@ -385,7 +393,7 @@ impl GitStash {
                 let message = parts.get(2).unwrap_or(&"").to_string();
 
                 stashes.push(GitStash {
-                    index: i as u32,
+                    index: i.min(u32::MAX as usize) as u32,
                     message,
                     branch,
                 });

--- a/src/cortex-tui/src/interactive/renderer.rs
+++ b/src/cortex-tui/src/interactive/renderer.rs
@@ -109,7 +109,13 @@ impl<'a> InteractiveWidget<'a> {
         let hints_height = 1;
         let border_height = 2;
 
-        (items_count as u16) + header_height + search_height + hints_height + border_height
+        // Use saturating conversion to prevent overflow when items_count exceeds u16::MAX
+        let items_height = u16::try_from(items_count).unwrap_or(u16::MAX);
+        items_height
+            .saturating_add(header_height)
+            .saturating_add(search_height)
+            .saturating_add(hints_height)
+            .saturating_add(border_height)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #5185 - git_info.rs uses unchecked narrowing casts.

## Problem

Several type conversions can silently truncate large values.

## Solution

Applied saturating conversions to prevent silent truncation.