### PR TITLE
feat(site): expose agent UID and sealed weight on arena boards

### DIFF
--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -14,9 +14,10 @@ use crate::state::SiteState;
 use crate::upstream::{self, DESIGN, PRISM};
 use site_data::map::{
     activity_from_lives, design_arena_from_dashboard, design_leaderboard, design_submission,
+    enrich_leaderboard_uids, enrich_leaderboard_weights, enrich_submission_uids,
     is_prism_champion_submission, leaderboard_matches_query, list_arenas, prism_arena_from_live,
     prism_bpb_leaderboard, prism_submission, prism_telemetry, prism_window,
-    submission_matches_query,
+    submission_matches_query, uid_index_from_hotkeys,
 };
 use site_types::coding_arena;
 use site_types::page_slice;
@@ -150,6 +151,52 @@ fn hex_hotkey(bytes: &[u8]) -> String {
         s.push(HEX[(b & 0xf) as usize] as char);
     }
     s
+}
+
+/// Current metagraph hotkey → UID index (hex + SS58). Empty when chain is down.
+fn metagraph_uid_index(st: &SiteState) -> HashMap<String, u16> {
+    let Some(chain) = st.chain.as_ref() else {
+        return HashMap::new();
+    };
+    let block = chain.current_block().unwrap_or(0);
+    let Ok(hash) = chain.block_hash(block) else {
+        return HashMap::new();
+    };
+    let Ok(mg) = chain.metagraph_at(&hash) else {
+        return HashMap::new();
+    };
+    uid_index_from_hotkeys(&mg.hotkeys)
+}
+
+/// Sealed hotkey → normalised weight share (SS58 keys from the bundle).
+fn sealed_weight_index(st: &SiteState) -> HashMap<String, f64> {
+    site_data::weights::sealed_view(st.latest_sealed_bundle())
+        .map(|view| view.hotkeys.into_iter().collect())
+        .unwrap_or_default()
+}
+
+/// Enrich leaderboard rows with on-chain UID + sealed weight / TAO/day.
+fn decorate_leaderboard(st: &SiteState, rows: &mut [crate::LeaderboardRow]) {
+    let uids = metagraph_uid_index(st);
+    if !uids.is_empty() {
+        enrich_leaderboard_uids(rows, &uids);
+    }
+    let weights = sealed_weight_index(st);
+    if !weights.is_empty() {
+        // `emission_per_day` is not yet hydrated from chain; pass 0 so we still
+        // surface `weight` and leave `taoPerDay` unset until the rate is known.
+        // Clients may also compute `weight × emissionPerDay` from /v1/weights/latest
+        // once network stats publish a non-zero emission.
+        enrich_leaderboard_weights(rows, &weights, 0.0);
+    }
+}
+
+/// Enrich submission agents with on-chain UID.
+fn decorate_submissions(st: &SiteState, rows: &mut [crate::Submission]) {
+    let uids = metagraph_uid_index(st);
+    if !uids.is_empty() {
+        enrich_submission_uids(rows, &uids);
+    }
 }
 
 async fn network_stats(st: &SiteState) -> NetworkStats {
@@ -328,6 +375,7 @@ async fn design_leaderboard_json(
             (ratings.as_slice(), previous.as_slice(), round_id)
         };
     let mut rows = design_leaderboard(board_ratings, board_previous, epoch);
+    decorate_leaderboard(st, &mut rows);
     if let Some(needle) = q.filter(|s| !s.trim().is_empty()) {
         rows.retain(|r| leaderboard_matches_query(r, needle));
     }
@@ -374,6 +422,7 @@ async fn prism_leaderboard_json(
         .cloned()
         .unwrap_or_default();
     let mut board = prism_bpb_leaderboard(&rows, epoch);
+    decorate_leaderboard(st, &mut board);
     if let Some(needle) = q.filter(|s| !s.trim().is_empty()) {
         board.retain(|r| leaderboard_matches_query(r, needle));
     }
@@ -445,6 +494,7 @@ async fn get_submissions(
                 .filter(|r| is_prism_champion_submission(r))
                 .filter_map(prism_submission)
                 .collect();
+            decorate_submissions(&st, &mut items);
             if let Some(st_f) = status_filter {
                 items.retain(|s| match st_f {
                     "scored" => s.status == crate::SubmissionStatus::Scored,
@@ -517,6 +567,7 @@ async fn design_submissions_page(
             items.push(sub);
         }
     }
+    decorate_submissions(st, &mut items);
     if let Some(st_f) = status_filter {
         items.retain(|s| match st_f {
             "scored" => s.status == crate::SubmissionStatus::Scored,

--- a/crates/site-data/src/map.rs
+++ b/crates/site-data/src/map.rs
@@ -43,6 +43,9 @@ fn truncate_middle(v: &str) -> String {
 /// The display identity is the SS58 hotkey when the upstream hex decodes —
 /// `operator` carries the truncated form and `hotkey` the full value so
 /// clients can render a copyable address instead of a bare hex prefix.
+///
+/// UID / `miner_number` stay empty here; callers that hold a metagraph index
+/// apply them with [`apply_agent_uid`].
 #[must_use]
 pub fn agent_from_hotkey(hotkey: &str, joined_epoch: u64) -> Agent {
     let hk = hotkey.trim();
@@ -64,8 +67,116 @@ pub fn agent_from_hotkey(hotkey: &str, joined_epoch: u64) -> Agent {
         model: "—".into(),
         operator: truncate_middle(&display),
         hotkey: if known { display } else { "—".into() },
+        uid: None,
         joined_epoch,
     }
+}
+
+/// Attach an on-chain UID (and zero-padded `miner_number`) when known.
+pub fn apply_agent_uid(agent: &mut Agent, uid: Option<u16>) {
+    let Some(uid) = uid else {
+        return;
+    };
+    agent.uid = Some(uid);
+    agent.miner_number = format!("{uid:03}");
+}
+
+/// Resolve a hotkey (hex or SS58) against a map keyed by lowercase hex + SS58.
+#[must_use]
+pub fn lookup_uid(uid_by_key: &HashMap<String, u16>, hotkey: &str) -> Option<u16> {
+    let hk = hotkey.trim();
+    if hk.is_empty() || hk == "—" {
+        return None;
+    }
+    if let Some(uid) = uid_by_key.get(hk) {
+        return Some(*uid);
+    }
+    let lower = hk.to_ascii_lowercase();
+    if let Some(uid) = uid_by_key.get(&lower) {
+        return Some(*uid);
+    }
+    if let Some(ss58) = ss58_from_hex(hk) {
+        return uid_by_key.get(&ss58).copied();
+    }
+    None
+}
+
+/// Build a hotkey → UID index from a metagraph's UID-ordered hotkey list.
+///
+/// Keys include lowercase hex and SS58 so both challenge payloads and sealed
+/// bundle addresses resolve.
+#[must_use]
+pub fn uid_index_from_hotkeys(hotkeys: &[Vec<u8>]) -> HashMap<String, u16> {
+    let mut map = HashMap::with_capacity(hotkeys.len().saturating_mul(2));
+    for (i, hk) in hotkeys.iter().enumerate() {
+        let Ok(uid) = u16::try_from(i) else {
+            continue;
+        };
+        let Ok(arr) = <[u8; 32]>::try_from(hk.as_slice()) else {
+            continue;
+        };
+        let hex = hex::encode(arr);
+        map.insert(hex, uid);
+        map.insert(ss58_encode(&arr, BITTENSOR_SS58_PREFIX), uid);
+    }
+    map
+}
+
+/// Attach UID / miner number onto every leaderboard agent from a metagraph index.
+pub fn enrich_leaderboard_uids(rows: &mut [LeaderboardRow], uid_by_key: &HashMap<String, u16>) {
+    for row in rows {
+        let uid = lookup_uid(uid_by_key, &row.agent.hotkey);
+        apply_agent_uid(&mut row.agent, uid);
+    }
+}
+
+/// Attach UID / miner number onto every submission agent from a metagraph index.
+pub fn enrich_submission_uids(rows: &mut [Submission], uid_by_key: &HashMap<String, u16>) {
+    for row in rows {
+        let uid = lookup_uid(uid_by_key, &row.agent.hotkey);
+        apply_agent_uid(&mut row.agent, uid);
+    }
+}
+
+/// Attach sealed weight share + estimated TAO/day onto leaderboard rows.
+///
+/// Formula: `tao_per_day = weight_share × subnet_emission_per_day`.
+/// `weight_by_hotkey` is keyed by SS58 (and optionally hex); shares are already
+/// normalised (sum ≈ 1). When `emission_per_day` is 0/unknown, `tao_per_day`
+/// stays unset so clients do not invent an absolute figure from a missing rate.
+pub fn enrich_leaderboard_weights(
+    rows: &mut [LeaderboardRow],
+    weight_by_hotkey: &HashMap<String, f64>,
+    emission_per_day: f64,
+) {
+    for row in rows {
+        let w = lookup_weight(weight_by_hotkey, &row.agent.hotkey);
+        let Some(weight) = w else {
+            continue;
+        };
+        row.weight = Some(weight);
+        if emission_per_day > 0.0 {
+            row.tao_per_day = Some(weight * emission_per_day);
+        }
+    }
+}
+
+fn lookup_weight(weight_by_hotkey: &HashMap<String, f64>, hotkey: &str) -> Option<f64> {
+    let hk = hotkey.trim();
+    if hk.is_empty() || hk == "—" {
+        return None;
+    }
+    if let Some(w) = weight_by_hotkey.get(hk) {
+        return Some(*w);
+    }
+    let lower = hk.to_ascii_lowercase();
+    if let Some(w) = weight_by_hotkey.get(&lower) {
+        return Some(*w);
+    }
+    if let Some(ss58) = ss58_from_hex(hk) {
+        return weight_by_hotkey.get(&ss58).copied();
+    }
+    None
 }
 
 pub use crate::timefmt::{ms_to_clock, ms_to_iso};
@@ -267,6 +378,8 @@ pub fn design_leaderboard(
                 delta7d,
                 bpb: None,
                 params_m: None,
+                weight: None,
+                tao_per_day: None,
             },
         )
         .collect()
@@ -546,6 +659,8 @@ pub fn prism_bpb_leaderboard(subs: &[Value], epoch: u64) -> Vec<LeaderboardRow> 
             delta7d: 0.0,
             bpb: Some(bpb),
             params_m: n_params.map(|p| p as f64 / 1e6),
+            weight: None,
+            tao_per_day: None,
         })
         .collect()
 }
@@ -1077,6 +1192,37 @@ mod tests {
         assert!((rows[0].elo - 1200.0).abs() < f64::EPSILON);
         assert!((rows[0].delta7d - 100.0).abs() < f64::EPSILON);
         assert_eq!(rows[0].rank, 1);
+    }
+
+    #[test]
+    fn apply_agent_uid_zero_pads_miner_number() {
+        let mut agent = agent_from_hotkey("aa", 1);
+        apply_agent_uid(&mut agent, Some(41));
+        assert_eq!(agent.uid, Some(41));
+        assert_eq!(agent.miner_number, "041");
+    }
+
+    #[test]
+    fn uid_index_maps_hex_and_ss58() {
+        let hk = vec![0x11_u8; 32];
+        let map = uid_index_from_hotkeys(std::slice::from_ref(&hk));
+        assert_eq!(map.get(&hex::encode(&hk)).copied(), Some(0));
+        let ss58 = ss58_encode(hk.as_slice().try_into().unwrap(), BITTENSOR_SS58_PREFIX);
+        assert_eq!(map.get(&ss58).copied(), Some(0));
+    }
+
+    #[test]
+    fn enrich_leaderboard_weights_sets_tao_per_day() {
+        let mut rows = design_leaderboard(
+            &[json!({"miner_hotkey":"aa","rating":1.0,"wins":1,"losses":0})],
+            &[],
+            1,
+        );
+        let mut weights = HashMap::new();
+        weights.insert(rows[0].agent.hotkey.clone(), 0.25);
+        enrich_leaderboard_weights(&mut rows, &weights, 100.0);
+        assert!((rows[0].weight.unwrap() - 0.25).abs() < f64::EPSILON);
+        assert!((rows[0].tao_per_day.unwrap() - 25.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/site-types/src/types.rs
+++ b/crates/site-types/src/types.rs
@@ -116,7 +116,8 @@ pub struct Agent {
     pub slug: String,
     /// Display handle.
     pub handle: String,
-    /// Printed miner number when known; `—` otherwise.
+    /// Printed miner number when known (`041`); `—` otherwise.
+    /// Mirrors [`Self::uid`] zero-padded when the metagraph lookup succeeds.
     pub miner_number: String,
     /// Declared model/stack when known; `—` otherwise.
     pub model: String,
@@ -126,6 +127,9 @@ pub struct Agent {
     /// raw upstream value; `—` when the miner is unknown. Copy targets read
     /// this, never the truncated `operator`.
     pub hotkey: String,
+    /// On-chain UID from the current metagraph when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<u16>,
     /// Join epoch when known.
     pub joined_epoch: u64,
 }
@@ -156,6 +160,12 @@ pub struct LeaderboardRow {
     /// Model parameters in millions when the submission measured them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params_m: Option<f64>,
+    /// Normalised sealed weight share for this hotkey (0..1), when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
+    /// Estimated TAO/day = `weight × subnet_emission_per_day` when both known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tao_per_day: Option<f64>,
 }
 
 /// Submission status.


### PR DESCRIPTION
## Summary
- Site API enriches leaderboard + submission agents with on-chain **UID** / zero-padded `minerNumber` from the metagraph cache.
- Leaderboard rows also carry normalised sealed **weight** (and `taoPerDay` when subnet emission/day is known).
- Frontend joins the same weight vector client-side as a fallback.

## Formula
`tao_per_day = weight_share × subnet_emission_per_day`

## Test plan
- [ ] `cargo test -p site-data --lib`
- [ ] After deploy: `GET /v1/site/arenas/design/leaderboard` shows `agent.uid` / `minerNumber` and optional `weight`
- [ ] `GET /v1/site/arenas/design/submissions` shows `agent.uid` when the hotkey is on the metagraph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leaderboards now display miner UIDs, normalized weights, and estimated TAO earned per day.
  * Submission records now include miner UIDs.
  * Design and Prism leaderboard and submission views include the enriched information.
* **Documentation**
  * Miner number formatting and optional on-chain UID information are now documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->