### PR TITLE
fix: reset 'Working x seconds' timer when new prompt is submitted

### DIFF
--- a/src/cortex-tui/src/app/state.rs
+++ b/src/cortex-tui/src/app/state.rs
@@ -465,7 +465,7 @@ impl AppState {
     /// # Arguments
     /// * `tool` - Optional tool name being executed
     /// * `reset_timer` - If true, resets the prompt elapsed timer (use for new user prompts).
-    ///                   If false, preserves existing timer (use for tool continuations).
+    ///   If false, preserves existing timer (use for tool continuations).
     pub fn start_streaming(&mut self, tool: Option<String>, reset_timer: bool) {
         self.streaming.start(tool, reset_timer);
         // Use typewriter only if streaming animation is enabled

--- a/src/cortex-tui/src/app/state.rs
+++ b/src/cortex-tui/src/app/state.rs
@@ -460,9 +460,14 @@ impl AppState {
 // ============================================================================
 
 impl AppState {
-    /// Start streaming a response
-    pub fn start_streaming(&mut self, tool: Option<String>) {
-        self.streaming.start(tool);
+    /// Start streaming a response.
+    ///
+    /// # Arguments
+    /// * `tool` - Optional tool name being executed
+    /// * `reset_timer` - If true, resets the prompt elapsed timer (use for new user prompts).
+    ///                   If false, preserves existing timer (use for tool continuations).
+    pub fn start_streaming(&mut self, tool: Option<String>, reset_timer: bool) {
+        self.streaming.start(tool, reset_timer);
         // Use typewriter only if streaming animation is enabled
         if self.streaming_enabled {
             self.typewriter = Some(Typewriter::dynamic(String::new(), 500.0));

--- a/src/cortex-tui/src/app/streaming.rs
+++ b/src/cortex-tui/src/app/streaming.rs
@@ -26,7 +26,7 @@ impl StreamingState {
     /// # Arguments
     /// * `tool` - Optional tool name being executed
     /// * `reset_timer` - If true, resets `prompt_started_at` to now (use for new user prompts).
-    ///                   If false, preserves existing timer (use for tool continuations).
+    ///   If false, preserves existing timer (use for tool continuations).
     pub fn start(&mut self, tool: Option<String>, reset_timer: bool) {
         self.is_streaming = true;
         self.thinking = true;

--- a/src/cortex-tui/src/app/streaming.rs
+++ b/src/cortex-tui/src/app/streaming.rs
@@ -21,13 +21,20 @@ pub struct StreamingState {
 }
 
 impl StreamingState {
-    pub fn start(&mut self, tool: Option<String>) {
+    /// Start streaming with option to reset the prompt timer.
+    ///
+    /// # Arguments
+    /// * `tool` - Optional tool name being executed
+    /// * `reset_timer` - If true, resets `prompt_started_at` to now (use for new user prompts).
+    ///                   If false, preserves existing timer (use for tool continuations).
+    pub fn start(&mut self, tool: Option<String>, reset_timer: bool) {
         self.is_streaming = true;
         self.thinking = true;
         self.current_tool = tool;
         self.task_started_at = Some(Instant::now());
-        // Only set prompt_started_at if not already set (first call in a turn)
-        if self.prompt_started_at.is_none() {
+        // Reset prompt timer only when explicitly requested (new user prompt)
+        // or when not yet set (first call)
+        if reset_timer || self.prompt_started_at.is_none() {
             self.prompt_started_at = Some(Instant::now());
         }
     }

--- a/src/cortex-tui/src/runner/event_loop/input.rs
+++ b/src/cortex-tui/src/runner/event_loop/input.rs
@@ -596,7 +596,9 @@ impl EventLoop {
         match event {
             AppEvent::StreamingStarted => {
                 self.stream_controller.start_processing();
-                self.app_state.start_streaming(None);
+                // Don't reset timer here - this is triggered by backend TaskStarted event
+                // which could be either a new prompt or a continuation
+                self.app_state.start_streaming(None, false);
             }
 
             AppEvent::StreamingChunk(chunk) => {

--- a/src/cortex-tui/src/runner/event_loop/streaming.rs
+++ b/src/cortex-tui/src/runner/event_loop/streaming.rs
@@ -111,7 +111,7 @@ impl EventLoop {
 
         // Start streaming UI state
         self.stream_controller.start_processing();
-        self.app_state.start_streaming(None);
+        self.app_state.start_streaming(None, true); // Reset timer for new user prompt
 
         // Reset cancellation flag and stream_done flag for new request
         self.streaming_cancelled.store(false, Ordering::SeqCst);
@@ -688,7 +688,7 @@ impl EventLoop {
 
         // Start streaming UI state
         self.stream_controller.start_processing();
-        self.app_state.start_streaming(None);
+        self.app_state.start_streaming(None, false); // Don't reset timer for tool continuation
 
         // Reset cancellation flag and stream_done flag
         self.streaming_cancelled.store(false, Ordering::SeqCst);

--- a/src/cortex-tui/src/runner/handlers/input.rs
+++ b/src/cortex-tui/src/runner/handlers/input.rs
@@ -34,7 +34,7 @@ impl<'a> ActionHandler<'a> {
         // Send to backend
         if let Some(session) = self.session {
             session.send_message(text).await?;
-            self.state.start_streaming(None);
+            self.state.start_streaming(None, true); // Reset timer for new user prompt
             self.stream.start_processing();
         }
 


### PR DESCRIPTION
## Summary

Fixes the issue where the 'Working x seconds' timer was not resetting to 0 when a user sent a new prompt.

## Problem

Previously, the timer would not reset if a previous conversation turn didn't properly call `full_reset()`. This resulted in the timer continuing from where it left off instead of starting fresh.

## Solution

Added a `reset_timer` parameter to `StreamingState::start()` that allows callers to explicitly control whether the prompt timer should be reset:

- **New user prompts** (`handle_submit_with_provider`, `handle_submit`) now reset the timer by passing `reset_timer=true`
- **Tool continuations** (`send_tool_results_to_llm`) preserve the timer by passing `reset_timer=false`

## Testing

- Verified with `cargo check -p cortex-tui` - compiles successfully

## Files Changed

- `src/cortex-tui/src/app/streaming.rs` - Updated `start()` method signature with `reset_timer` parameter
- `src/cortex-tui/src/app/state.rs` - Updated `start_streaming()` to pass through `reset_timer`
- `src/cortex-tui/src/runner/handlers/input.rs` - Pass `reset_timer=true` for new user prompts
- `src/cortex-tui/src/runner/event_loop/streaming.rs` - Pass `reset_timer=true` for new prompts, `false` for continuations
- `src/cortex-tui/src/runner/event_loop/input.rs` - Pass `reset_timer=false` for backend events (legacy handler)