### PR TITLE
fix(ci): add libasound2-dev dependency for Linux release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,12 +150,20 @@ jobs:
           shared-key: ${{ needs.prepare.outputs.cache_key }}
 
       # =========================================================================
+      # Linux dependencies (required for alsa-sys crate)
+      # =========================================================================
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev
+
+      # =========================================================================
       # Static musl build setup (for portable Linux binaries)
       # =========================================================================
       - name: Install musl toolchain (x86_64 static)
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
-          sudo apt-get update
           sudo apt-get install -y musl-tools musl-dev
           # Verify musl-gcc is available
           which musl-gcc
@@ -164,7 +172,6 @@ jobs:
       - name: Install musl toolchain (aarch64 static)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: |
-          sudo apt-get update
           # For cross-compiling to aarch64-musl, we need the cross toolchain
           sudo apt-get install -y musl-tools musl-dev gcc-aarch64-linux-gnu
           # Install aarch64-linux-musl-gcc cross compiler


### PR DESCRIPTION
## Summary

The release workflow was missing the `libasound2-dev` system dependency required by the `alsa-sys` Rust crate, causing all Linux release builds to fail.

## Changes

- Added a new step to install `libasound2-dev` for all Linux builds in the release workflow
- This affects all 4 Linux targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`
- Removed duplicate `apt-get update` calls from musl toolchain installation steps (now only run once)

## Root Cause

The CI workflow (`ci.yml`) had `libasound2-dev` in its Linux dependencies installation, but the release workflow (`release.yml`) did not. This caused the `alsa-sys` crate (used by audio functionality) to fail during compilation.

## Testing

After merging, the release workflow should successfully build all Linux targets.