### PR TITLE
fix(tools): add serde alias for Glob tool folder parameter

### DIFF
--- a/src/cortex-engine/src/tools/handlers/glob.rs
+++ b/src/cortex-engine/src/tools/handlers/glob.rs
@@ -17,6 +17,7 @@ pub struct GlobHandler;
 #[derive(Debug, Deserialize)]
 struct GlobArgs {
     patterns: Vec<String>,
+    #[serde(alias = "folder")]
     directory: Option<String>,
     #[serde(default)]
     exclude_patterns: Vec<String>,


### PR DESCRIPTION
## Problem

The Glob tool has a parameter naming mismatch between its definition and handler:

- In `src/cortex-engine/src/tools/registry/definitions.rs`, the Glob tool definition specifies the parameter name as `folder`
- In `src/cortex-engine/src/tools/handlers/glob.rs`, the `GlobArgs` struct expects a field named `directory`

This mismatch can cause deserialization failures when the model sends a `folder` parameter (based on the tool definition), since serde expects `directory`.

## Solution

Add a serde alias attribute to the `directory` field in `GlobArgs`:

```rust
#[serde(alias = "folder")]
directory: Option<String>,
```

This allows the handler to accept both `folder` and `directory` parameter names, ensuring compatibility with the tool definition while maintaining backward compatibility with any existing code that uses `directory`.