### PR TITLE
fix(auth): use unwrap_or_default for SystemTime operations

### DIFF
--- a/src/cortex-app-server/src/auth.rs
+++ b/src/cortex-app-server/src/auth.rs
@@ -45,7 +45,7 @@ impl Claims {
     pub fn new(user_id: impl Into<String>, expiry_seconds: u64) -> Self {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs();
 
         Self {
@@ -75,7 +75,7 @@ impl Claims {
     pub fn is_expired(&self) -> bool {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs();
         self.exp < now
     }
@@ -187,7 +187,7 @@ impl AuthService {
     pub async fn cleanup_revoked_tokens(&self) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs();
 
         let mut revoked = self.revoked_tokens.write().await;


### PR DESCRIPTION
## Summary

This PR replaces `.unwrap()` calls on `SystemTime::duration_since(UNIX_EPOCH)` with `.unwrap_or_default()` in the authentication module for defensive programming.

## Problem

The current implementation uses `.unwrap()` on `SystemTime::duration_since(UNIX_EPOCH)` in three locations within `cortex-app-server/src/auth.rs`:

- `Claims::new()` (line 48)
- `Claims::is_expired()` (line 78)  
- `AuthService::cleanup_revoked_tokens()` (line 190)

While extremely unlikely in practice, `duration_since(UNIX_EPOCH)` can return an `Err` if the system clock is set to a time before the Unix epoch (January 1, 1970). In such a case, the current code would panic.

## Solution

Replace all three instances of:
```rust
.duration_since(UNIX_EPOCH)
.unwrap()
```

with:
```rust
.duration_since(UNIX_EPOCH)
.unwrap_or_default()
```

This provides a safe fallback to `Duration::default()` (zero duration) in the unlikely event of a misconfigured system clock, preventing potential panics while maintaining normal operation for correctly configured systems.

## Testing

- Verified compilation with `cargo check -p cortex-app-server`