### PR TITLE
fix(engine): use saturating casts for token counts in streaming

### DIFF
--- a/src/cortex-engine/src/streaming.rs
+++ b/src/cortex-engine/src/streaming.rs
@@ -26,12 +26,25 @@ pub struct StreamTokenUsage {
     pub total_tokens: u32,
 }
 
+/// Safely convert an i64 token count to u32 with saturation.
+/// Negative values clamp to 0, values > u32::MAX clamp to u32::MAX.
+#[inline]
+fn saturating_i64_to_u32(value: i64) -> u32 {
+    if value <= 0 {
+        0
+    } else if value > u32::MAX as i64 {
+        u32::MAX
+    } else {
+        value as u32
+    }
+}
+
 impl From<crate::client::TokenUsage> for StreamTokenUsage {
     fn from(usage: crate::client::TokenUsage) -> Self {
         Self {
-            prompt_tokens: usage.input_tokens as u32,
-            completion_tokens: usage.output_tokens as u32,
-            total_tokens: usage.total_tokens as u32,
+            prompt_tokens: saturating_i64_to_u32(usage.input_tokens),
+            completion_tokens: saturating_i64_to_u32(usage.output_tokens),
+            total_tokens: saturating_i64_to_u32(usage.total_tokens),
         }
     }
 }

--- a/src/cortex-tui/src/interactive/renderer.rs
+++ b/src/cortex-tui/src/interactive/renderer.rs
@@ -109,7 +109,13 @@ impl<'a> InteractiveWidget<'a> {
         let hints_height = 1;
         let border_height = 2;
 
-        (items_count as u16) + header_height + search_height + hints_height + border_height
+        // Use saturating conversion to prevent overflow when items_count exceeds u16::MAX
+        let items_height = u16::try_from(items_count).unwrap_or(u16::MAX);
+        items_height
+            .saturating_add(header_height)
+            .saturating_add(search_height)
+            .saturating_add(hints_height)
+            .saturating_add(border_height)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #5188 - streaming.rs uses unchecked narrowing casts.

## Problem

Token count conversions can silently truncate on very large values.

## Solution

Used saturating conversion to cap at u32::MAX instead of truncating.