### PR TITLE
fix: improve response timeout error message with user-friendly description

### DIFF
--- a/src/cortex-tui/src/runner/event_loop/streaming.rs
+++ b/src/cortex-tui/src/runner/event_loop/streaming.rs
@@ -285,7 +285,7 @@ impl EventLoop {
                     Err(_) => {
                         // Timeout
                         let _ = tx
-                            .send(StreamEvent::Error("Response timeout".to_string()))
+                            .send(StreamEvent::Error("The provider appears to be overloaded or your internet connection/proxy is experiencing issues communicating with it.".to_string()))
                             .await;
                         break;
                     }
@@ -833,7 +833,7 @@ impl EventLoop {
                     }
                     Err(_) => {
                         let _ = tx
-                            .send(StreamEvent::Error("Response timeout".to_string()))
+                            .send(StreamEvent::Error("The provider appears to be overloaded or your internet connection/proxy is experiencing issues communicating with it.".to_string()))
                             .await;
                         break;
                     }

--- a/src/cortex-tui/src/runner/event_loop/subagent.rs
+++ b/src/cortex-tui/src/runner/event_loop/subagent.rs
@@ -314,7 +314,7 @@ impl EventLoop {
                                 .send(ToolEvent::Failed {
                                     id: id.clone(),
                                     name: "Task".to_string(),
-                                    error: "Response timeout".to_string(),
+                                    error: "The provider appears to be overloaded or your internet connection/proxy is experiencing issues communicating with it.".to_string(),
                                     duration: started_at.elapsed(),
                                 })
                                 .await


### PR DESCRIPTION
## Summary

Improves the 'Response timeout' error message displayed during streaming communication failures. 

## Changes

Replace generic 'Response timeout' message with a more descriptive, user-friendly error message:

> The provider appears to be overloaded or your internet connection/proxy is experiencing issues communicating with it.

This helps users understand potential causes when they encounter timeout errors.

## Files Modified

- `src/cortex-tui/src/runner/event_loop/streaming.rs` (2 occurrences)
- `src/cortex-tui/src/runner/event_loop/subagent.rs` (1 occurrence)

## Testing

- [x] Code compiles without errors (`cargo check -p cortex-tui`)
- [x] All error messages updated consistently