### PR TITLE
fix: consolidated memory and storage improvements

### DIFF
--- a/src/cortex-cli/src/utils/paths.rs
+++ b/src/cortex-cli/src/utils/paths.rs
@@ -34,10 +34,16 @@ pub fn get_cortex_home() -> PathBuf {
 /// // Returns: /home/user/documents/file.txt
 /// ```
 pub fn expand_tilde(path: &str) -> String {
-    if path.starts_with("~/")
-        && let Some(home) = dirs::home_dir()
-    {
-        return home.join(&path[2..]).to_string_lossy().to_string();
+    if path == "~" {
+        // Handle bare "~" - return home directory
+        if let Some(home) = dirs::home_dir() {
+            return home.to_string_lossy().to_string();
+        }
+    } else if path.starts_with("~/") {
+        // Handle "~/" prefix - expand to home directory + rest of path
+        if let Some(home) = dirs::home_dir() {
+            return home.join(&path[2..]).to_string_lossy().to_string();
+        }
     }
     path.to_string()
 }
@@ -58,8 +64,12 @@ pub fn expand_tilde(path: &str) -> String {
 pub fn validate_path_safety(path: &Path, base_dir: Option<&Path>) -> Result<(), String> {
     let path_str = path.to_string_lossy();
 
-    // Check for path traversal attempts
-    if path_str.contains("..") {
+    // Check for path traversal attempts by examining path components
+    // This correctly handles filenames containing ".." like "file..txt"
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
         return Err("Path contains traversal sequence '..'".to_string());
     }
 
@@ -257,8 +267,15 @@ mod tests {
 
     #[test]
     fn test_expand_tilde_with_tilde_only() {
-        // Test tilde alone - should remain unchanged (not "~/")
-        assert_eq!(expand_tilde("~"), "~");
+        // Test bare "~" - should expand to home directory
+        let result = expand_tilde("~");
+        if let Some(home) = dirs::home_dir() {
+            let expected = home.to_string_lossy().to_string();
+            assert_eq!(result, expected);
+        } else {
+            // If no home dir, original is returned
+            assert_eq!(result, "~");
+        }
     }
 
     #[test]
@@ -320,20 +337,30 @@ mod tests {
 
     #[test]
     fn test_validate_path_safety_detects_various_traversal_patterns() {
-        // Different traversal patterns
-        let patterns = ["foo/../bar", "...", "foo/bar/../baz", "./foo/../../../etc"];
+        // Patterns that ARE path traversal (contain ".." as a component)
+        let traversal_patterns = ["foo/../bar", "foo/bar/../baz", "./foo/../../../etc", ".."];
 
-        for pattern in patterns {
+        for pattern in traversal_patterns {
             let path = Path::new(pattern);
             let result = validate_path_safety(path, None);
-            // Only patterns containing ".." should fail
-            if pattern.contains("..") {
-                assert!(
-                    result.is_err(),
-                    "Expected traversal detection for: {}",
-                    pattern
-                );
-            }
+            assert!(
+                result.is_err(),
+                "Expected traversal detection for: {}",
+                pattern
+            );
+        }
+
+        // Patterns that are NOT path traversal (contain ".." in filenames only)
+        let safe_patterns = ["file..txt", "..hidden", "test...file", "foo/bar..baz/file"];
+
+        for pattern in safe_patterns {
+            let path = Path::new(pattern);
+            let result = validate_path_safety(path, None);
+            assert!(
+                result.is_ok(),
+                "False positive: '{}' should not be detected as traversal",
+                pattern
+            );
         }
     }
 

--- a/src/cortex-cli/src/utils/paths.rs
+++ b/src/cortex-cli/src/utils/paths.rs
@@ -39,10 +39,10 @@ pub fn expand_tilde(path: &str) -> String {
         if let Some(home) = dirs::home_dir() {
             return home.to_string_lossy().to_string();
         }
-    } else if path.starts_with("~/") {
+    } else if let Some(suffix) = path.strip_prefix("~/") {
         // Handle "~/" prefix - expand to home directory + rest of path
         if let Some(home) = dirs::home_dir() {
-            return home.join(&path[2..]).to_string_lossy().to_string();
+            return home.join(suffix).to_string_lossy().to_string();
         }
     }
     path.to_string()

--- a/src/cortex-engine/src/tools/mod.rs
+++ b/src/cortex-engine/src/tools/mod.rs
@@ -30,6 +30,7 @@ pub mod artifacts;
 pub mod context;
 pub mod handlers;
 pub mod registry;
+pub mod response_store;
 pub mod router;
 pub mod spec;
 pub mod unified_executor;
@@ -45,6 +46,10 @@ pub use artifacts::{
 pub use context::ToolContext;
 pub use handlers::*;
 pub use registry::{PluginTool, ToolRegistry};
+pub use response_store::{
+    CLEANUP_INTERVAL, DEFAULT_TTL, MAX_STORE_SIZE, StoreInfo, StoreStats, StoredResponse,
+    ToolResponseStore, ToolResponseStoreConfig, create_shared_store, create_shared_store_with_config,
+};
 pub use router::ToolRouter;
 pub use spec::{ToolCall, ToolDefinition, ToolHandler, ToolResult};
 pub use unified_executor::{ExecutorConfig, UnifiedToolExecutor};

--- a/src/cortex-engine/src/tools/mod.rs
+++ b/src/cortex-engine/src/tools/mod.rs
@@ -48,7 +48,8 @@ pub use handlers::*;
 pub use registry::{PluginTool, ToolRegistry};
 pub use response_store::{
     CLEANUP_INTERVAL, DEFAULT_TTL, MAX_STORE_SIZE, StoreInfo, StoreStats, StoredResponse,
-    ToolResponseStore, ToolResponseStoreConfig, create_shared_store, create_shared_store_with_config,
+    ToolResponseStore, ToolResponseStoreConfig, create_shared_store,
+    create_shared_store_with_config,
 };
 pub use router::ToolRouter;
 pub use spec::{ToolCall, ToolDefinition, ToolHandler, ToolResult};

--- a/src/cortex-engine/src/tools/response_store.rs
+++ b/src/cortex-engine/src/tools/response_store.rs
@@ -1,0 +1,511 @@
+//! Tool response storage with bounded capacity and automatic cleanup.
+//!
+//! This module provides a bounded storage for tool execution results that:
+//! - Limits maximum number of stored responses to prevent unbounded memory growth
+//! - Removes entries when they are consumed (read and take)
+//! - Periodically cleans up stale entries based on TTL
+//!
+//! Fixes #5292 (unbounded growth) and #5293 (missing removal on read).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+use crate::tools::spec::ToolResult;
+
+/// Maximum number of responses to store before eviction.
+/// This prevents unbounded memory growth from accumulated tool responses.
+pub const MAX_STORE_SIZE: usize = 500;
+
+/// Default time-to-live for stored responses (5 minutes).
+pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
+
+/// Interval for periodic cleanup of stale entries (1 minute).
+pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// A stored tool response with metadata.
+#[derive(Debug, Clone)]
+pub struct StoredResponse {
+    /// The tool execution result.
+    pub result: ToolResult,
+    /// Tool name that produced this result.
+    pub tool_name: String,
+    /// When the response was stored.
+    pub stored_at: Instant,
+    /// Whether this response has been read (but not yet consumed).
+    pub read: bool,
+}
+
+impl StoredResponse {
+    /// Create a new stored response.
+    pub fn new(tool_name: impl Into<String>, result: ToolResult) -> Self {
+        Self {
+            result,
+            tool_name: tool_name.into(),
+            stored_at: Instant::now(),
+            read: false,
+        }
+    }
+
+    /// Check if the response has expired.
+    pub fn is_expired(&self, ttl: Duration) -> bool {
+        self.stored_at.elapsed() > ttl
+    }
+
+    /// Get the age of this response.
+    pub fn age(&self) -> Duration {
+        self.stored_at.elapsed()
+    }
+}
+
+/// Configuration for the tool response store.
+#[derive(Debug, Clone)]
+pub struct ToolResponseStoreConfig {
+    /// Maximum number of responses to store.
+    pub max_size: usize,
+    /// Time-to-live for stored responses.
+    pub ttl: Duration,
+    /// Whether to remove entries on read (peek vs consume).
+    pub remove_on_read: bool,
+}
+
+impl Default for ToolResponseStoreConfig {
+    fn default() -> Self {
+        Self {
+            max_size: MAX_STORE_SIZE,
+            ttl: DEFAULT_TTL,
+            remove_on_read: true,
+        }
+    }
+}
+
+impl ToolResponseStoreConfig {
+    /// Create a config with custom max size.
+    pub fn with_max_size(mut self, max_size: usize) -> Self {
+        self.max_size = max_size;
+        self
+    }
+
+    /// Create a config with custom TTL.
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = ttl;
+        self
+    }
+
+    /// Set whether to remove entries on read.
+    pub fn with_remove_on_read(mut self, remove: bool) -> Self {
+        self.remove_on_read = remove;
+        self
+    }
+}
+
+/// Bounded storage for tool execution responses.
+///
+/// This store prevents unbounded memory growth by:
+/// 1. Enforcing a maximum number of stored responses
+/// 2. Removing entries when they are consumed
+/// 3. Periodically cleaning up stale entries
+///
+/// # Thread Safety
+///
+/// The store uses `RwLock` for interior mutability and is safe to share
+/// across threads via `Arc<ToolResponseStore>`.
+#[derive(Debug)]
+pub struct ToolResponseStore {
+    /// Stored responses keyed by tool call ID.
+    responses: RwLock<HashMap<String, StoredResponse>>,
+    /// Configuration.
+    config: ToolResponseStoreConfig,
+    /// Last cleanup time.
+    last_cleanup: RwLock<Instant>,
+    /// Statistics.
+    stats: RwLock<StoreStats>,
+}
+
+impl ToolResponseStore {
+    /// Create a new tool response store with default configuration.
+    pub fn new() -> Self {
+        Self::with_config(ToolResponseStoreConfig::default())
+    }
+
+    /// Create a tool response store with custom configuration.
+    pub fn with_config(config: ToolResponseStoreConfig) -> Self {
+        Self {
+            responses: RwLock::new(HashMap::new()),
+            config,
+            last_cleanup: RwLock::new(Instant::now()),
+            stats: RwLock::new(StoreStats::default()),
+        }
+    }
+
+    /// Store a tool response.
+    ///
+    /// If the store is at capacity, the oldest entry will be evicted.
+    /// Returns `true` if an entry was evicted to make room.
+    pub async fn store(&self, call_id: impl Into<String>, tool_name: impl Into<String>, result: ToolResult) -> bool {
+        let call_id = call_id.into();
+        let tool_name = tool_name.into();
+        let mut evicted = false;
+
+        // Perform periodic cleanup if needed
+        self.maybe_cleanup().await;
+
+        let mut responses = self.responses.write().await;
+
+        // Evict oldest entry if at capacity
+        if responses.len() >= self.config.max_size {
+            if let Some(oldest_key) = self.find_oldest_key(&responses) {
+                responses.remove(&oldest_key);
+                evicted = true;
+                debug!(
+                    evicted_key = %oldest_key,
+                    "Evicted oldest response to make room"
+                );
+            }
+        }
+
+        let response = StoredResponse::new(tool_name, result);
+        responses.insert(call_id.clone(), response);
+
+        // Update stats
+        let mut stats = self.stats.write().await;
+        stats.total_stored += 1;
+        if evicted {
+            stats.evictions += 1;
+        }
+
+        evicted
+    }
+
+    /// Get a response without removing it (peek).
+    ///
+    /// Marks the response as read but does not consume it.
+    pub async fn get(&self, call_id: &str) -> Option<ToolResult> {
+        let mut responses = self.responses.write().await;
+        
+        if let Some(response) = responses.get_mut(call_id) {
+            response.read = true;
+            let mut stats = self.stats.write().await;
+            stats.reads += 1;
+            Some(response.result.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Take (consume) a response, removing it from the store.
+    ///
+    /// This is the primary method for retrieving responses as it ensures
+    /// entries are cleaned up after being consumed (#5293).
+    pub async fn take(&self, call_id: &str) -> Option<ToolResult> {
+        let mut responses = self.responses.write().await;
+        
+        if let Some(response) = responses.remove(call_id) {
+            let mut stats = self.stats.write().await;
+            stats.takes += 1;
+            Some(response.result)
+        } else {
+            None
+        }
+    }
+
+    /// Check if a response exists for the given call ID.
+    pub async fn contains(&self, call_id: &str) -> bool {
+        self.responses.read().await.contains_key(call_id)
+    }
+
+    /// Get the current number of stored responses.
+    pub async fn len(&self) -> usize {
+        self.responses.read().await.len()
+    }
+
+    /// Check if the store is empty.
+    pub async fn is_empty(&self) -> bool {
+        self.responses.read().await.is_empty()
+    }
+
+    /// Remove all expired entries.
+    ///
+    /// Returns the number of entries removed.
+    pub async fn cleanup_expired(&self) -> usize {
+        let mut responses = self.responses.write().await;
+        let ttl = self.config.ttl;
+        let before = responses.len();
+        
+        responses.retain(|_, v| !v.is_expired(ttl));
+        
+        let removed = before - responses.len();
+        if removed > 0 {
+            debug!(removed, "Cleaned up expired responses");
+            let mut stats = self.stats.write().await;
+            stats.expired_cleanups += removed as u64;
+        }
+        
+        removed
+    }
+
+    /// Remove all read entries that haven't been consumed.
+    ///
+    /// This is useful for cleaning up entries that were peeked but never taken.
+    pub async fn cleanup_read(&self) -> usize {
+        let mut responses = self.responses.write().await;
+        let before = responses.len();
+        
+        responses.retain(|_, v| !v.read);
+        
+        let removed = before - responses.len();
+        if removed > 0 {
+            debug!(removed, "Cleaned up read-but-not-consumed responses");
+        }
+        
+        removed
+    }
+
+    /// Clear all stored responses.
+    pub async fn clear(&self) {
+        self.responses.write().await.clear();
+    }
+
+    /// Get store statistics.
+    pub async fn stats(&self) -> StoreStats {
+        self.stats.read().await.clone()
+    }
+
+    /// Get detailed store info including current size and config.
+    pub async fn info(&self) -> StoreInfo {
+        let responses = self.responses.read().await;
+        let stats = self.stats.read().await;
+        
+        StoreInfo {
+            current_size: responses.len(),
+            max_size: self.config.max_size,
+            ttl_secs: self.config.ttl.as_secs(),
+            oldest_age_secs: responses
+                .values()
+                .map(|r| r.age().as_secs())
+                .max()
+                .unwrap_or(0),
+            stats: stats.clone(),
+        }
+    }
+
+    // Internal helpers
+
+    /// Find the key of the oldest entry.
+    fn find_oldest_key(&self, responses: &HashMap<String, StoredResponse>) -> Option<String> {
+        responses
+            .iter()
+            .min_by_key(|(_, v)| v.stored_at)
+            .map(|(k, _)| k.clone())
+    }
+
+    /// Perform cleanup if enough time has passed since last cleanup.
+    async fn maybe_cleanup(&self) {
+        let should_cleanup = {
+            let last = self.last_cleanup.read().await;
+            last.elapsed() > CLEANUP_INTERVAL
+        };
+
+        if should_cleanup {
+            *self.last_cleanup.write().await = Instant::now();
+            let removed = self.cleanup_expired().await;
+            if removed > 0 {
+                debug!(removed, "Periodic cleanup removed expired entries");
+            }
+        }
+    }
+}
+
+impl Default for ToolResponseStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Statistics for the tool response store.
+#[derive(Debug, Clone, Default)]
+pub struct StoreStats {
+    /// Total responses stored.
+    pub total_stored: u64,
+    /// Number of get (peek) operations.
+    pub reads: u64,
+    /// Number of take (consume) operations.
+    pub takes: u64,
+    /// Number of evictions due to capacity limit.
+    pub evictions: u64,
+    /// Number of entries removed by TTL cleanup.
+    pub expired_cleanups: u64,
+}
+
+/// Detailed store information.
+#[derive(Debug, Clone)]
+pub struct StoreInfo {
+    /// Current number of stored responses.
+    pub current_size: usize,
+    /// Maximum allowed size.
+    pub max_size: usize,
+    /// TTL in seconds.
+    pub ttl_secs: u64,
+    /// Age of oldest entry in seconds.
+    pub oldest_age_secs: u64,
+    /// Store statistics.
+    pub stats: StoreStats,
+}
+
+/// Create a shared tool response store.
+pub fn create_shared_store() -> Arc<ToolResponseStore> {
+    Arc::new(ToolResponseStore::new())
+}
+
+/// Create a shared tool response store with custom configuration.
+pub fn create_shared_store_with_config(config: ToolResponseStoreConfig) -> Arc<ToolResponseStore> {
+    Arc::new(ToolResponseStore::with_config(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_store_and_take() {
+        let store = ToolResponseStore::new();
+
+        let result = ToolResult::success("test output");
+        store.store("call-1", "Read", result.clone()).await;
+
+        assert!(store.contains("call-1").await);
+        assert_eq!(store.len().await, 1);
+
+        let taken = store.take("call-1").await;
+        assert!(taken.is_some());
+        assert_eq!(taken.unwrap().output, "test output");
+
+        // After take, entry should be gone
+        assert!(!store.contains("call-1").await);
+        assert_eq!(store.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_store_and_get() {
+        let store = ToolResponseStore::new();
+
+        let result = ToolResult::success("test output");
+        store.store("call-1", "Read", result).await;
+
+        // Get should return result but not remove it
+        let got = store.get("call-1").await;
+        assert!(got.is_some());
+        assert!(store.contains("call-1").await);
+
+        // Second get should still work
+        let got2 = store.get("call-1").await;
+        assert!(got2.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_capacity_eviction() {
+        let config = ToolResponseStoreConfig::default().with_max_size(3);
+        let store = ToolResponseStore::with_config(config);
+
+        // Fill to capacity
+        store.store("call-1", "Read", ToolResult::success("1")).await;
+        store.store("call-2", "Read", ToolResult::success("2")).await;
+        store.store("call-3", "Read", ToolResult::success("3")).await;
+
+        assert_eq!(store.len().await, 3);
+
+        // Add one more, should evict oldest
+        let evicted = store.store("call-4", "Read", ToolResult::success("4")).await;
+        assert!(evicted);
+        assert_eq!(store.len().await, 3);
+
+        // call-1 should be evicted (oldest)
+        assert!(!store.contains("call-1").await);
+        assert!(store.contains("call-4").await);
+    }
+
+    #[tokio::test]
+    async fn test_expired_cleanup() {
+        let config = ToolResponseStoreConfig::default()
+            .with_ttl(Duration::from_millis(50));
+        let store = ToolResponseStore::with_config(config);
+
+        store.store("call-1", "Read", ToolResult::success("1")).await;
+        assert_eq!(store.len().await, 1);
+
+        // Wait for expiration
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let removed = store.cleanup_expired().await;
+        assert_eq!(removed, 1);
+        assert_eq!(store.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_read() {
+        let store = ToolResponseStore::new();
+
+        store.store("call-1", "Read", ToolResult::success("1")).await;
+        store.store("call-2", "Read", ToolResult::success("2")).await;
+
+        // Read one entry
+        store.get("call-1").await;
+
+        // Cleanup read entries
+        let removed = store.cleanup_read().await;
+        assert_eq!(removed, 1);
+        assert_eq!(store.len().await, 1);
+        assert!(!store.contains("call-1").await);
+        assert!(store.contains("call-2").await);
+    }
+
+    #[tokio::test]
+    async fn test_stats() {
+        let store = ToolResponseStore::new();
+
+        store.store("call-1", "Read", ToolResult::success("1")).await;
+        store.get("call-1").await;
+        store.take("call-1").await;
+
+        let stats = store.stats().await;
+        assert_eq!(stats.total_stored, 1);
+        assert_eq!(stats.reads, 1);
+        assert_eq!(stats.takes, 1);
+    }
+
+    #[tokio::test]
+    async fn test_nonexistent_key() {
+        let store = ToolResponseStore::new();
+
+        assert!(store.get("nonexistent").await.is_none());
+        assert!(store.take("nonexistent").await.is_none());
+        assert!(!store.contains("nonexistent").await);
+    }
+
+    #[tokio::test]
+    async fn test_clear() {
+        let store = ToolResponseStore::new();
+
+        store.store("call-1", "Read", ToolResult::success("1")).await;
+        store.store("call-2", "Read", ToolResult::success("2")).await;
+
+        assert_eq!(store.len().await, 2);
+
+        store.clear().await;
+        assert_eq!(store.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_info() {
+        let store = ToolResponseStore::new();
+
+        store.store("call-1", "Read", ToolResult::success("1")).await;
+
+        let info = store.info().await;
+        assert_eq!(info.current_size, 1);
+        assert_eq!(info.max_size, MAX_STORE_SIZE);
+    }
+}

--- a/src/cortex-engine/src/validation.rs
+++ b/src/cortex-engine/src/validation.rs
@@ -280,9 +280,8 @@ fn normalize_command(cmd: &str) -> String {
         .enumerate()
         .map(|(idx, part)| {
             // Remove surrounding quotes (single and double)
-            let unquoted = part
-                .trim_matches(|c| c == '\'' || c == '"');
-            
+            let unquoted = part.trim_matches(|c| c == '\'' || c == '"');
+
             // For the first part (command), extract basename to handle path variants
             if idx == 0 {
                 Path::new(unquoted)
@@ -738,10 +737,16 @@ mod tests {
 
         // Extra whitespace should not bypass validation
         let result = validator.validate("rm  -rf  /");
-        assert!(!result.valid, "Extra whitespace should not bypass blocked command");
+        assert!(
+            !result.valid,
+            "Extra whitespace should not bypass blocked command"
+        );
 
         let result = validator.validate("rm   -rf   /");
-        assert!(!result.valid, "Multiple spaces should not bypass blocked command");
+        assert!(
+            !result.valid,
+            "Multiple spaces should not bypass blocked command"
+        );
     }
 
     #[test]
@@ -750,13 +755,22 @@ mod tests {
 
         // Quoted commands should not bypass validation
         let result = validator.validate("'rm' -rf /");
-        assert!(!result.valid, "Single quotes should not bypass blocked command");
+        assert!(
+            !result.valid,
+            "Single quotes should not bypass blocked command"
+        );
 
         let result = validator.validate("\"rm\" -rf /");
-        assert!(!result.valid, "Double quotes should not bypass blocked command");
+        assert!(
+            !result.valid,
+            "Double quotes should not bypass blocked command"
+        );
 
         let result = validator.validate("'rm' '-rf' '/'");
-        assert!(!result.valid, "Fully quoted command should not bypass blocked command");
+        assert!(
+            !result.valid,
+            "Fully quoted command should not bypass blocked command"
+        );
     }
 
     #[test]
@@ -765,13 +779,19 @@ mod tests {
 
         // Path variants should not bypass validation
         let result = validator.validate("/bin/rm -rf /");
-        assert!(!result.valid, "Absolute path should not bypass blocked command");
+        assert!(
+            !result.valid,
+            "Absolute path should not bypass blocked command"
+        );
 
         let result = validator.validate("/usr/bin/rm -rf /");
         assert!(!result.valid, "Full path should not bypass blocked command");
 
         let result = validator.validate("./rm -rf /");
-        assert!(!result.valid, "Relative path should not bypass blocked command");
+        assert!(
+            !result.valid,
+            "Relative path should not bypass blocked command"
+        );
     }
 
     #[test]
@@ -780,10 +800,16 @@ mod tests {
 
         // Combined bypass attempts
         let result = validator.validate("'/bin/rm'  -rf  /");
-        assert!(!result.valid, "Combined path and whitespace should not bypass");
+        assert!(
+            !result.valid,
+            "Combined path and whitespace should not bypass"
+        );
 
         let result = validator.validate("\"/usr/bin/rm\"   '-rf'   '/'");
-        assert!(!result.valid, "Combined quotes, path, and whitespace should not bypass");
+        assert!(
+            !result.valid,
+            "Combined quotes, path, and whitespace should not bypass"
+        );
     }
 
     #[test]

--- a/src/cortex-engine/src/validation.rs
+++ b/src/cortex-engine/src/validation.rs
@@ -269,6 +269,34 @@ pub struct CommandValidator {
     pub allow_shell_operators: bool,
 }
 
+/// Normalize a command string for consistent validation.
+///
+/// This function handles bypass attempts such as:
+/// - Extra whitespace: "rm  -rf" → "rm -rf"
+/// - Quoted parts: "'rm' -rf" → "rm -rf"
+/// - Path variants: "/bin/rm -rf" → "rm -rf"
+fn normalize_command(cmd: &str) -> String {
+    cmd.split_whitespace()
+        .enumerate()
+        .map(|(idx, part)| {
+            // Remove surrounding quotes (single and double)
+            let unquoted = part
+                .trim_matches(|c| c == '\'' || c == '"');
+            
+            // For the first part (command), extract basename to handle path variants
+            if idx == 0 {
+                Path::new(unquoted)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(unquoted)
+            } else {
+                unquoted
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 impl CommandValidator {
     /// Create a new validator.
     pub fn new() -> Self {
@@ -332,9 +360,12 @@ impl CommandValidator {
             ));
         }
 
-        // Check allowed list
+        // Normalize the command for consistent validation
+        let normalized = normalize_command(command);
+
+        // Check allowed list using normalized command
         if let Some(ref allowed) = self.allowed {
-            let cmd = command.split_whitespace().next().unwrap_or("");
+            let cmd = normalized.split_whitespace().next().unwrap_or("");
             if !allowed.contains(cmd) {
                 result.add_error(ValidationError::new(
                     "command",
@@ -343,9 +374,10 @@ impl CommandValidator {
             }
         }
 
-        // Check blocked commands
+        // Check blocked commands against normalized form
         for blocked in &self.blocked {
-            if command.contains(blocked) {
+            let normalized_blocked = normalize_command(blocked);
+            if normalized.contains(&normalized_blocked) {
                 result.add_error(ValidationError::new(
                     "command",
                     "Command contains blocked pattern",
@@ -354,9 +386,9 @@ impl CommandValidator {
             }
         }
 
-        // Check blocked patterns
+        // Check blocked patterns against both original and normalized
         for pattern in &self.blocked_patterns {
-            if command.contains(pattern) {
+            if command.contains(pattern) || normalized.contains(pattern) {
                 result.add_error(ValidationError::new(
                     "command",
                     "Command contains dangerous pattern",
@@ -698,6 +730,70 @@ mod tests {
 
         let result = validator.validate("ls -la");
         assert!(result.valid);
+    }
+
+    #[test]
+    fn test_command_validation_whitespace_bypass() {
+        let validator = CommandValidator::new();
+
+        // Extra whitespace should not bypass validation
+        let result = validator.validate("rm  -rf  /");
+        assert!(!result.valid, "Extra whitespace should not bypass blocked command");
+
+        let result = validator.validate("rm   -rf   /");
+        assert!(!result.valid, "Multiple spaces should not bypass blocked command");
+    }
+
+    #[test]
+    fn test_command_validation_quote_bypass() {
+        let validator = CommandValidator::new();
+
+        // Quoted commands should not bypass validation
+        let result = validator.validate("'rm' -rf /");
+        assert!(!result.valid, "Single quotes should not bypass blocked command");
+
+        let result = validator.validate("\"rm\" -rf /");
+        assert!(!result.valid, "Double quotes should not bypass blocked command");
+
+        let result = validator.validate("'rm' '-rf' '/'");
+        assert!(!result.valid, "Fully quoted command should not bypass blocked command");
+    }
+
+    #[test]
+    fn test_command_validation_path_bypass() {
+        let validator = CommandValidator::new();
+
+        // Path variants should not bypass validation
+        let result = validator.validate("/bin/rm -rf /");
+        assert!(!result.valid, "Absolute path should not bypass blocked command");
+
+        let result = validator.validate("/usr/bin/rm -rf /");
+        assert!(!result.valid, "Full path should not bypass blocked command");
+
+        let result = validator.validate("./rm -rf /");
+        assert!(!result.valid, "Relative path should not bypass blocked command");
+    }
+
+    #[test]
+    fn test_command_validation_combined_bypass() {
+        let validator = CommandValidator::new();
+
+        // Combined bypass attempts
+        let result = validator.validate("'/bin/rm'  -rf  /");
+        assert!(!result.valid, "Combined path and whitespace should not bypass");
+
+        let result = validator.validate("\"/usr/bin/rm\"   '-rf'   '/'");
+        assert!(!result.valid, "Combined quotes, path, and whitespace should not bypass");
+    }
+
+    #[test]
+    fn test_normalize_command() {
+        // Test the normalize function directly
+        assert_eq!(normalize_command("rm -rf /"), "rm -rf /");
+        assert_eq!(normalize_command("rm  -rf  /"), "rm -rf /");
+        assert_eq!(normalize_command("'rm' -rf /"), "rm -rf /");
+        assert_eq!(normalize_command("/bin/rm -rf /"), "rm -rf /");
+        assert_eq!(normalize_command("'/usr/bin/rm' '-rf' '/'"), "rm -rf /");
     }
 
     #[test]

--- a/src/cortex-tui/src/session/storage.rs
+++ b/src/cortex-tui/src/session/storage.rs
@@ -120,12 +120,10 @@ impl SessionStorage {
 
         // Sync parent directory on Unix for crash safety (ensures directory entry is persisted)
         #[cfg(unix)]
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = File::open(parent)
         {
-            if let Some(parent) = path.parent() {
-                if let Ok(dir) = File::open(parent) {
-                    let _ = dir.sync_all();
-                }
-            }
+            let _ = dir.sync_all();
         }
 
         Ok(())
@@ -241,12 +239,10 @@ impl SessionStorage {
 
         // Sync parent directory on Unix for crash safety (ensures directory entry is persisted)
         #[cfg(unix)]
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = File::open(parent)
         {
-            if let Some(parent) = path.parent() {
-                if let Ok(dir) = File::open(parent) {
-                    let _ = dir.sync_all();
-                }
-            }
+            let _ = dir.sync_all();
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

This PR consolidates **6 memory and storage fixes** into a single, cohesive change.

### Included PRs:
- #44: Add cleanup for stale file locks to prevent memory leak
- #45: Add cache size limits to prevent unbounded memory growth
- #47: Add fsync after file writes to prevent data loss
- #50: Bound ToolResponseStore size and cleanup consumed entries
- #51: Eliminate TOCTOU races in MCP server and plugin registry
- #52: Improve path validation and tilde expansion

### Key Changes:
- Added periodic cleanup of stale file locks to prevent memory leaks
- Implemented LRU cache limits for config discovery and tokenizer caches
- Added `fsync` calls after critical file writes for data durability
- Created bounded `ToolResponseStore` with configurable limits and automatic cleanup
- Fixed time-of-check-time-of-use (TOCTOU) races in MCP server and plugin registry
- Improved path validation with secure tilde expansion

### Files Modified:
- `src/cortex-common/src/file_locking.rs`
- `src/cortex-resume/src/session_store.rs`
- `src/cortex-engine/src/config/config_discovery.rs`
- `src/cortex-engine/src/tokenizer.rs`
- `src/cortex-storage/src/sessions/storage.rs`
- `src/cortex-tui/src/session/storage.rs`
- `src/cortex-engine/src/tools/response_store.rs` (new)
- `src/cortex-cli/src/utils/paths.rs`
- `src/cortex-engine/src/validation.rs`
- `src/cortex-mcp-server/src/server.rs`
- `src/cortex-plugins/src/registry.rs`

Closes #44, #45, #47, #50, #51, #52