### PR TITLE
fix(exec): replace unwrap with proper error handling for client access

### DIFF
--- a/src/cortex-exec/src/runner.rs
+++ b/src/cortex-exec/src/runner.rs
@@ -195,7 +195,10 @@ impl ExecRunner {
             self.client = Some(client);
         }
 
-        Ok(self.client.as_ref().unwrap().as_ref())
+        self.client
+            .as_ref()
+            .map(|c| c.as_ref())
+            .ok_or_else(|| CortexError::Internal("LLM client not initialized".to_string()))
     }
 
     /// Get filtered tool definitions based on options.


### PR DESCRIPTION
## Problem

The get_or_create_client method in cortex-exec/src/runner.rs line 198 contained an unsafe .unwrap() call:

```rust
Ok(self.client.as_ref().unwrap().as_ref())
```

This could panic at runtime if the client field is None, leading to an unrecoverable crash.

## Solution

Replaced the unsafe .unwrap() with proper error handling that returns a descriptive CortexError::Internal when the client is not initialized:

```rust
self.client
    .as_ref()
    .map(|c| c.as_ref())
    .ok_or_else(|| CortexError::Internal("LLM client not initialized".to_string()))
```

This approach:
- Prevents runtime panics
- Provides a clear error message for debugging
- Follows Rust best practices for error handling
- Maintains the same return type (Result<&dyn ModelClient, CortexError>)

## Testing

- Verified compilation with cargo check -p cortex-exec