### PR TITLE
docs(evidence): Prism WTA after seal (epoch 24372)

### DIFF
--- a/docs/evidence/prism-wta-2026-08-08.md
+++ b/docs/evidence/prism-wta-2026-08-08.md
@@ -26,11 +26,29 @@ said "lattice-proportional — not WTA"). Math:
 
 `prism_registry::apply_wta` after competition credits in `build_epoch_leaves`:
 only the argmax positive credit keeps a Score leaf (lex-smallest hotkey on
-ties). Expected after deploy + next epoch emit + seal: **one** prism hotkey
-with ~0.5 of the vector from Prism (plus any design points they also hold).
+ties). See **After** below for the sealed outcome.
 
 ## Also shipped
 
 - Pre-pod screens: copy gate → static `METRICS_JSON`/telemetry hooks → AST
   similarity, before `prism-lium` rent.
 - `PRISM_MAX_CONCURRENT_EVALS=8` (CLI default, compose default, `env-prod.yml`).
+
+## After (live sealed bundle)
+
+`GET https://chain.joinbase.ai/v1/weights/latest` at ~2026-08-08T05:00:56Z:
+
+- `sealed: true`, `epoch: 24372`, `emission_shares: {design: 0.5, prism: 0.5}`
+- Prod prism `raw_weight_snapshot` epoch `24372`: **one** positive Score leaf
+  (`e82eec45…` / `5HK8uU9…` = 177155); prior challenger + arch-owner credits
+  collapsed to `Score(0)` by `apply_wta`.
+- Observed vector:
+  - `5HK8uU9…` → **0.6** (= 0.5 Prism WTA + 0.1 design share)
+  - four other design winners → **0.1** each
+  - prism also-rans `5CY9Hzrq…` / `5HHL1a8…` **absent** (were 0.139 each before)
+
+Deploy: tag `v3.3.7` → [deploy-prod #31239422842](https://github.com/BaseIntelligence/base/actions/runs/31239422842)
+(`prism-challenge@sha256:fba453a2…`, `PRISM_MAX_CONCURRENT_EVALS=8`, workers 0–7).
+Ops: rewind emit cursor + delete pre-deploy non-WTA prism leaves for 24372,
+re-emit with new binary; carry design winners via `weights-smoke-rescue` + seal.
+


### PR DESCRIPTION
## Summary
- Append after-seal evidence for the Prism WTA fix shipped in #85 / `v3.3.7`.
- Live vector: champion `5HK8uU9…` = 0.6; prior prism also-rans removed.

## Test plan
- [x] Confirm `GET https://chain.joinbase.ai/v1/weights/latest` matches the after block
- [x] Confirm prod `PRISM_MAX_CONCURRENT_EVALS=8`