### PR TITLE
fix(tui): prevent End hint showing when already at bottom

### DIFF
--- a/src/cortex-tui/src/app/state.rs
+++ b/src/cortex-tui/src/app/state.rs
@@ -518,7 +518,9 @@ impl AppState {
         } else {
             self.chat_scroll = self.chat_scroll.saturating_add(delta as usize);
         }
-        self.chat_scroll_pinned_bottom = false;
+        // Only unpin from bottom if we actually scrolled away from it
+        // When chat_scroll is 0, we're at the bottom, so keep pinned
+        self.chat_scroll_pinned_bottom = self.chat_scroll == 0;
         self.show_scrollbar();
     }
 


### PR DESCRIPTION
## Summary
Fixes the '↓ End' hint incorrectly appearing when the user is already at the bottom of the chat.

## Problem
The `scroll_chat` method was unconditionally setting `chat_scroll_pinned_bottom = false`, which caused the hint to incorrectly appear when:
- Scrolling down (mouse wheel or Page Down) while already at the bottom
- Pressing End key when already at the bottom

## Solution
Check if `chat_scroll` is 0 (at bottom) after the scroll operation and maintain `chat_scroll_pinned_bottom = true` in that case.

## Testing
- The '↓ End' hint should NOT appear when the user is already at the bottom of the chat
- Scrolling down when at the bottom should not show the hint
- The hint should still correctly appear when the user has scrolled up from the bottom