### PR TITLE
fix(tui): prevent usize to u16 overflow in card count displays

### DIFF
--- a/src/cortex-tui/src/cards/commands.rs
+++ b/src/cortex-tui/src/cards/commands.rs
@@ -225,8 +225,9 @@ impl CardView for CommandsCard {
 
     fn desired_height(&self, max_height: u16, _width: u16) -> u16 {
         // Base height for list items + search bar + some padding
-        let command_count = self.commands.len() as u16;
-        let content_height = command_count + 2; // +2 for search bar and padding
+        // Use saturating conversion to prevent overflow when count > u16::MAX
+        let command_count = u16::try_from(self.commands.len()).unwrap_or(u16::MAX);
+        let content_height = command_count.saturating_add(2); // +2 for search bar and padding
 
         // Clamp between min 5 and max 14, respecting max_height
         content_height.clamp(5, 14).min(max_height)

--- a/src/cortex-tui/src/cards/models.rs
+++ b/src/cortex-tui/src/cards/models.rs
@@ -147,8 +147,9 @@ impl CardView for ModelsCard {
 
     fn desired_height(&self, max_height: u16, _width: u16) -> u16 {
         // Base height for list items + search bar + some padding
-        let model_count = self.models.len() as u16;
-        let content_height = model_count + 2; // +2 for search bar and padding
+        // Use saturating conversion to prevent overflow when count > u16::MAX
+        let model_count = u16::try_from(self.models.len()).unwrap_or(u16::MAX);
+        let content_height = model_count.saturating_add(2); // +2 for search bar and padding
 
         // Clamp between min 5 and max 12, respecting max_height
         content_height.clamp(5, 12).min(max_height)

--- a/src/cortex-tui/src/cards/sessions.rs
+++ b/src/cortex-tui/src/cards/sessions.rs
@@ -207,7 +207,9 @@ impl CardView for SessionsCard {
 
     fn desired_height(&self, max_height: u16, _width: u16) -> u16 {
         // Base height: sessions + header + search bar + padding
-        let content_height = self.sessions.len() as u16 + 3;
+        // Use saturating conversion to prevent overflow when count > u16::MAX
+        let session_count = u16::try_from(self.sessions.len()).unwrap_or(u16::MAX);
+        let content_height = session_count.saturating_add(3);
         let min_height = 5;
         let max_desired = 15;
         content_height


### PR DESCRIPTION
## Summary

Fixes #5166, #5159, #5141 - Card count displays overflow on large values.

## Problem

Direct usize to u16 casts truncate when counts exceed 65535.

## Solution

Used saturating conversion to cap at u16::MAX.