### PR TITLE
fix(ci): properly disable audio feature for musl builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,7 @@ cortex-app-server = { path = "src/cortex-app-server" }
 cortex-commands = { path = "src/cortex-commands" }
 cortex-storage = { path = "src/cortex-storage" }
 cortex-core = { path = "src/cortex-core" }
-cortex-tui = { path = "src/cortex-tui" }
+cortex-tui = { path = "src/cortex-tui", default-features = false }
 cortex-tui-capture = { path = "src/cortex-tui-capture" }
 cortex-tui-components = { path = "src/cortex-tui-components" }
 cortex-update = { path = "src/cortex-update" }


### PR DESCRIPTION
## Summary
The previous fix (PR #100) didn't fully disable the audio feature because the workspace dependency still had default-features enabled.

## Changes
This changes the workspace dependency for `cortex-tui` to have `default-features = false`, allowing `cortex-cli` to properly control which features are enabled via its own feature flags.

## Verification
```bash
# Without audio (no alsa-sys)
cargo tree -p cortex-cli --no-default-features --features cortex-tui -i alsa-sys
# error: package ID specification `alsa-sys` did not match any packages

# With audio (alsa-sys included)
cargo tree -p cortex-cli -i alsa-sys
# alsa-sys v0.3.1
# └── alsa v0.9.1
#     └── cpal v0.15.3
#         └── rodio v0.19.0
#             └── cortex-tui v0.0.7
#                 └── cortex-cli v0.0.7
```

## Impact
This fix allows the musl static builds to succeed by properly excluding `alsa-sys` when the audio feature is disabled.