### PR TITLE
fix(exec): replace unsafe unwrap() with expect() in init_client

### DIFF
--- a/src/cortex-exec/src/runner.rs
+++ b/src/cortex-exec/src/runner.rs
@@ -187,7 +187,7 @@ impl ExecRunner {
             self.client = Some(client);
         }
 
-        Ok(self.client.as_ref().unwrap().as_ref())
+        Ok(self.client.as_ref().expect("Client should be initialized in init_client").as_ref())
     }
 
     /// Get filtered tool definitions based on options.


### PR DESCRIPTION
## Summary
Replaces an unsafe unwrap() call in the ExecRunner::init_client method with expect() containing a descriptive error message.

## Problem
The init_client method uses `self.client.as_ref().unwrap().as_ref()` which could panic without context if the client is unexpectedly None. While the code structure ensures client is set before this line, the unwrap provides no debugging context if this invariant is violated.

## Changes
- Updated /workspace/src/cortex-exec/src/runner.rs to use expect() with a descriptive message

## Testing
- Verified code compiles with cargo check -p cortex-exec
- The expect() message clarifies that this should never fail because init_client sets the client field

## Verification
```bash
cargo check -p cortex-exec
```