### PR TITLE
fix(site): design activity logs, hotkey search, agent history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4918,6 +4918,8 @@ name = "site-data"
 version = "0.1.0"
 dependencies = [
  "bundle",
+ "hex",
+ "keystore",
  "reqwest 0.12.28",
  "serde_json",
  "site-types",

--- a/crates/design-http/src/stats.rs
+++ b/crates/design-http/src/stats.rs
@@ -189,22 +189,29 @@ pub async fn get_miner(State(st): State<Arc<AppState>>, Path(hotkey): Path<Strin
         Err(e) => return json_err(StatusCode::INTERNAL_SERVER_ERROR, "store", &e.to_string()),
     };
     let used = st.store.quota_get(&hk, &day).await.unwrap_or(0);
-    let round_runs = st.store.runs_for_round(rid).await.unwrap_or_default();
+    // All recent generations for this miner (not only the current round) so
+    // public agent history can list every design run the harness produced.
     let hid: std::collections::HashSet<_> = harnesses.iter().map(|h| h.id.clone()).collect();
-    let runs: Vec<Value> = round_runs
+    let recent = st.store.list_runs(None, 200).await.unwrap_or_default();
+    let runs: Vec<Value> = recent
         .into_iter()
         .filter(|r| hid.contains(&r.harness_id))
         .map(|r| {
+            let (prompt_title, _) = prompt_fields(&r.prompt_id);
             json!({
                 "id": r.id,
                 "status": r.status.as_str(),
                 "prompt_id": r.prompt_id,
+                "prompt_title": prompt_title,
+                "round_id": r.round_id,
                 "harness_id": r.harness_id,
                 "terminal": r.status.is_terminal()
                     || r.status == RunStage::AwaitingAdmin
                     || r.status == RunStage::AwaitingAnnotation,
                 "error_detail": r.error_detail,
                 "artifact_digest": r.artifact_digest,
+                "created_at_ms": r.created_at_ms,
+                "updated_at_ms": r.updated_at_ms,
             })
         })
         .collect();
@@ -263,10 +270,17 @@ pub async fn run_status_json(store: &dyn DesignStore, id: &str) -> Result<Value,
     let pages = store.list_pages(id).await.unwrap_or_default();
     let events = store.run_events(id).await.unwrap_or_default();
     let (prompt_title, prompt) = prompt_fields(&r.prompt_id);
+    let miner_hotkey = store
+        .get_harness(&r.harness_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|h| h.miner_hotkey);
     Ok(json!({
         "id": r.id,
         "round_id": r.round_id,
         "harness_id": r.harness_id,
+        "miner_hotkey": miner_hotkey,
         "prompt_id": r.prompt_id,
         "prompt_title": prompt_title,
         "prompt": prompt,

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -10,13 +10,13 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::state::SiteState;
+use crate::upstream::{self, DESIGN, PRISM};
 use site_data::map::{
     activity_from_lives, design_arena_from_dashboard, design_leaderboard, design_submission,
     leaderboard_matches_query, list_arenas, prism_arena_from_live, prism_bpb_leaderboard,
     prism_submission, prism_telemetry, prism_window, submission_matches_query,
 };
-use crate::state::SiteState;
-use crate::upstream::{self, DESIGN, PRISM};
 use site_types::coding_arena;
 use site_types::page_slice;
 use site_types::{

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -12,8 +12,8 @@ use serde_json::{json, Value};
 
 use crate::map::{
     activity_from_lives, design_arena_from_dashboard, design_leaderboard, design_submission,
-    list_arenas, prism_arena_from_live, prism_bpb_leaderboard, prism_submission, prism_telemetry,
-    prism_window,
+    leaderboard_matches_query, list_arenas, prism_arena_from_live, prism_bpb_leaderboard,
+    prism_submission, prism_telemetry, prism_window, submission_matches_query,
 };
 use crate::state::SiteState;
 use crate::upstream::{self, DESIGN, PRISM};
@@ -57,6 +57,8 @@ struct PageQuery {
     #[serde(rename = "pageSize")]
     page_size: Option<u32>,
     status: Option<String>,
+    /// Hotkey / handle / prompt substring filter (SS58 or hex).
+    q: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -217,7 +219,7 @@ async fn get_landing(State(st): State<SiteState>) -> impl IntoResponse {
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
-    let activity = activity_from_lives(&design_runs, &prism_rows, 10);
+    let activity = activity_from_lives(design.as_ref(), &design_runs, &prism_rows, 10);
     Json(LandingSummary {
         stats,
         arenas,
@@ -267,7 +269,12 @@ fn empty_leaderboard_json(page: u32, page_size: u32) -> Value {
     })
 }
 
-async fn design_leaderboard_json(st: &SiteState, page: u32, page_size: u32) -> Value {
+async fn design_leaderboard_json(
+    st: &SiteState,
+    page: u32,
+    page_size: u32,
+    q: Option<&str>,
+) -> Value {
     let dash = fetch_design_dash(st).await;
     let round_id = dash
         .as_ref()
@@ -306,7 +313,10 @@ async fn design_leaderboard_json(st: &SiteState, page: u32, page_size: u32) -> V
         .and_then(|d| d.get("epoch"))
         .and_then(Value::as_u64)
         .unwrap_or(0);
-    let rows = design_leaderboard(&ratings, &previous, epoch);
+    let mut rows = design_leaderboard(&ratings, &previous, epoch);
+    if let Some(needle) = q.filter(|s| !s.trim().is_empty()) {
+        rows.retain(|r| leaderboard_matches_query(r, needle));
+    }
     let page_out = page_slice(&rows, page, page_size);
     let seconds_remaining = dash
         .as_ref()
@@ -331,7 +341,12 @@ async fn design_leaderboard_json(st: &SiteState, page: u32, page_size: u32) -> V
     })
 }
 
-async fn prism_leaderboard_json(st: &SiteState, page: u32, page_size: u32) -> Value {
+async fn prism_leaderboard_json(
+    st: &SiteState,
+    page: u32,
+    page_size: u32,
+    q: Option<&str>,
+) -> Value {
     let status = fetch_prism_status(st).await;
     let epoch = status
         .as_ref()
@@ -344,7 +359,10 @@ async fn prism_leaderboard_json(st: &SiteState, page: u32, page_size: u32) -> Va
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
-    let board = prism_bpb_leaderboard(&rows, epoch);
+    let mut board = prism_bpb_leaderboard(&rows, epoch);
+    if let Some(needle) = q.filter(|s| !s.trim().is_empty()) {
+        board.retain(|r| leaderboard_matches_query(r, needle));
+    }
     let page_out = page_slice(&board, page, page_size);
     json!({
         "items": page_out.items,
@@ -368,13 +386,14 @@ async fn get_leaderboard(
     };
     let page = q.page.unwrap_or(1);
     let page_size = q.page_size.unwrap_or(24);
+    let needle = q.q.as_deref();
     match slug {
         ArenaSlug::Coding => Json(empty_leaderboard_json(page, page_size)).into_response(),
         ArenaSlug::Design => {
-            Json(design_leaderboard_json(&st, page, page_size).await).into_response()
+            Json(design_leaderboard_json(&st, page, page_size, needle).await).into_response()
         }
         ArenaSlug::Prism => {
-            Json(prism_leaderboard_json(&st, page, page_size).await).into_response()
+            Json(prism_leaderboard_json(&st, page, page_size, needle).await).into_response()
         }
     }
 }
@@ -390,11 +409,14 @@ async fn get_submissions(
     let page = q.page.unwrap_or(1);
     let page_size = q.page_size.unwrap_or(24);
     let status_filter = q.status.as_deref();
+    let needle = q.q.as_deref();
     match slug {
         ArenaSlug::Coding => {
             Json(page_slice::<crate::Submission>(&[], page, page_size)).into_response()
         }
-        ArenaSlug::Design => design_submissions_page(&st, page, page_size, status_filter).await,
+        ArenaSlug::Design => {
+            design_submissions_page(&st, page, page_size, status_filter, needle).await
+        }
         ArenaSlug::Prism => {
             let raw = fetch_prism_subs(&st, 500).await;
             let rows = raw
@@ -412,6 +434,9 @@ async fn get_submissions(
                     _ => true,
                 });
             }
+            if let Some(n) = needle.filter(|s| !s.trim().is_empty()) {
+                items.retain(|s| submission_matches_query(s, n));
+            }
             Json(page_slice(&items, page, page_size)).into_response()
         }
     }
@@ -422,6 +447,7 @@ async fn design_submissions_page(
     page: u32,
     page_size: u32,
     status_filter: Option<&str>,
+    q: Option<&str>,
 ) -> Response {
     let dash = fetch_design_dash(st).await;
     let epoch = dash
@@ -479,6 +505,9 @@ async fn design_submissions_page(
             "failed" => s.status == crate::SubmissionStatus::Failed,
             _ => true,
         });
+    }
+    if let Some(n) = q.filter(|s| !s.trim().is_empty()) {
+        items.retain(|s| submission_matches_query(s, n));
     }
     Json(page_slice(&items, page, page_size)).into_response()
 }
@@ -596,7 +625,12 @@ async fn get_activity(
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
-    Json(activity_from_lives(&design_runs, &prism_rows, limit))
+    Json(activity_from_lives(
+        design.as_ref(),
+        &design_runs,
+        &prism_rows,
+        limit,
+    ))
 }
 
 async fn get_metrics(
@@ -900,9 +934,36 @@ mod tests {
         .await;
         assert_eq!(s, StatusCode::NOT_FOUND, "{v}");
 
-        let (s, v) = call(app, "/v1/site/arenas/coding/submissions").await;
+        let (s, v) = call(app.clone(), "/v1/site/arenas/coding/submissions").await;
         assert_eq!(s, StatusCode::OK);
         assert_eq!(v["total"], 0);
+
+        // Hotkey / prompt search (`?q=`) filters design submissions.
+        let expected_hk = keystore::ss58_encode(&[0xaa; 32], keystore::BITTENSOR_SS58_PREFIX);
+        let (s, v) = call(
+            app.clone(),
+            &format!("/v1/site/arenas/design/submissions?q={}", &expected_hk[..8]),
+        )
+        .await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v["total"], 1, "{v}");
+        let (s, v) = call(app.clone(), "/v1/site/arenas/design/submissions?q=nope-xyz").await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v["total"], 0, "{v}");
+
+        let (s, v) = call(app, "/v1/site/activity?limit=8").await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        let msgs: Vec<&str> = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|e| e.get("message").and_then(Value::as_str))
+            .collect();
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("Design evaluated") || m.contains("winner")),
+            "{msgs:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -10,7 +10,7 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use crate::map::{
+use site_data::map::{
     activity_from_lives, design_arena_from_dashboard, design_leaderboard, design_submission,
     leaderboard_matches_query, list_arenas, prism_arena_from_live, prism_bpb_leaderboard,
     prism_submission, prism_telemetry, prism_window, submission_matches_query,
@@ -79,7 +79,7 @@ fn now_iso() -> String {
     let ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(0));
-    crate::map::ms_to_iso(ms)
+    site_data::map::ms_to_iso(ms)
 }
 
 async fn fetch_design_dash(st: &SiteState) -> Option<Value> {
@@ -326,7 +326,7 @@ async fn design_leaderboard_json(
         .as_ref()
         .and_then(|d| d.pointer("/round/closes_at_secs"))
         .and_then(Value::as_u64)
-        .map(|s| crate::map::ms_to_iso(s.saturating_mul(1000)));
+        .map(|s| site_data::map::ms_to_iso(s.saturating_mul(1000)));
     json!({
         "items": page_out.items,
         "page": page_out.page,

--- a/crates/site-api/src/lib.rs
+++ b/crates/site-api/src/lib.rs
@@ -13,7 +13,6 @@
 #![allow(clippy::doc_markdown)]
 
 mod handlers;
-mod map;
 mod state;
 mod upstream;
 

--- a/crates/site-api/src/map.rs
+++ b/crates/site-api/src/map.rs
@@ -729,46 +729,153 @@ pub fn prism_window(
     }
 }
 
-/// Activity lines from design `recent_runs` + prism submissions (bounded).
+/// Short run / harness id for ops-style log lines.
+fn short_id(id: &str) -> &str {
+    &id[..id.len().min(8)]
+}
+
+/// Prompt label for activity copy — title when known, else short run id.
+fn design_prompt_label(run: &Value, id: &str) -> String {
+    run.get("prompt_title")
+        .and_then(Value::as_str)
+        .filter(|t| !t.is_empty())
+        .map_or_else(|| format!("run {}", short_id(id)), str::to_owned)
+}
+
+/// One natural-English design activity line from a dashboard `recent_run`.
+fn design_activity_line(run: &Value) -> Option<(u64, String, ActivityEvent)> {
+    let id = run.get("id").and_then(Value::as_str).unwrap_or("?");
+    let status = run.get("status").and_then(Value::as_str).unwrap_or("");
+    let ms = run
+        .get("updated_at_ms")
+        .and_then(Value::as_u64)
+        .or_else(|| run.get("created_at_ms").and_then(Value::as_u64))
+        .unwrap_or(0);
+    let title = design_prompt_label(run, id);
+    let rid = run.get("round_id").and_then(Value::as_u64);
+    let (sev, msg) = match status {
+        "scored" => (
+            ActivitySeverity::Score,
+            format!(
+                "Design evaluated for prompt «{title}» · run {}",
+                short_id(id)
+            ),
+        ),
+        "failed" => (
+            ActivitySeverity::Fail,
+            format!("Design run {} failed on «{title}»", short_id(id)),
+        ),
+        "rejected" => (
+            ActivitySeverity::Fail,
+            format!("Harness rejected for «{title}» · run {}", short_id(id)),
+        ),
+        "awaiting_admin" | "awaiting_annotation" => (
+            ActivitySeverity::Settle,
+            rid.map_or_else(
+                || format!("Candidate awaiting review · «{title}»"),
+                |r| format!("Round {r} candidate ready for review · «{title}»"),
+            ),
+        ),
+        "agentic_review" => (
+            ActivitySeverity::Assign,
+            format!("Anti-cheat review running on «{title}»"),
+        ),
+        "sanitizing" => (
+            ActivitySeverity::Prompt,
+            format!("Screenshot captured · sanitizing «{title}»"),
+        ),
+        "running" => (
+            ActivitySeverity::Assign,
+            format!("Harness generating pages for «{title}»"),
+        ),
+        "installing" => (
+            ActivitySeverity::Assign,
+            format!("Installing harness for «{title}»"),
+        ),
+        "queued" => (
+            ActivitySeverity::Prompt,
+            format!("Design queued · «{title}» · run {}", short_id(id)),
+        ),
+        _ => return None,
+    };
+    // Dedupe key collapses identical prompt+status spam (batch score floods).
+    let dedupe = format!("design:{status}:{title}");
+    Some((
+        ms,
+        dedupe,
+        ActivityEvent {
+            id: format!("design:{id}:{status}"),
+            at: ms_to_clock(ms),
+            severity: sev,
+            message: msg,
+        },
+    ))
+}
+
+/// Winner / rating settle lines from the design dashboard leaderboard.
+fn design_winner_events(dash: Option<&Value>) -> Vec<(u64, String, ActivityEvent)> {
+    let Some(dash) = dash else {
+        return Vec::new();
+    };
+    let rid = dash
+        .pointer("/leaderboard/current_round")
+        .and_then(Value::as_u64)
+        .or_else(|| dash.pointer("/round/round_id").and_then(Value::as_u64))
+        .unwrap_or(0);
+    let ratings = dash
+        .pointer("/leaderboard/ratings")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut out = Vec::new();
+    for r in ratings {
+        let wins = r.get("wins").and_then(Value::as_u64).unwrap_or(0);
+        if wins == 0 {
+            continue;
+        }
+        let hk = r.get("miner_hotkey").and_then(Value::as_str).unwrap_or("");
+        let agent = agent_from_hotkey(hk, 0);
+        let label = if agent.hotkey == "—" {
+            truncate_middle(hk)
+        } else {
+            agent.operator
+        };
+        // Prefer round close time when present so winners sort with the round.
+        let ms = dash
+            .pointer("/round/closes_at_secs")
+            .and_then(Value::as_u64)
+            .map_or(0, |s| s.saturating_mul(1000));
+        out.push((
+            ms,
+            format!("design:winner:{rid}:{hk}"),
+            ActivityEvent {
+                id: format!("design:winner:{rid}:{}", short_id(hk)),
+                at: ms_to_clock(ms),
+                severity: ActivitySeverity::Reward,
+                message: format!("Round {rid} winner selected · {label}"),
+            },
+        ));
+    }
+    out
+}
+
+/// Activity lines from design dashboard + prism submissions (bounded, deduped).
+///
+/// Copy is ops-style English tied to real run stages — not a cycling prompt
+/// title loop. Duplicate `(status, prompt)` lines collapse to the newest.
 #[must_use]
 pub fn activity_from_lives(
+    design_dash: Option<&Value>,
     design_runs: &[Value],
     prism_subs: &[Value],
     limit: usize,
 ) -> Vec<ActivityEvent> {
-    let mut events: Vec<(u64, ActivityEvent)> = Vec::new();
+    let mut events: Vec<(u64, String, ActivityEvent)> = Vec::new();
+    events.extend(design_winner_events(design_dash));
     for r in design_runs {
-        let id = r.get("id").and_then(Value::as_str).unwrap_or("?");
-        let status = r.get("status").and_then(Value::as_str).unwrap_or("");
-        let ms = r
-            .get("updated_at_ms")
-            .and_then(Value::as_u64)
-            .or_else(|| r.get("created_at_ms").and_then(Value::as_u64))
-            .unwrap_or(0);
-        // Label by the pinned-bank prompt title when known; else a short run id.
-        let label = r
-            .get("prompt_title")
-            .and_then(Value::as_str)
-            .filter(|t| !t.is_empty())
-            .map_or_else(
-                || format!("design run {}", &id[..id.len().min(8)]),
-                str::to_owned,
-            );
-        let (sev, msg) = match status {
-            "scored" => (ActivitySeverity::Score, format!("{label} scored")),
-            "failed" => (ActivitySeverity::Fail, format!("{label} failed")),
-            "awaiting_admin" => (ActivitySeverity::Settle, format!("{label} awaiting admin")),
-            _ => continue,
-        };
-        events.push((
-            ms,
-            ActivityEvent {
-                id: format!("design:{id}:{status}"),
-                at: ms_to_clock(ms),
-                severity: sev,
-                message: msg,
-            },
-        ));
+        if let Some(ev) = design_activity_line(r) {
+            events.push(ev);
+        }
     }
     for r in prism_subs {
         let id = r.get("id").and_then(Value::as_str).unwrap_or("?");
@@ -782,24 +889,29 @@ pub fn activity_from_lives(
             .get("label")
             .and_then(Value::as_str)
             .filter(|t| !t.is_empty())
-            .map_or_else(
-                || format!("prism {}", &id[..id.len().min(8)]),
-                str::to_owned,
-            );
+            .map_or_else(|| format!("prism {}", short_id(id)), str::to_owned);
         let bpb = r.get("bpb").and_then(Value::as_f64);
         let (sev, msg) = match status {
             "terminated" => (
                 ActivitySeverity::Score,
                 bpb.map_or_else(
-                    || format!("{label} terminated"),
-                    |b| format!("{label} bpb {b:.4}"),
+                    || format!("Prism evaluated · {label}"),
+                    |b| format!("Prism evaluated · {label} · bpb {b:.4}"),
                 ),
             ),
-            "failed" => (ActivitySeverity::Fail, format!("{label} failed")),
+            "failed" => (
+                ActivitySeverity::Fail,
+                format!("Prism run {} failed · {label}", short_id(id)),
+            ),
+            "running" | "leased" => (
+                ActivitySeverity::Assign,
+                format!("Prism training · {label}"),
+            ),
             _ => continue,
         };
         events.push((
             ms,
+            format!("prism:{status}:{label}"),
             ActivityEvent {
                 id: format!("prism:{id}:{status}"),
                 at: ms_to_clock(ms),
@@ -809,7 +921,85 @@ pub fn activity_from_lives(
         ));
     }
     events.sort_by_key(|b| std::cmp::Reverse(b.0));
-    events.into_iter().take(limit).map(|(_, e)| e).collect()
+    // Keep the newest line per dedupe key so batch-scored identical prompts
+    // do not flood the live tail with the same sentence.
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::with_capacity(limit);
+    for (_, key, ev) in events {
+        if !seen.insert(key) {
+            continue;
+        }
+        out.push(ev);
+        if out.len() >= limit {
+            break;
+        }
+    }
+    out
+}
+
+/// Hex form of an SS58 hotkey when the address decodes; used so `?q=` can
+/// match either wire form miners paste.
+fn hex_from_ss58_hotkey(ss58: &str) -> Option<String> {
+    let (bytes, prefix) = keystore::ss58_decode(ss58).ok()?;
+    if prefix != BITTENSOR_SS58_PREFIX {
+        return None;
+    }
+    Some(hex::encode(bytes))
+}
+
+fn agent_matches_query(agent: &Agent, needle: &str) -> bool {
+    let hay: [&str; 4] = [
+        agent.hotkey.as_str(),
+        agent.operator.as_str(),
+        agent.slug.as_str(),
+        agent.handle.as_str(),
+    ];
+    if hay.iter().any(|h| h.to_ascii_lowercase().contains(needle)) {
+        return true;
+    }
+    // Full hex → SS58 equality (miners often paste the 64-char form).
+    if let Some(ss58) = ss58_from_hex(needle) {
+        if agent.hotkey.eq_ignore_ascii_case(&ss58) {
+            return true;
+        }
+    }
+    // Hex substring against the decoded SS58 payload.
+    if let Some(hex_hk) = hex_from_ss58_hotkey(&agent.hotkey) {
+        if hex_hk.contains(needle) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Case-insensitive substring match against hotkey (SS58/hex), operator, slug,
+/// handle, prompt title/id, or submission id — for `?q=` on list endpoints.
+#[must_use]
+pub fn submission_matches_query(sub: &Submission, q: &str) -> bool {
+    let needle = q.trim().to_ascii_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    if agent_matches_query(&sub.agent, &needle) {
+        return true;
+    }
+    let hay: [&str; 4] = [
+        sub.prompt_id.as_str(),
+        sub.prompt_title.as_deref().unwrap_or(""),
+        sub.title.as_str(),
+        sub.id.as_str(),
+    ];
+    hay.iter().any(|h| h.to_ascii_lowercase().contains(&needle))
+}
+
+/// Leaderboard row match for `?q=` (hotkey / handle / slug / operator).
+#[must_use]
+pub fn leaderboard_matches_query(row: &LeaderboardRow, q: &str) -> bool {
+    let needle = q.trim().to_ascii_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    agent_matches_query(&row.agent, &needle)
 }
 
 fn num_f64(v: &Value) -> Option<f64> {
@@ -1160,5 +1350,89 @@ mod tests {
         assert_eq!(a.round_id, Some(42));
         assert_eq!(a.seconds_remaining, Some(99));
         assert!(a.round_ends_at.as_ref().unwrap().starts_with("20"));
+    }
+
+    #[test]
+    fn activity_dedupes_identical_prompt_score_spam() {
+        let runs = vec![
+            json!({
+                "id": "aaa111",
+                "status": "scored",
+                "prompt_title": "Crypto on-ramp compliance",
+                "round_id": 9,
+                "updated_at_ms": 1_700_000_003_000_u64
+            }),
+            json!({
+                "id": "bbb222",
+                "status": "scored",
+                "prompt_title": "Crypto on-ramp compliance",
+                "round_id": 9,
+                "updated_at_ms": 1_700_000_002_000_u64
+            }),
+            json!({
+                "id": "ccc333",
+                "status": "running",
+                "prompt_title": "Farm sensor IoT",
+                "round_id": 9,
+                "updated_at_ms": 1_700_000_001_000_u64
+            }),
+        ];
+        let events = activity_from_lives(None, &runs, &[], 10);
+        assert_eq!(events.len(), 2, "{events:?}");
+        assert!(events[0].message.contains("Design evaluated"));
+        assert!(events[0].message.contains("Crypto on-ramp"));
+        assert!(events[1].message.contains("Harness generating"));
+        // Same prompt+status collapses — only the newest scored line survives.
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| e.message.contains("Crypto on-ramp"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn activity_includes_winner_settle_lines() {
+        let dash = json!({
+            "round": {"round_id": 9, "closes_at_secs": 1_700_000_100_u64},
+            "leaderboard": {
+                "current_round": 9,
+                "ratings": [
+                    {"miner_hotkey": "aa".repeat(32), "rating": 1200, "wins": 1, "losses": 0}
+                ]
+            }
+        });
+        let events = activity_from_lives(Some(&dash), &[], &[], 10);
+        assert_eq!(events.len(), 1);
+        assert!(events[0].message.contains("Round 9 winner selected"));
+        assert!(matches!(events[0].severity, ActivitySeverity::Reward));
+    }
+
+    #[test]
+    fn submission_query_matches_hotkey_and_prompt() {
+        let sub = design_submission(
+            &json!({
+                "id": "deadbeef01",
+                "status": "scored",
+                "prompt_id": "fin03",
+                "prompt_title": "Crypto on-ramp compliance",
+                "updated_at_ms": 1_700_000_000_000_u64
+            }),
+            &"aa".repeat(32),
+            Some(&json!({
+                "id": "deadbeef01",
+                "status": "scored",
+                "prompt_title": "Crypto on-ramp compliance",
+                "pages": [{"path": "index.png", "bytes": 1}]
+            })),
+            1,
+        )
+        .unwrap();
+        let ss58 = sub.agent.hotkey.clone();
+        assert!(submission_matches_query(&sub, &ss58[..8]));
+        assert!(submission_matches_query(&sub, "crypto"));
+        assert!(submission_matches_query(&sub, &"aa".repeat(8)));
+        assert!(!submission_matches_query(&sub, "no-such-miner"));
     }
 }

--- a/crates/site-data/Cargo.toml
+++ b/crates/site-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "site-data"
-description = "Live data adapters for the site API: TAO quote cache, sealed weights, metrics frames"
+description = "Live data adapters for the site API: TAO quote cache, sealed weights, metrics frames, design/prism mappers"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,6 +10,8 @@ publish = false
 
 [dependencies]
 bundle = { path = "../bundle" }
+hex = "0.4"
+keystore = { path = "../keystore" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde_json = "1"
 site-types = { path = "../site-types" }

--- a/crates/site-data/src/lib.rs
+++ b/crates/site-data/src/lib.rs
@@ -1,6 +1,6 @@
 //! Live data adapters behind `site-api`: TAO/USD quote cache, sealed weight
-//! vector projection, and metrics frames. Pure functions / explicit handles so
-//! the HTTP crate stays a thin router.
+//! vector projection, metrics frames, and honest design/prism → site mappers.
+//! Pure functions / explicit handles so the HTTP crate stays a thin router.
 
 #![forbid(unsafe_code)]
 #![allow(clippy::cast_precision_loss)]
@@ -8,6 +8,7 @@
 #![allow(clippy::cast_sign_loss)]
 #![allow(clippy::doc_markdown)]
 
+pub mod map;
 pub mod metrics;
 pub mod price;
 pub mod timefmt;

--- a/crates/site-data/src/map.rs
+++ b/crates/site-data/src/map.rs
@@ -68,7 +68,7 @@ pub fn agent_from_hotkey(hotkey: &str, joined_epoch: u64) -> Agent {
     }
 }
 
-pub use site_data::timefmt::{ms_to_clock, ms_to_iso};
+pub use crate::timefmt::{ms_to_clock, ms_to_iso};
 
 /// Map design run status → site submission status.
 #[must_use]

--- a/crates/site-data/src/map.rs
+++ b/crates/site-data/src/map.rs
@@ -602,7 +602,7 @@ fn telemetry_x(point: &PrismTelemetryPoint) -> u32 {
 /// Params prefer telemetry `n_params`, then the list-row `n_params` so
 /// historical runs still surface a measured size when the detail blob is thin.
 #[must_use]
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::implicit_hasher)]
 pub fn prism_window(
     recipe: Option<&Value>,
     status: Option<&Value>,

--- a/crates/site-types/src/types.rs
+++ b/crates/site-types/src/types.rs
@@ -442,7 +442,7 @@ pub struct Validator {
 }
 
 /// Activity severity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ActivitySeverity {
     /// Score event.

--- a/docs/SITE_API.md
+++ b/docs/SITE_API.md
@@ -11,6 +11,7 @@ frontend `BaseApi` contract (`types.ts` / `contract.ts`).
 | `/v1/site/arenas/prism/*` | Registry pick `challenge_id=prism` → `/v1/status`, `/v1/submissions`, `/v1/recipe` |
 | `/v1/site/network`, `/validators` | Chain tip / metagraph when available; numeric unknowns are `0` or omitted — never invented TAO price/emission |
 | `/v1/site/arenas/design/duels` | Always `[]` (admin winners model; no fabricated matchups) |
+| `/v1/site/activity` | Design `recent_runs` + round winners + prism submissions → ops-style English lines (deduped) |
 | Coding arena | `status: "paused"`, empty submissions / matrix / leaderboard |
 
 Design submissions carry **no `url`** (produced HTML is never served); the
@@ -19,6 +20,10 @@ and runs without a captured screenshot are excluded from the submissions list.
 Leaderboard `elo` is the design
 `rating` field. Prism window series use real terminal `bpb` with a single
 `[final]` point when no step curve is stored.
+
+`GET /v1/site/arenas/{slug}/submissions` and `/leaderboard` accept optional
+`?q=` — case-insensitive substring over miner hotkey (SS58 or hex), handle,
+slug, operator, and (for submissions) prompt title / id / run id.
 
 Backends must be registered (same as challenge proxy), e.g.
 `deploy/scripts/register-challenge-backends.sh`.


### PR DESCRIPTION
## Summary
- Replace repetitive EVALUATION LOGS spam (`"{prompt} scored"` loops) with deduped ops-style English events from real design run stages, round winners, and prism activity.
- Add `?q=` hotkey/prompt filtering on `/v1/site/arenas/{slug}/submissions` and `/leaderboard` (SS58 + hex).
- Expose `miner_hotkey` on design run detail and list all recent generations on `/v1/miners/{hotkey}` (not only the current round) for the public agent history page.

## Test plan
- [x] `cargo test -p site-api -p design-http --lib`
- [x] `cargo clippy -p site-api -p site-types -p design-http --all-targets -- -D warnings`
- [ ] Deploy gateway/site-api to prod carefully (site-only; do not clobber metagraph/auto-seal source roll)
- [ ] Confirm `GET /v1/site/activity?limit=20` shows varied English lines (not identical prompt titles at one timestamp)
- [ ] Confirm `GET /v1/site/arenas/design/submissions?q=<ss58-prefix>` filters

## Deploy note
Pairs with frontend PR `BaseIntelligence/frontend` branch `fix/design-site-ux`. Prefer site-api roll via normal gateway image pin when ready; leave metagraph/auto-seal automation untouched.