### PR TITLE
feat(tui): display main agent TodoWrite items above input field

### DIFF
--- a/src/cortex-tui/src/app/mod.rs
+++ b/src/cortex-tui/src/app/mod.rs
@@ -15,7 +15,7 @@ mod types;
 pub use approval::{ApprovalState, PendingToolResult};
 pub use autocomplete::{AutocompleteItem, AutocompleteState};
 pub use session::{ActiveModal, SessionSummary};
-pub use state::AppState;
+pub use state::{AppState, MainAgentTodoItem, MainAgentTodoStatus};
 pub use streaming::StreamingState;
 pub use subagent::{
     SubagentDisplayStatus, SubagentTaskDisplay, SubagentTodoItem, SubagentTodoStatus,

--- a/src/cortex-tui/src/app/state.rs
+++ b/src/cortex-tui/src/app/state.rs
@@ -22,6 +22,26 @@ use super::streaming::StreamingState;
 use super::subagent::SubagentTaskDisplay;
 use super::types::{AppView, FocusTarget, OperationMode};
 
+/// A todo item for the main agent's todo list display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MainAgentTodoItem {
+    /// Content/description of the todo.
+    pub content: String,
+    /// Status of this todo item.
+    pub status: MainAgentTodoStatus,
+}
+
+/// Status of a main agent todo item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MainAgentTodoStatus {
+    /// Not started yet.
+    Pending,
+    /// Currently being worked on.
+    InProgress,
+    /// Completed.
+    Completed,
+}
+
 /// Main application state
 pub struct AppState {
     pub view: AppView,
@@ -172,6 +192,8 @@ pub struct AppState {
     pub user_email: Option<String>,
     /// Organization name for welcome screen
     pub org_name: Option<String>,
+    /// Main agent's todo list items (from TodoWrite tool calls).
+    pub main_agent_todos: Vec<MainAgentTodoItem>,
 }
 
 impl AppState {
@@ -272,6 +294,7 @@ impl AppState {
             user_name: None,
             user_email: None,
             org_name: None,
+            main_agent_todos: Vec::new(),
         }
     }
 
@@ -675,5 +698,26 @@ impl AppState {
     /// Scroll the diff view
     pub fn scroll_diff(&mut self, delta: i32) {
         self.diff_scroll = (self.diff_scroll + delta).max(0);
+    }
+}
+
+// ============================================================================
+// APPSTATE METHODS - Main Agent Todos
+// ============================================================================
+
+impl AppState {
+    /// Update the main agent's todo list.
+    pub fn update_main_todos(&mut self, todos: Vec<MainAgentTodoItem>) {
+        self.main_agent_todos = todos;
+    }
+
+    /// Clear the main agent's todo list.
+    pub fn clear_main_todos(&mut self) {
+        self.main_agent_todos.clear();
+    }
+
+    /// Check if the main agent has any todos.
+    pub fn has_main_todos(&self) -> bool {
+        !self.main_agent_todos.is_empty()
     }
 }


### PR DESCRIPTION
## Summary

This PR implements a TodoWrite display feature for the main Cortex agent in the TUI. When the main agent uses the TodoWrite tool, the todo list is displayed above the input field, providing real-time visibility into the agent's planned tasks.

## Changes

### State Management (`src/cortex-tui/src/app/state.rs`)
- Added `MainAgentTodoItem` struct with `content` and `status` fields
- Added `MainAgentTodoStatus` enum (`Pending`, `InProgress`, `Completed`)
- Added `main_agent_todos: Vec<MainAgentTodoItem>` field to `AppState`
- Added methods: `update_main_todos()`, `clear_main_todos()`, `has_main_todos()`

### Tool Event Handling (`src/cortex-tui/src/runner/event_loop/tools.rs`)
- Intercepts TodoWrite tool calls in `spawn_tool_execution()` 
- Parses todos immediately (before execution) for real-time display
- Supports both numbered string format (`1. [status] content`) and array format

### Rendering (`src/cortex-tui/src/views/minimal_session/rendering.rs`)
- Added `render_main_agent_todos()` function
- Displays with "📋 Plan" header
- Status indicators: ○ pending, ● in_progress, ✓ completed
- Completed items show with strikethrough styling (`Modifier::CROSSED_OUT`)
- Status colors: pending=muted, in_progress=accent, completed=success

### View Integration (`src/cortex-tui/src/views/minimal_session/view.rs`)
- Integrated todo display in Widget render method
- Positioned above status indicator and input field
- Dynamic height calculation based on number of todos

## Visual Example

```
📋 Plan
  ⎿ ○ First task
    ● Second task (highlighted)
    ✓ ~~Third task~~ (strikethrough)
```

## Acceptance Criteria
- [x] TodoWrite items from the main agent are tracked in application state
- [x] A todo list is displayed above the input field when todos exist
- [x] Each todo item shows its status (pending, in_progress, completed)
- [x] Completed todo items are displayed with strikethrough styling
- [x] The display updates in real-time when TodoWrite tool is called
- [x] Empty state: no todo section shown when there are no todos

## Testing
- `cargo check -p cortex-tui` passes with no errors