### PR TITLE
feat: implement proper LLM request cancellation on ESC

### DIFF
--- a/src/cortex-tui/src/runner/event_loop/core.rs
+++ b/src/cortex-tui/src/runner/event_loop/core.rs
@@ -446,6 +446,9 @@ impl EventLoop {
                 task.abort();
             }
 
+            // Reset ESC timer after cancellation to prevent accidental quit
+            self.app_state.reset_esc();
+
             self.stream_controller.reset();
         }
     }

--- a/src/cortex-tui/src/runner/event_loop/input.rs
+++ b/src/cortex-tui/src/runner/event_loop/input.rs
@@ -401,11 +401,11 @@ impl EventLoop {
         // Priority 6: Double-tap ESC to quit when idle
         if self.app_state.handle_esc() {
             self.app_state.set_quit();
-            return Ok(());
+            Ok(())
         } else {
             self.app_state.toasts.info("Press ESC again to quit");
             self.render(terminal)?;
-            return Ok(());
+            Ok(())
         }
     }
 

--- a/src/cortex-tui/src/runner/event_loop/input.rs
+++ b/src/cortex-tui/src/runner/event_loop/input.rs
@@ -368,24 +368,45 @@ impl EventLoop {
             return Ok(());
         }
 
-        // Check if app is idle (nothing active that ESC should cancel)
-        let is_idle = !self.app_state.streaming.is_streaming
-            && self.app_state.pending_approval.is_none()
-            && !self.app_state.has_queued_messages()
-            && !self.app_state.autocomplete.visible;
-
-        if is_idle {
-            if self.app_state.handle_esc() {
-                self.app_state.set_quit();
-                return Ok(());
-            } else {
-                self.app_state.toasts.info("Press ESC again to quit");
-                self.render(terminal)?;
-                return Ok(());
-            }
+        // Priority 2: If streaming is active, cancel it
+        if self.app_state.streaming.is_streaming {
+            self.cancel_streaming();
+            self.render(terminal)?;
+            return Ok(());
         }
 
-        Ok(())
+        // Priority 3: If there are queued messages, cancel them
+        if self.app_state.has_queued_messages() {
+            let count = self.app_state.queued_count();
+            self.app_state.clear_message_queue();
+            self.add_system_message(&format!("Cancelled {} queued message(s)", count));
+            self.render(terminal)?;
+            return Ok(());
+        }
+
+        // Priority 4: If there's pending approval, reject it
+        if self.app_state.pending_approval.is_some() {
+            self.app_state.reject();
+            self.render(terminal)?;
+            return Ok(());
+        }
+
+        // Priority 5: If autocomplete is visible, hide it (already handled in handle_autocomplete_key)
+        if self.app_state.autocomplete.visible {
+            self.app_state.autocomplete.hide();
+            self.render(terminal)?;
+            return Ok(());
+        }
+
+        // Priority 6: Double-tap ESC to quit when idle
+        if self.app_state.handle_esc() {
+            self.app_state.set_quit();
+            return Ok(());
+        } else {
+            self.app_state.toasts.info("Press ESC again to quit");
+            self.render(terminal)?;
+            return Ok(());
+        }
     }
 
     /// Handle autocomplete navigation keys

--- a/src/cortex-tui/src/runner/event_loop/streaming.rs
+++ b/src/cortex-tui/src/runner/event_loop/streaming.rs
@@ -203,91 +203,93 @@ impl EventLoop {
             let mut reasoning = String::new();
             let mut tokens: Option<cortex_engine::streaming::StreamTokenUsage> = None;
 
-            // Process stream events
+            // Process stream events using tokio::select! for faster cancellation response
             loop {
-                // Check for cancellation
-                if cancelled.load(Ordering::SeqCst) {
-                    let _ = tx
-                        .send(StreamEvent::Error("Cancelled by user".to_string()))
-                        .await;
-                    break;
-                }
+                tokio::select! {
+                    // Check for cancellation with polling
+                    _ = async {
+                        while !cancelled.load(Ordering::SeqCst) {
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                        }
+                    } => {
+                        let _ = tx
+                            .send(StreamEvent::Error("Cancelled by user".to_string()))
+                            .await;
+                        break;
+                    }
 
-                // Wait for next event with timeout
-                let event = tokio::time::timeout(
-                    Duration::from_secs(30), // 30 second timeout between chunks
-                    stream.next(),
-                )
-                .await;
-
-                match event {
-                    Ok(Some(Ok(ResponseEvent::Delta(delta)))) => {
-                        content.push_str(&delta);
-                        if tx.send(StreamEvent::Delta(delta)).await.is_err() {
-                            break; // Receiver dropped
+                    // Wait for next event with timeout
+                    event = tokio::time::timeout(Duration::from_secs(30), stream.next()) => {
+                        match event {
+                            Ok(Some(Ok(ResponseEvent::Delta(delta)))) => {
+                                content.push_str(&delta);
+                                if tx.send(StreamEvent::Delta(delta)).await.is_err() {
+                                    break; // Receiver dropped
+                                }
+                            }
+                            Ok(Some(Ok(ResponseEvent::Reasoning(r)))) => {
+                                reasoning.push_str(&r);
+                                if tx.send(StreamEvent::Reasoning(r)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Ok(Some(Ok(ResponseEvent::Done(response)))) => {
+                                tokens = Some(cortex_engine::streaming::StreamTokenUsage::from(
+                                    response.usage,
+                                ));
+                                let _ = tx
+                                    .send(StreamEvent::Done {
+                                        content,
+                                        reasoning,
+                                        tokens,
+                                    })
+                                    .await;
+                                break;
+                            }
+                            Ok(Some(Ok(ResponseEvent::Error(e)))) => {
+                                let _ = tx.send(StreamEvent::Error(e)).await;
+                                break;
+                            }
+                            Ok(Some(Ok(ResponseEvent::ToolCall(tool_call)))) => {
+                                // Parse arguments from JSON string
+                                let arguments = serde_json::from_str(&tool_call.arguments)
+                                    .unwrap_or_else(|_| serde_json::json!({"raw": tool_call.arguments}));
+                                // Send tool call to main event loop for processing
+                                if tx
+                                    .send(StreamEvent::ToolCall {
+                                        id: tool_call.id.clone(),
+                                        name: tool_call.name.clone(),
+                                        arguments,
+                                    })
+                                    .await
+                                    .is_err()
+                                {
+                                    break; // Receiver dropped
+                                }
+                            }
+                            Ok(Some(Err(e))) => {
+                                let _ = tx.send(StreamEvent::Error(e.to_string())).await;
+                                break;
+                            }
+                            Ok(None) => {
+                                // Stream ended without Done event
+                                let _ = tx
+                                    .send(StreamEvent::Done {
+                                        content,
+                                        reasoning,
+                                        tokens,
+                                    })
+                                    .await;
+                                break;
+                            }
+                            Err(_) => {
+                                // Timeout
+                                let _ = tx
+                                    .send(StreamEvent::Error("Response timeout".to_string()))
+                                    .await;
+                                break;
+                            }
                         }
-                    }
-                    Ok(Some(Ok(ResponseEvent::Reasoning(r)))) => {
-                        reasoning.push_str(&r);
-                        if tx.send(StreamEvent::Reasoning(r)).await.is_err() {
-                            break;
-                        }
-                    }
-                    Ok(Some(Ok(ResponseEvent::Done(response)))) => {
-                        tokens = Some(cortex_engine::streaming::StreamTokenUsage::from(
-                            response.usage,
-                        ));
-                        let _ = tx
-                            .send(StreamEvent::Done {
-                                content,
-                                reasoning,
-                                tokens,
-                            })
-                            .await;
-                        break;
-                    }
-                    Ok(Some(Ok(ResponseEvent::Error(e)))) => {
-                        let _ = tx.send(StreamEvent::Error(e)).await;
-                        break;
-                    }
-                    Ok(Some(Ok(ResponseEvent::ToolCall(tool_call)))) => {
-                        // Parse arguments from JSON string
-                        let arguments = serde_json::from_str(&tool_call.arguments)
-                            .unwrap_or_else(|_| serde_json::json!({"raw": tool_call.arguments}));
-                        // Send tool call to main event loop for processing
-                        if tx
-                            .send(StreamEvent::ToolCall {
-                                id: tool_call.id.clone(),
-                                name: tool_call.name.clone(),
-                                arguments,
-                            })
-                            .await
-                            .is_err()
-                        {
-                            break; // Receiver dropped
-                        }
-                    }
-                    Ok(Some(Err(e))) => {
-                        let _ = tx.send(StreamEvent::Error(e.to_string())).await;
-                        break;
-                    }
-                    Ok(None) => {
-                        // Stream ended without Done event
-                        let _ = tx
-                            .send(StreamEvent::Done {
-                                content,
-                                reasoning,
-                                tokens,
-                            })
-                            .await;
-                        break;
-                    }
-                    Err(_) => {
-                        // Timeout
-                        let _ = tx
-                            .send(StreamEvent::Error("Response timeout".to_string()))
-                            .await;
-                        break;
                     }
                 }
             }
@@ -762,80 +764,89 @@ impl EventLoop {
             let mut reasoning = String::new();
             let mut tokens: Option<cortex_engine::streaming::StreamTokenUsage> = None;
 
+            // Process stream events using tokio::select! for faster cancellation response
             loop {
-                if cancelled.load(Ordering::SeqCst) {
-                    let _ = tx
-                        .send(StreamEvent::Error("Cancelled by user".to_string()))
-                        .await;
-                    break;
-                }
+                tokio::select! {
+                    // Check for cancellation with polling
+                    _ = async {
+                        while !cancelled.load(Ordering::SeqCst) {
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                        }
+                    } => {
+                        let _ = tx
+                            .send(StreamEvent::Error("Cancelled by user".to_string()))
+                            .await;
+                        break;
+                    }
 
-                let event = tokio::time::timeout(Duration::from_secs(30), stream.next()).await;
-
-                match event {
-                    Ok(Some(Ok(ResponseEvent::Delta(delta)))) => {
-                        content.push_str(&delta);
-                        if tx.send(StreamEvent::Delta(delta)).await.is_err() {
-                            break;
+                    // Wait for next event with timeout
+                    event = tokio::time::timeout(Duration::from_secs(30), stream.next()) => {
+                        match event {
+                            Ok(Some(Ok(ResponseEvent::Delta(delta)))) => {
+                                content.push_str(&delta);
+                                if tx.send(StreamEvent::Delta(delta)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Ok(Some(Ok(ResponseEvent::Reasoning(r)))) => {
+                                reasoning.push_str(&r);
+                                if tx.send(StreamEvent::Reasoning(r)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Ok(Some(Ok(ResponseEvent::Done(response)))) => {
+                                tokens = Some(cortex_engine::streaming::StreamTokenUsage::from(
+                                    response.usage,
+                                ));
+                                let _ = tx
+                                    .send(StreamEvent::Done {
+                                        content,
+                                        reasoning,
+                                        tokens,
+                                    })
+                                    .await;
+                                break;
+                            }
+                            Ok(Some(Ok(ResponseEvent::Error(e)))) => {
+                                let _ = tx.send(StreamEvent::Error(e)).await;
+                                break;
+                            }
+                            Ok(Some(Ok(ResponseEvent::ToolCall(tool_call)))) => {
+                                let arguments = serde_json::from_str(&tool_call.arguments)
+                                    .unwrap_or_else(|_| serde_json::json!({"raw": tool_call.arguments}));
+                                if tx
+                                    .send(StreamEvent::ToolCall {
+                                        id: tool_call.id.clone(),
+                                        name: tool_call.name.clone(),
+                                        arguments,
+                                    })
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Ok(Some(Err(e))) => {
+                                let _ = tx.send(StreamEvent::Error(e.to_string())).await;
+                                break;
+                            }
+                            Ok(None) => {
+                                let _ = tx
+                                    .send(StreamEvent::Done {
+                                        content,
+                                        reasoning,
+                                        tokens,
+                                    })
+                                    .await;
+                                break;
+                            }
+                            Err(_) => {
+                                let _ = tx
+                                    .send(StreamEvent::Error("Response timeout".to_string()))
+                                    .await;
+                                break;
+                            }
                         }
-                    }
-                    Ok(Some(Ok(ResponseEvent::Reasoning(r)))) => {
-                        reasoning.push_str(&r);
-                        if tx.send(StreamEvent::Reasoning(r)).await.is_err() {
-                            break;
-                        }
-                    }
-                    Ok(Some(Ok(ResponseEvent::Done(response)))) => {
-                        tokens = Some(cortex_engine::streaming::StreamTokenUsage::from(
-                            response.usage,
-                        ));
-                        let _ = tx
-                            .send(StreamEvent::Done {
-                                content,
-                                reasoning,
-                                tokens,
-                            })
-                            .await;
-                        break;
-                    }
-                    Ok(Some(Ok(ResponseEvent::Error(e)))) => {
-                        let _ = tx.send(StreamEvent::Error(e)).await;
-                        break;
-                    }
-                    Ok(Some(Ok(ResponseEvent::ToolCall(tool_call)))) => {
-                        let arguments = serde_json::from_str(&tool_call.arguments)
-                            .unwrap_or_else(|_| serde_json::json!({"raw": tool_call.arguments}));
-                        if tx
-                            .send(StreamEvent::ToolCall {
-                                id: tool_call.id.clone(),
-                                name: tool_call.name.clone(),
-                                arguments,
-                            })
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    Ok(Some(Err(e))) => {
-                        let _ = tx.send(StreamEvent::Error(e.to_string())).await;
-                        break;
-                    }
-                    Ok(None) => {
-                        let _ = tx
-                            .send(StreamEvent::Done {
-                                content,
-                                reasoning,
-                                tokens,
-                            })
-                            .await;
-                        break;
-                    }
-                    Err(_) => {
-                        let _ = tx
-                            .send(StreamEvent::Error("Response timeout".to_string()))
-                            .await;
-                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
This PR improves the LLM request cancellation functionality when the Escape key is pressed during agent inference.

## Changes

### 1. ESC key handling in `input.rs`
- Added streaming cancellation as **Priority 2** in `handle_esc()` (after subagent view handling)
- Added priority handling for queued messages, pending approvals, and autocomplete visibility
- Ensures pressing ESC during streaming immediately cancels the operation

### 2. Cancellation cleanup in `core.rs`  
- Added `reset_esc()` call after cancellation to prevent accidental quit after cancelling streaming

### 3. Faster cancellation response in `streaming.rs`
- Replaced sequential cancellation check + stream polling with `tokio::select!` pattern
- Cancellation is now checked every 50ms concurrently with stream processing
- Applied to both `handle_submit_with_provider()` and `send_tool_results_to_llm()`

## Behavior After Fix
1. User presses ESC during LLM inference → Streaming stops immediately
2. System message "Streaming cancelled." appears
3. HTTP connection is aborted (no orphaned connections)
4. UI properly reflects cancelled state
5. User can start a new conversation turn

## Testing
- `cargo check -p cortex-tui` passes with no errors
- No additional warnings introduced

## Priority Order for ESC Key
1. Return from subagent view
2. **Cancel streaming** (NEW)
3. Cancel queued messages
4. Reject pending approval
5. Hide autocomplete
6. Double-tap to quit