### PR TITLE
feat(tui): display Execute tool command and streaming output

### DIFF
--- a/src/cortex-tui/src/app/methods.rs
+++ b/src/cortex-tui/src/app/methods.rs
@@ -326,6 +326,8 @@ impl AppState {
     /// Update tool call result
     pub fn update_tool_result(&mut self, id: &str, output: String, success: bool, summary: String) {
         if let Some(call) = self.tool_calls.iter_mut().find(|c| c.id == id) {
+            // Clear live output when tool completes (replaced by result summary)
+            call.clear_live_output();
             call.set_result(ToolResultDisplay {
                 output,
                 success,

--- a/src/cortex-tui/src/runner/event_loop/input.rs
+++ b/src/cortex-tui/src/runner/event_loop/input.rs
@@ -669,8 +669,14 @@ impl EventLoop {
                 self.app_state.streaming.current_tool = None;
             }
 
-            AppEvent::ToolProgress { name: _, status: _ } => {
-                // Tool progress updates are handled by stream controller
+            AppEvent::ToolProgress { name, status } => {
+                // Forward output to tool call's live_output buffer for real-time display
+                // Note: `name` here is actually the call_id from ExecCommandOutputDeltaEvent
+                for line in status.lines() {
+                    if !line.is_empty() {
+                        self.app_state.append_tool_output(&name, line.to_string());
+                    }
+                }
             }
 
             AppEvent::ToolApproved(_) | AppEvent::ToolRejected(_) => {


### PR DESCRIPTION
## Summary

This PR enhances the Execute tool display in the TUI to show:
1. **Command header**: The command being executed (e.g., '$ cargo build') is displayed as the tool call header
2. **Real-time streaming output**: Up to 3 lines of output are displayed below the command during execution
3. **Clean completion**: Live output is cleared when the command completes, replaced by the result summary

## Changes

### `src/cortex-tui/src/runner/event_loop/input.rs`
- Modified `AppEvent::ToolProgress` handler to forward output chunks to the tool call's `live_output` buffer
- The output is split by lines and non-empty lines are appended to the buffer

### `src/cortex-tui/src/app/methods.rs`
- Added call to `clear_live_output()` in `update_tool_result()` to clear streaming output when tool completes

### `src/cortex-tui/src/views/tool_call.rs`
- Enhanced `format_tool_summary()` to handle both string and array formats for command arguments
- Added tests for `live_output` buffer management (`append_output`, `clear_live_output`)
- Added test for array command format handling

## Testing

- All existing tests pass
- Added new tests:
  - `test_append_output_keeps_last_3_lines`: Verifies buffer keeps only last 3 lines
  - `test_clear_live_output`: Verifies buffer is properly cleared
  - `test_format_tool_summary_execute_array`: Verifies array command format handling

## Visual Example

Before:
```
● Execute $ cargo build
  ⎿ 35 lines of output
```

After:
```
● Execute $ cargo build
  │ Compiling cortex-core v0.0.7
  │ Compiling cortex-engine v0.0.7
  │ Compiling cortex-tui v0.0.7
  ⎿ 35 lines of output
```

The infrastructure for this feature (ToolCallDisplay.live_output, append_output(), rendering logic) already existed - this PR wires up the streaming output from command execution to the UI buffer.