### PR TITLE
fix: implement proper unicode-aware word wrapping for text overflow

### DIFF
--- a/src/cortex-core/src/markdown/renderer/state.rs
+++ b/src/cortex-core/src/markdown/renderer/state.rs
@@ -87,6 +87,8 @@ pub(super) struct RenderState<'a> {
     pub(super) in_paragraph: bool,
     /// Whether we need a blank line before the next block.
     pub(super) needs_newline: bool,
+    /// Current line width for paragraph wrapping (visual columns).
+    pub(super) current_line_width: usize,
 
     // Heading state
     /// Current heading level (if in a heading).
@@ -121,6 +123,7 @@ impl<'a> RenderState<'a> {
             current_cell: String::new(),
             in_paragraph: false,
             needs_newline: false,
+            current_line_width: 0,
             current_heading_level: None,
             current_link_url: None,
             current_list_item: Vec::new(),

--- a/src/cortex-tui/src/views/minimal_session/text_utils.rs
+++ b/src/cortex-tui/src/views/minimal_session/text_utils.rs
@@ -1,9 +1,12 @@
 //! Text utility functions for minimal session view.
 
-/// Wraps text to fit within a maximum width.
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Wraps text to fit within a maximum width (measured in visual columns).
 ///
 /// This function performs word wrapping, breaking lines at word boundaries
 /// when possible. Very long words that exceed the width are broken mid-word.
+/// Uses unicode-width for proper handling of CJK characters and emoji.
 pub fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
     if max_width == 0 {
         return vec![text.to_string()];
@@ -18,7 +21,8 @@ pub fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
         }
 
         // Check if line fits as-is (fast path)
-        if line.chars().count() <= max_width {
+        let line_width = UnicodeWidthStr::width(line);
+        if line_width <= max_width {
             result.push(line.to_string());
             continue;
         }
@@ -28,7 +32,7 @@ pub fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
         let mut current_width = 0;
 
         for word in line.split_whitespace() {
-            let word_width = word.chars().count();
+            let word_width = UnicodeWidthStr::width(word);
 
             if current_line.is_empty() {
                 // First word on line
@@ -36,17 +40,11 @@ pub fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
                     current_line = word.to_string();
                     current_width = word_width;
                 } else {
-                    // Word is too long - break it
-                    let mut chars = word.chars().peekable();
-                    while chars.peek().is_some() {
-                        let chunk: String = chars.by_ref().take(max_width).collect();
-                        if !chunk.is_empty() {
-                            result.push(chunk);
-                        }
-                    }
+                    // Word is too long - break it by visual width
+                    split_long_word_into_lines(word, max_width, &mut result);
                 }
             } else if current_width + 1 + word_width <= max_width {
-                // Word fits on current line
+                // Word fits on current line (1 for space)
                 current_line.push(' ');
                 current_line.push_str(word);
                 current_width += 1 + word_width;
@@ -58,20 +56,13 @@ pub fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
                     current_line = word.to_string();
                     current_width = word_width;
                 } else {
-                    // Word is too long - break it
+                    // Word is too long - break it by visual width
                     current_line = String::new();
                     current_width = 0;
-                    let mut chars = word.chars().peekable();
-                    while chars.peek().is_some() {
-                        let chunk: String = chars.by_ref().take(max_width).collect();
-                        let chunk_len = chunk.chars().count();
-                        if chunk_len == max_width {
-                            result.push(chunk);
-                        } else {
-                            // Last chunk - keep for next word
-                            current_line = chunk;
-                            current_width = chunk_len;
-                        }
+                    let last_chunk = split_long_word_returning_last(word, max_width, &mut result);
+                    if let Some((chunk, width)) = last_chunk {
+                        current_line = chunk;
+                        current_width = width;
                     }
                 }
             }
@@ -88,4 +79,64 @@ pub fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
     }
 
     result
+}
+
+/// Splits a long word into lines by visual width, pushing all lines to result.
+fn split_long_word_into_lines(word: &str, max_width: usize, result: &mut Vec<String>) {
+    let mut current_chunk = String::new();
+    let mut current_width = 0;
+
+    for ch in word.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+
+        if current_width + ch_width > max_width && !current_chunk.is_empty() {
+            result.push(current_chunk);
+            current_chunk = String::new();
+            current_width = 0;
+        }
+
+        current_chunk.push(ch);
+        current_width += ch_width;
+    }
+
+    if !current_chunk.is_empty() {
+        result.push(current_chunk);
+    }
+}
+
+/// Splits a long word into lines by visual width, returning the last partial chunk.
+/// Returns Some((last_chunk, width)) if there's a partial chunk, None otherwise.
+fn split_long_word_returning_last(
+    word: &str,
+    max_width: usize,
+    result: &mut Vec<String>,
+) -> Option<(String, usize)> {
+    let mut current_chunk = String::new();
+    let mut current_width = 0;
+
+    for ch in word.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+
+        if current_width + ch_width > max_width && !current_chunk.is_empty() {
+            result.push(current_chunk);
+            current_chunk = String::new();
+            current_width = 0;
+        }
+
+        current_chunk.push(ch);
+        current_width += ch_width;
+    }
+
+    if !current_chunk.is_empty() {
+        // Return the last chunk instead of pushing it
+        if current_width == max_width {
+            // If it's exactly max_width, push it and return None
+            result.push(current_chunk);
+            None
+        } else {
+            Some((current_chunk, current_width))
+        }
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
## Summary

Fixes text overflow issue where streaming text or conversation text sometimes extends beyond terminal borders.

## Root Causes Fixed

### 1. Assistant messages (markdown-rendered)
The `MarkdownRenderer` in `cortex-core/src/markdown/renderer` did not implement word wrapping for paragraph text. The `width` parameter was only used for code blocks and tables, not for regular text paragraphs.

**Fix:** Added proper word wrapping in `handlers.rs`:
- New `wrap_paragraph_text()` method that wraps text at word boundaries
- New `wrap_long_word()` method for breaking oversized words
- Tracks `current_line_width` in state for accurate wrapping decisions
- Properly accounts for blockquote prefix width

### 2. User/System messages
The `wrap_text` function in `cortex-tui/src/views/minimal_session/text_utils.rs` used `chars().count()` for width calculation instead of Unicode-aware width (`UnicodeWidthStr`), causing incorrect wrapping for wide characters (CJK, emoji).

**Fix:** Replaced all `chars().count()` with `UnicodeWidthStr::width()`:
- Added `split_long_word_into_lines()` and `split_long_word_returning_last()` helpers
- Proper visual width calculation for all text

### 3. cortex-core wrapping utilities
Same issue in `cortex-core/src/widgets/chat/wrapping.rs`.

**Fix:** 
- Added `split_at_visual_width()` function for visual-width-aware splitting
- Updated all width calculations to use `UnicodeWidthStr::width()`
- Added tests for CJK character handling

## Changes

- `src/cortex-core/src/markdown/renderer/handlers.rs` - Added paragraph word wrapping
- `src/cortex-core/src/markdown/renderer/state.rs` - Added `current_line_width` field
- `src/cortex-core/src/widgets/chat/wrapping.rs` - Unicode-aware width calculations
- `src/cortex-tui/src/views/minimal_session/text_utils.rs` - Unicode-aware width calculations

## Testing

- All existing tests pass
- Added new tests for CJK character and visual width handling
- `cargo check -p cortex-core -p cortex-tui` passes
- `cargo test -p cortex-core --lib wrapping` - 8 tests pass

## Acceptance Criteria Met

- ✅ Assistant messages (markdown-rendered) properly wrap to terminal width
- ✅ User and System messages properly wrap with Unicode-aware width calculation  
- ✅ Wide characters (CJK, emoji) are measured correctly and don't cause overflow
- ✅ Streaming text respects terminal boundaries throughout the streaming process
- ✅ Code blocks and tables continue to work correctly (already have width handling)