### PR TITLE
cleanup: remove dead code and unnecessary allow(dead_code) annotations

### DIFF
--- a/src/cortex-app-server/src/storage.rs
+++ b/src/cortex-app-server/src/storage.rs
@@ -47,8 +47,6 @@ pub struct StoredToolCall {
 
 /// Session storage manager.
 pub struct SessionStorage {
-    #[allow(dead_code)]
-    base_dir: PathBuf,
     sessions_dir: PathBuf,
     history_dir: PathBuf,
 }
@@ -66,7 +64,6 @@ impl SessionStorage {
         info!("Session storage initialized at {:?}", base_dir);
 
         Ok(Self {
-            base_dir,
             sessions_dir,
             history_dir,
         })

--- a/src/cortex-apply-patch/src/hunk.rs
+++ b/src/cortex-apply-patch/src/hunk.rs
@@ -250,9 +250,6 @@ pub struct SearchReplace {
     pub search: String,
     /// The text to replace with.
     pub replace: String,
-    /// Replace all occurrences (true) or just the first (false).
-    #[allow(dead_code)]
-    pub replace_all: bool,
 }
 
 impl SearchReplace {
@@ -266,15 +263,7 @@ impl SearchReplace {
             path: path.into(),
             search: search.into(),
             replace: replace.into(),
-            replace_all: false,
         }
-    }
-
-    /// Set whether to replace all occurrences.
-    #[allow(dead_code)]
-    pub fn with_replace_all(mut self, replace_all: bool) -> Self {
-        self.replace_all = replace_all;
-        self
     }
 }
 


### PR DESCRIPTION
## Summary

This PR cleans up `#[allow(dead_code)]` annotations in several modules. Dead code is either removed if truly unused, or the annotation is removed if the code is actually used.

## Changes

- cortex-app-server/src/storage.rs: Removed unused `base_dir` field from `SessionStorage` struct (the field was stored but never read after initialization)
- cortex-mcp-client/src/transport.rs: Removed unused `reconnect()` methods from both `StdioTransport` and `HttpTransport`, along with the unused `test_connection()` method from `HttpTransport`. Also removed unused imports (`tokio::time::sleep` and `tracing::error`)
- cortex-apply-patch/src/hunk.rs: Removed unused `replace_all` field and `with_replace_all()` method from `SearchReplace` struct (internal struct not exposed in public API)

## Verification

```bash
cargo check -p cortex-app-server -p cortex-mcp-client -p cortex-apply-patch
cargo test -p cortex-app-server -p cortex-mcp-client -p cortex-apply-patch
```