### PR TITLE
fix(design-sanitize): stop nuking CSS on scroll-behavior

### DIFF
--- a/crates/design-sanitize/src/lib.rs
+++ b/crates/design-sanitize/src/lib.rs
@@ -538,7 +538,7 @@ body { margin: 0; background: var(--bg); }
     #[test]
     fn ie_behavior_still_nukes_block() {
         let (out, report) =
-            sanitize_html(r#"<style>body{behavior:url(evil.htc);color:red}</style><p>x</p>"#);
+            sanitize_html(r"<style>body{behavior:url(evil.htc);color:red}</style><p>x</p>");
         assert!(report.css_stripped, "{report:?}");
         assert!(!out.to_ascii_lowercase().contains("<style>"), "{out}");
         assert!(!out.contains("evil.htc"), "{out}");

--- a/crates/design-sanitize/src/lib.rs
+++ b/crates/design-sanitize/src/lib.rs
@@ -117,19 +117,54 @@ fn rewrite_body_wrapper(html: &str) -> String {
     re_close.replace_all(&with_open, "</div>").into_owned()
 }
 
+/// True when `css` (already lowercased) contains the IE-only `behavior:`
+/// property, not a suffix like `scroll-behavior:`.
+fn has_ie_behavior_property(lower: &str) -> bool {
+    let mut start = 0;
+    while let Some(rel) = lower[start..].find("behavior:") {
+        let abs = start + rel;
+        if abs == 0 {
+            return true;
+        }
+        let prev = lower.as_bytes()[abs - 1];
+        // Property names may include `-` / `_` / alphanumerics (`scroll-behavior`).
+        if prev.is_ascii_alphanumeric() || prev == b'-' || prev == b'_' {
+            start = abs + "behavior:".len();
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
 /// Filter dangerous CSS constructs from a style attribute / block.
+///
+/// Soft-strips `@import` rules (keeps the rest of the block). Hard-nukes the
+/// whole input for XSS-prone constructs (`expression(`, `url(javascript:`,
+/// IE `behavior:`, `-moz-binding`). `scroll-behavior:` is presentation CSS
+/// and must not match the IE `behavior:` check.
 #[must_use]
 pub fn filter_css(css: &str) -> (String, bool) {
-    let lower = css.to_ascii_lowercase();
-    let bad = lower.contains("@import")
-        || lower.contains("expression(")
+    let mut stripped = false;
+    let mut out = css.to_owned();
+    if out.to_ascii_lowercase().contains("@import") {
+        if let Ok(re) = Regex::new(r"(?i)@import[^;]*;?") {
+            let next = re.replace_all(&out, "");
+            if next.as_ref() != out {
+                stripped = true;
+                out = next.into_owned();
+            }
+        }
+    }
+    let lower = out.to_ascii_lowercase();
+    let hard_bad = lower.contains("expression(")
         || lower.contains("url(javascript:")
-        || lower.contains("behavior:")
+        || has_ie_behavior_property(&lower)
         || lower.contains("-moz-binding");
-    if bad {
+    if hard_bad {
         (String::new(), true)
     } else {
-        (css.to_owned(), false)
+        (out, stripped)
     }
 }
 
@@ -155,17 +190,21 @@ pub fn sanitize_html(raw: &str) -> (String, SanitizeReport) {
         notes.push("meta_refresh".into());
     }
 
-    // Pre-strip style blocks with dangerous CSS; keep safe blocks for ammonia.
+    // Pre-filter style blocks: soft-strip `@import`, hard-nuke XSS CSS.
     let mut pre = rewrite_body_wrapper(raw);
     if let Ok(re) = Regex::new(r"(?is)<style[^>]*>(.*?)</style>") {
         let mut stripped = false;
         let mut css_notes = Vec::new();
         pre = re
             .replace_all(&pre, |caps: &regex::Captures<'_>| {
-                let (filtered, bad) = filter_css(&caps[1]);
-                if bad {
+                let original = &caps[1];
+                let (filtered, touched) = filter_css(original);
+                if touched {
                     stripped = true;
                     css_notes.push("css_blocked".into());
+                }
+                // Hard-bad → empty filtered; soft-strip keeps remaining rules.
+                if filtered.is_empty() && !original.is_empty() {
                     String::new()
                 } else {
                     format!("<style>{filtered}</style>")
@@ -216,13 +255,14 @@ fn filter_inline_styles(html: &str) -> (String, bool) {
                 .get(2)
                 .or_else(|| caps.get(3))
                 .map_or("", |m| m.as_str());
-            let (filtered, bad) = filter_css(val);
-            if bad || filtered.is_empty() && !val.is_empty() {
+            let (filtered, touched) = filter_css(val);
+            if filtered.is_empty() && !val.is_empty() {
                 stripped = true;
                 String::new()
             } else if filtered == val {
                 caps[0].to_owned()
             } else {
+                stripped |= touched;
                 format!(" style=\"{filtered}\"")
             }
         })
@@ -448,5 +488,59 @@ mod tests {
             out.contains("class=\"ok\"") || out.contains("class='ok'"),
             "{out}"
         );
+    }
+
+    #[test]
+    fn scroll_behavior_must_not_nuke_style_block() {
+        let html = r#"<style>
+html{scroll-behavior:smooth}
+body{margin:0;color:#172220;background:#f4f7f6}
+.hero{padding:2rem}
+</style><main class="hero">Hello</main>"#;
+        let (out, report) = sanitize_html(html);
+        assert!(
+            !report.css_stripped,
+            "scroll-behavior is safe presentation CSS: {report:?}"
+        );
+        assert!(
+            out.to_ascii_lowercase().contains("<style>"),
+            "style kept: {out}"
+        );
+        assert!(out.contains("scroll-behavior"), "{out}");
+        assert!(out.contains(".hero"), "{out}");
+    }
+
+    #[test]
+    fn amp_in_css_comment_must_not_drop_style() {
+        let html = r#"<style>
+/* --- RESET & VARIABLES --- */
+:root { --bg: #07090E; }
+body { margin: 0; background: var(--bg); }
+</style><p class="x">hi</p>"#;
+        let (out, report) = sanitize_html(html);
+        assert!(!report.css_stripped, "{report:?}");
+        assert!(out.to_ascii_lowercase().contains("<style>"), "{out}");
+        assert!(out.contains("--bg"), "{out}");
+    }
+
+    #[test]
+    fn import_soft_stripped_keeps_remaining_rules() {
+        let (out, report) = sanitize_html(
+            r#"<style>@import url('https://fonts.example/x.css');
+.hero{color:red}</style><p class="hero">x</p>"#,
+        );
+        assert!(report.css_stripped, "{report:?}");
+        assert!(!out.contains("@import"), "{out}");
+        assert!(out.to_ascii_lowercase().contains("<style>"), "{out}");
+        assert!(out.contains(".hero"), "{out}");
+    }
+
+    #[test]
+    fn ie_behavior_still_nukes_block() {
+        let (out, report) =
+            sanitize_html(r#"<style>body{behavior:url(evil.htc);color:red}</style><p>x</p>"#);
+        assert!(report.css_stripped, "{report:?}");
+        assert!(!out.to_ascii_lowercase().contains("<style>"), "{out}");
+        assert!(!out.contains("evil.htc"), "{out}");
     }
 }

--- a/docs/DESIGN_CHALLENGE.md
+++ b/docs/DESIGN_CHALLENGE.md
@@ -199,7 +199,12 @@ only (§6).
 - Tags: `script`, `iframe`, `object`, `embed`, `applet`, `base`, `form`, `meta[http-equiv=refresh]`, `link[rel=import]`, scriptable SVG
 - All `on*` event attributes
 - URL schemes: reject `javascript:`, `vbscript:`, `data:text/html`; allow `http`, `https`, `mailto`, `data:image/*`
-- CSS: reject `@import`, `expression(`, `url(javascript:`, `behavior:`, `-moz-binding`
+- CSS: soft-strip `@import …;` rules (remainder of the `<style>` block is kept);
+  hard-reject (drop the whole block/attr) for `expression(`, `url(javascript:`,
+  IE-only `behavior:` (not `scroll-behavior:`), `-moz-binding`
+- External `<link rel=stylesheet>` is stripped (no CDN / Tailwind CDN); miners
+  must embed presentation CSS in `<style>` or inline `style=` for screenshots
+  and the sandboxed viewer to look styled
 
 ### Annotator signal
 

--- a/docs/external-miner/design.md
+++ b/docs/external-miner/design.md
@@ -158,9 +158,22 @@ Screenshots only: `GET /v1/view/{run_id}/index.png` returns the full-page PNG
 screenshot the orchestrator captures right after sanitize. Produced HTML is
 never served — `.html` requests return `410 Gone` (the gateway still wraps
 view responses in a CSP `sandbox` (no scripts) lockdown as defense in depth).
-Your pages stay static HTML + inline CSS (`img` may use `data:`/`https:`,
-fonts `data:`/`https:`) so the headless capture renders them faithfully.
-`GET /v1/runs/{id}/pages` stays available for page metadata.
+Your pages stay static HTML + **embedded** CSS (`<style>` blocks and/or inline
+`style=`) so the headless capture renders them faithfully. External
+`<link rel=stylesheet>` (Tailwind CDN, Google Fonts CSS, etc.) is stripped by
+sanitize — screenshots will look unstyled if that was your only CSS. Prefer
+system font stacks over `@import` font CSS (`@import` rules are removed).
+`img` may use `data:` / `https:`. `GET /v1/runs/{id}/pages` stays available for
+page metadata.
+
+### Why a run is rejected / scored zero
+
+| Outcome | What it means |
+|---------|----------------|
+| `rejected` + `near_identical_harness_copy` / `ast_architecture_copy` | Pre-LLM copy gate: your harness is a byte/AST copy of an **earlier** miner harness (baseline starter is OK; copying another miner is not) |
+| `scored` with agentic `cheat` / `suspicious` | LLM anti-cheat found a listed cheat pattern (same Score(0); not admin-eligible) |
+| `failed` + harness / install / timeout | Agent crashed, timed out, or infra exhausted retries — check `/events` + `/logs` |
+| Missing required pages | Bundle must include `index.html`, `pricing.html`, `components.html` |
 
 ## Useful routes
 


### PR DESCRIPTION
## Summary
- **Root cause of ugly screenshots:** `filter_css` treated any `behavior:` substring as IE XSS CSS, so legitimate `scroll-behavior:smooth` wiped entire `<style>` blocks. Chromium then screenshotted class-only HTML → unstyled pages. Confirmed on prod (e.g. ClearRail run with full design system CSS in raw, zero `<style>` after sanitize).
- **Fix:** match only the IE `behavior:` property (not suffixes), soft-strip `@import …;` while keeping remaining rules, keep hard-nuke for `expression(` / `url(javascript:` / `-moz-binding`.
- **Docs:** clarify that external `<link rel=stylesheet>` / Tailwind CDN is stripped (expected); miners must embed CSS; document reject taxonomy for miners.

## Prod evidence (master, design_run)
- ~21 recent runs lost all `<style>` via the `scroll-behavior` false positive (`css_stripped` + `css_blocked`).
- Styled vs bare screenshots compared: kept-style looks designed; nuked-style is default browser chrome.
- External `<link>` strip is intentional (security); not the dominant prod failure mode right now.

## Reject taxonomy (terminal runs ≈163)
| Status | Count | % | Why |
|--------|------:|--:|-----|
| scored | 105 | 64% | Clean (or legacy cheat-scored) |
| rejected | 33 | 20% | **All** pre-LLM copy gate (`near_identical_harness_copy` / `ast_architecture_copy`) |
| failed | 22 | 14% | 18× harness `NoneType.__dict__`, 4× `stuck timeout` |
| awaiting_admin | 3 | 2% | Clean, waiting for winners |

## Test plan
- [x] `cargo test -p design-sanitize`
- [x] `xtask design-check` / `external-docs-check`
- [ ] After promote: new runs with `scroll-behavior` keep CSS in screenshots
- [ ] Ops follow-up: re-sanitize stored `raw_html` + `backfill-screenshots` (or force recapture) for historical ugly PNGs — existing artifacts stay broken until reprocessed

## Deploy note
Does **not** touch metagraph cache / real-seal. Promote `design-challenge` (+ any image that vendors `design-sanitize`). Historical screenshots need a one-shot re-sanitize from `design_artifact.raw_html` then screenshot backfill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS sanitization to preserve safe presentation styles such as `scroll-behavior`.
  * Continued blocking dangerous CSS patterns, including IE-specific `behavior:` rules.
  * Preserved valid style rules when removing unsafe `@import` statements.
  * Prevented safe CSS comments and constructs from causing entire style blocks to be removed.

* **Documentation**
  * Clarified CSS sanitization rules, supported styling methods, external stylesheet restrictions, and run rejection conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->