### PR TITLE
fix(ci): disable audio feature for musl static builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,8 @@ jobs:
       - name: Build release binary (static musl x86_64)
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
-          cargo +nightly build --release --target ${{ matrix.target }} -p cortex-cli
+          # Build without audio feature (rodio/alsa) for musl - uses terminal bell fallback
+          cargo +nightly build --release --target ${{ matrix.target }} -p cortex-cli --no-default-features --features cortex-tui
         env:
           RUSTFLAGS: "-Zthreads=32 -C target-feature=+crt-static"
           CARGO_PROFILE_RELEASE_LTO: thin
@@ -257,7 +258,8 @@ jobs:
       - name: Build release binary (static musl aarch64)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: |
-          cargo +nightly build --release --target ${{ matrix.target }} -p cortex-cli
+          # Build without audio feature (rodio/alsa) for musl - uses terminal bell fallback
+          cargo +nightly build --release --target ${{ matrix.target }} -p cortex-cli --no-default-features --features cortex-tui
         env:
           RUSTFLAGS: "-Zthreads=32 -C target-feature=+crt-static"
           CARGO_PROFILE_RELEASE_LTO: thin

--- a/src/cortex-cli/Cargo.toml
+++ b/src/cortex-cli/Cargo.toml
@@ -17,9 +17,12 @@ path = "src/lib.rs"
 workspace = true
 
 [features]
-default = ["cortex-tui"]
+default = ["cortex-tui", "audio"]
 # Use the new Cortex TUI (120 FPS, Cortex theme)
 cortex-tui = ["dep:cortex-tui"]
+# Audio notifications - disabled on musl targets due to alsa-sys incompatibility
+# Falls back to terminal bell when disabled
+audio = ["cortex-tui?/audio"]
 
 [dependencies]
 cortex-engine = { workspace = true }

--- a/src/cortex-tui/Cargo.toml
+++ b/src/cortex-tui/Cargo.toml
@@ -7,6 +7,11 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[features]
+default = ["audio"]
+# Audio notifications - disabled on musl targets due to alsa-sys incompatibility
+audio = ["dep:rodio"]
+
 [dependencies]
 # Cortex TUI core (the TUI engine)
 cortex-core = { path = "../cortex-core" }
@@ -66,8 +71,8 @@ walkdir = { workspace = true }
 # External editor
 which = { workspace = true }
 
-# Audio notifications
-rodio = { workspace = true }
+# Audio notifications (optional - disabled on musl targets)
+rodio = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/cortex-tui/src/sound.rs
+++ b/src/cortex-tui/src/sound.rs
@@ -10,12 +10,12 @@
 //! On platforms without audio support (e.g., musl builds), falls back to
 //! terminal bell notifications.
 
-use std::io::Write;
 #[cfg(feature = "audio")]
 use std::io::Cursor;
+use std::io::Write;
+use std::sync::OnceLock;
 #[cfg(feature = "audio")]
 use std::sync::mpsc;
-use std::sync::OnceLock;
 #[cfg(feature = "audio")]
 use std::thread;
 

--- a/src/cortex-tui/src/sound.rs
+++ b/src/cortex-tui/src/sound.rs
@@ -6,10 +6,17 @@
 //! Audio playback is handled in a dedicated thread since rodio's OutputStream
 //! is not Send/Sync. We use a channel-based approach to send sound requests
 //! from any thread to the dedicated audio thread.
+//!
+//! On platforms without audio support (e.g., musl builds), falls back to
+//! terminal bell notifications.
 
-use std::io::{Cursor, Write};
-use std::sync::OnceLock;
+use std::io::Write;
+#[cfg(feature = "audio")]
+use std::io::Cursor;
+#[cfg(feature = "audio")]
 use std::sync::mpsc;
+use std::sync::OnceLock;
+#[cfg(feature = "audio")]
 use std::thread;
 
 /// Type of sound notification
@@ -23,16 +30,24 @@ pub enum SoundType {
 
 /// Channel sender for sound requests (Send + Sync)
 /// Using sync_channel with capacity of 16 to prevent unbounded growth
+#[cfg(feature = "audio")]
 static SOUND_SENDER: OnceLock<mpsc::SyncSender<SoundType>> = OnceLock::new();
 
+/// Track whether sound system has been initialized (for non-audio builds)
+#[cfg(not(feature = "audio"))]
+static SOUND_INITIALIZED: OnceLock<bool> = OnceLock::new();
+
 /// Embedded WAV data for response complete sound
+#[cfg(feature = "audio")]
 const COMPLETE_WAV: &[u8] = include_bytes!("sounds/complete.wav");
 /// Embedded WAV data for approval required sound
+#[cfg(feature = "audio")]
 const APPROVAL_WAV: &[u8] = include_bytes!("sounds/approval.wav");
 
 /// Initialize the global sound system.
 /// Spawns a dedicated audio thread that owns the OutputStream.
 /// Should be called once at application startup.
+#[cfg(feature = "audio")]
 pub fn init() {
     // Only initialize once
     if SOUND_SENDER.get().is_some() {
@@ -78,7 +93,17 @@ pub fn init() {
         .expect("Failed to spawn audio thread");
 }
 
+/// Initialize the global sound system (no-op for non-audio builds).
+/// Falls back to terminal bell for notifications.
+#[cfg(not(feature = "audio"))]
+pub fn init() {
+    // Mark as initialized so is_initialized() returns true
+    let _ = SOUND_INITIALIZED.set(true);
+    tracing::debug!("Audio support not available, using terminal bell fallback");
+}
+
 /// Internal function to play WAV data using a stream handle
+#[cfg(feature = "audio")]
 fn play_wav_internal(
     handle: &rodio::OutputStreamHandle,
     data: &'static [u8],
@@ -103,6 +128,7 @@ fn emit_terminal_bell() {
 /// If `enabled` is false or audio is unavailable, this function does nothing.
 /// Falls back to terminal bell if the sound system is not initialized.
 /// This function is non-blocking - sound plays in background thread.
+#[cfg(feature = "audio")]
 pub fn play(sound_type: SoundType, enabled: bool) {
     if !enabled {
         return;
@@ -121,6 +147,16 @@ pub fn play(sound_type: SoundType, enabled: bool) {
     }
 }
 
+/// Play a notification sound (non-audio build - uses terminal bell).
+#[cfg(not(feature = "audio"))]
+pub fn play(_sound_type: SoundType, enabled: bool) {
+    if !enabled {
+        return;
+    }
+    // No audio support, use terminal bell
+    emit_terminal_bell();
+}
+
 /// Play notification for response completion
 pub fn play_response_complete(enabled: bool) {
     play(SoundType::ResponseComplete, enabled);
@@ -133,8 +169,15 @@ pub fn play_approval_required(enabled: bool) {
 
 /// Check if the sound system has been initialized.
 /// Useful for testing and diagnostics.
+#[cfg(feature = "audio")]
 pub fn is_initialized() -> bool {
     SOUND_SENDER.get().is_some()
+}
+
+/// Check if the sound system has been initialized (non-audio build).
+#[cfg(not(feature = "audio"))]
+pub fn is_initialized() -> bool {
+    SOUND_INITIALIZED.get().is_some()
 }
 
 #[cfg(test)]
@@ -183,6 +226,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "audio")]
     fn test_embedded_wav_data_not_empty() {
         // Verify that the embedded WAV files are not empty
         assert!(!COMPLETE_WAV.is_empty(), "complete.wav should not be empty");
@@ -190,6 +234,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "audio")]
     fn test_embedded_wav_data_has_riff_header() {
         // WAV files should start with "RIFF" magic bytes
         assert!(


### PR DESCRIPTION
## Summary
The alsa-sys crate requires glibc-based ALSA libraries which are incompatible with musl static builds. This change makes the audio feature optional and disables it for musl targets.

## Changes
- Made `rodio` dependency optional in `cortex-tui` behind the `audio` feature
- Added conditional compilation for audio-related code in `sound.rs`
- Disabled audio feature for musl builds in release workflow
- Non-audio builds fall back to terminal bell notifications

## Testing
- `cargo check -p cortex-tui --no-default-features` ✅
- `cargo check -p cortex-tui --features audio` ✅
- `cargo check -p cortex-cli --no-default-features --features cortex-tui` ✅

## Impact
- Standard (glibc) Linux builds: Full audio support preserved
- musl static builds: Uses terminal bell fallback instead of audio

This allows portable static Linux binaries to be built without audio dependencies, fixing the Release CI failures for musl targets.