### PR TITLE
refactor: replace unsafe unwrap() calls with expect() containing context

### DIFF
--- a/src/cortex-exec/src/runner.rs
+++ b/src/cortex-exec/src/runner.rs
@@ -187,7 +187,11 @@ impl ExecRunner {
             self.client = Some(client);
         }
 
-        Ok(self.client.as_ref().unwrap().as_ref())
+        Ok(self
+            .client
+            .as_ref()
+            .expect("ModelClient should be initialized before use")
+            .as_ref())
     }
 
     /// Get filtered tool definitions based on options.


### PR DESCRIPTION
Replaces PR #26 which had merge conflicts.

This PR replaces the unsafe `.unwrap()` call in `runner.rs` with `.expect()` containing context message for better debugging when the assertion fails.

Closes #26