### PR TITLE
fix: consolidated security and robustness improvements

### DIFF
--- a/src/cortex-exec/src/runner.rs
+++ b/src/cortex-exec/src/runner.rs
@@ -192,7 +192,11 @@ impl ExecRunner {
             self.client = Some(client);
         }
 
-        Ok(self.client.as_ref().expect("Client should be initialized in init_client").as_ref())
+        Ok(self
+            .client
+            .as_ref()
+            .expect("Client should be initialized in init_client")
+            .as_ref())
     }
 
     /// Get filtered tool definitions based on options.

--- a/src/cortex-exec/src/runner.rs
+++ b/src/cortex-exec/src/runner.rs
@@ -32,6 +32,11 @@ const DEFAULT_TIMEOUT_SECS: u64 = 600;
 /// Default timeout for a single LLM request (2 minutes).
 const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 120;
 
+/// Per-chunk timeout during streaming responses.
+/// Prevents indefinite hangs when connections stall mid-stream.
+/// See cortex_common::http_client for timeout hierarchy documentation.
+const STREAMING_CHUNK_TIMEOUT_SECS: u64 = 30;
+
 /// Maximum retries for transient errors.
 const MAX_RETRIES: usize = 3;
 
@@ -187,7 +192,7 @@ impl ExecRunner {
             self.client = Some(client);
         }
 
-        Ok(self.client.as_ref().unwrap().as_ref())
+        Ok(self.client.as_ref().expect("Client should be initialized in init_client").as_ref())
     }
 
     /// Get filtered tool definitions based on options.
@@ -555,7 +560,28 @@ impl ExecRunner {
         let mut partial_tool_calls: std::collections::HashMap<String, (String, String)> =
             std::collections::HashMap::new();
 
-        while let Some(event) = stream.next().await {
+        loop {
+            // Apply per-chunk timeout to prevent indefinite hangs when connections stall
+            let event = match tokio::time::timeout(
+                Duration::from_secs(STREAMING_CHUNK_TIMEOUT_SECS),
+                stream.next(),
+            )
+            .await
+            {
+                Ok(Some(event)) => event,
+                Ok(None) => break, // Stream ended normally
+                Err(_) => {
+                    tracing::warn!(
+                        "Stream chunk timeout after {}s",
+                        STREAMING_CHUNK_TIMEOUT_SECS
+                    );
+                    return Err(CortexError::Provider(format!(
+                        "Streaming timeout: no response chunk received within {}s",
+                        STREAMING_CHUNK_TIMEOUT_SECS
+                    )));
+                }
+            };
+
             match event? {
                 ResponseEvent::Delta(delta) => {
                     if self.options.streaming {

--- a/src/cortex-tui/Cargo.toml
+++ b/src/cortex-tui/Cargo.toml
@@ -65,6 +65,7 @@ walkdir = { workspace = true }
 
 # External editor
 which = { workspace = true }
+tempfile = { workspace = true }
 
 # Audio notifications
 rodio = { workspace = true }


### PR DESCRIPTION
## Summary

This PR consolidates **4 security and robustness fixes** into a single, cohesive change.

### Included PRs:
- #74: Prevent shell injection in restore_script via path escaping
- #76: Replace unsafe unwrap() with expect() in init_client
- #78: Use secure random temp files in external editor to prevent symlink attacks
- #79: Add per-chunk streaming timeout to prevent indefinite hangs

### Key Changes:
- Added shell escaping for paths in shell-snapshot restore scripts to prevent injection
- Replaced `unwrap()` with `expect()` for better error context in exec runner
- Use secure random temp files instead of predictable names to prevent symlink attacks
- Added streaming chunk timeout to prevent indefinite hangs during LLM responses

### Files Modified:
- `src/cortex-shell-snapshot/src/snapshot.rs`
- `src/cortex-exec/src/runner.rs`
- `src/cortex-tui/Cargo.toml`
- `src/cortex-tui/src/external_editor.rs`

Closes #74, #76, #78, #79