### PR TITLE
fix(tui): use secure random temp files in external editor to prevent symlink attacks

### DIFF
--- a/src/cortex-tui/Cargo.toml
+++ b/src/cortex-tui/Cargo.toml
@@ -65,6 +65,7 @@ walkdir = { workspace = true }
 
 # External editor
 which = { workspace = true }
+tempfile = { workspace = true }
 
 # Audio notifications
 rodio = { workspace = true }


### PR DESCRIPTION
## Summary

Fix symlink attack vulnerability in external editor temp file handling.

## Problem

The external editor was using predictable temp filenames based on PID (`cortex_prompt_{PID}.md`), making it vulnerable to symlink attacks.

## Solution

- Use the tempfile crate with cryptographically random names (16 random bytes)
- Use O_EXCL flag to fail if file exists (preventing TOCTOU races)
- Set restrictive permissions (0600 on Unix)

## Testing

- Cargo check passes
- Both async and sync versions updated

## Security Impact

Prevents local privilege escalation via symlink attacks on temp files.

## Related Issue

Fixes issue #5405