### PR TITLE
feat(tui): dynamic status indicator for Execute vs Streaming states

### DIFF
--- a/src/cortex-tui/src/runner/event_loop/streaming.rs
+++ b/src/cortex-tui/src/runner/event_loop/streaming.rs
@@ -305,6 +305,8 @@ impl EventLoop {
         match event {
             StreamEvent::Delta(delta) => {
                 self.stream_controller.append_text(&delta);
+                // Mark that we are now actively receiving tokens (transition from Execute to Streaming..)
+                self.app_state.streaming.start_active_streaming();
                 // Track text for interleaved display
                 self.app_state.append_streaming_text(&delta);
                 // Keep scroll at bottom if pinned (user hasn't scrolled up)

--- a/src/cortex-tui/src/views/minimal_session/view.rs
+++ b/src/cortex-tui/src/views/minimal_session/view.rs
@@ -402,7 +402,12 @@ impl<'a> MinimalSessionView<'a> {
         } else if self.app_state.streaming.thinking && self.app_state.thinking_budget.is_some() {
             "Thinking".to_string()
         } else if self.app_state.streaming.is_streaming {
-            "Working".to_string()
+            // Differentiate between waiting for first token and actively streaming
+            if self.app_state.streaming.is_actively_streaming {
+                "Streaming..".to_string()
+            } else {
+                "Execute".to_string()
+            }
         } else {
             "Idle".to_string()
         }


### PR DESCRIPTION
## Summary

Add distinct status indicators for different streaming phases:
- **'Execute'** when request is pending (waiting for first token)
- **'Streaming..'** when actively receiving tokens from the LLM

## Motivation

Previously, both states showed 'Working' which didn't distinguish between waiting for a response and actively streaming one. This provides clearer feedback to users about the current state of their request.

## Changes

- Add `is_actively_streaming` field to `StreamingState`
- Update `status_header()` to show different text based on streaming phase  
- Mark `is_actively_streaming = true` when first delta arrives

## Testing

- [x] cargo check passes
- [x] cargo test passes
- [x] Manual verification of status changes