### PR TITLE
fix(prism): cargo fmt for TokenMix label-leak screen

### DIFF
--- a/crates/challenge-agentic/src/sim.rs
+++ b/crates/challenge-agentic/src/sim.rs
@@ -11,8 +11,8 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use challenge_ast::{
-    fingerprint_source, similarity_bps, static_source_cheat, top_k_nearest, AST_CHEAT_BPS,
-    AST_SUSPICIOUS_BPS, BASELINE_CORPUS_PREFIX, SourceCheatKind,
+    fingerprint_source, similarity_bps, static_source_cheat, top_k_nearest, SourceCheatKind,
+    AST_CHEAT_BPS, AST_SUSPICIOUS_BPS, BASELINE_CORPUS_PREFIX,
 };
 use serde_json::Value;
 

--- a/crates/challenge-ast/src/source_cheats.rs
+++ b/crates/challenge-ast/src/source_cheats.rs
@@ -89,9 +89,7 @@ fn noncausal_seq_mix_reason(architecture_py: &str) -> Option<&'static str> {
         || src.contains("transpose(-1, -2)")
         || src.contains("transpose(-2, -1)")
         || src.contains(".mT")
-        || (src.contains("einops.rearrange")
-            && src.contains("b t d")
-            && src.contains("b d t"));
+        || (src.contains("einops.rearrange") && src.contains("b t d") && src.contains("b d t"));
 
     if !has_time_transpose {
         return None;


### PR DESCRIPTION
## Summary
- `cargo fmt` follow-up for #95 so CI can green and images can ship the TokenMix label-leak screen.

## Test plan
- [x] `cargo fmt --all -- --check`
- [ ] CI green → images → promote prism-challenge