### PR TITLE
fix(gateway): require bearer auth for /v1/admin/*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Working branch: **`main`**. Prod ships from annotated tags `v*.*.*` cut on `main
 | Key | Who | Needed for |
 |-----|-----|------------|
 | `gateway_sk` | Gateway | Bundle **seal** signatures (`POST /v1/admin/seal`) |
+| `gateway_admin_token` | Gateway + seal scripts | Bearer for **`/v1/admin/*`** (seal, backends, attest-grant). **Required** when `BASE_GATEWAY_REQUIRE_OWNER=1` |
 | `prism_sk` / `design_sk` | Challenge / smoke | Signed leaves (`POST /v1/weights/raw`); pubs must match trust root |
 | Gateway owner wallet + `BASE_GATEWAY_REQUIRE_OWNER` | Gateway | Master-only **identity** check (live/prod). **Not** required to seal or serve `/v1/weights/latest` |
 | Validator wallet | Validator | On-chain weight **submit** only — validators *fetch* sealed weights; they do not need a gateway wallet |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "tracing",
  "uuid",
 ]
 

--- a/bins/weights-smoke/src/main.rs
+++ b/bins/weights-smoke/src/main.rs
@@ -82,6 +82,14 @@ struct Args {
     /// after an anti-cheat false positive is overridden by the operator).
     #[arg(long = "score", value_name = "HOTKEY_HEX:SCORE")]
     score_overrides: Vec<String>,
+
+    /// Admin bearer for `POST /v1/admin/seal` (prod requires this).
+    #[arg(long, env = "BASE_GATEWAY_ADMIN_TOKEN")]
+    admin_token: Option<String>,
+
+    /// File containing the admin bearer token (single line).
+    #[arg(long, env = "BASE_GATEWAY_ADMIN_TOKEN_FILE")]
+    admin_token_file: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -166,24 +174,49 @@ fn score_map(
     scores
 }
 
+fn load_admin_token(args: &Args) -> Result<Option<String>, String> {
+    if let Some(t) = args.admin_token.as_ref() {
+        let t = t.trim();
+        if t.is_empty() {
+            return Err("admin token is empty".into());
+        }
+        return Ok(Some(t.to_owned()));
+    }
+    if let Some(path) = args.admin_token_file.as_ref() {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| format!("read admin token file {}: {e}", path.display()))?;
+        let t = raw.trim();
+        if t.is_empty() {
+            return Err(format!("admin token file {} is empty", path.display()));
+        }
+        return Ok(Some(t.to_owned()));
+    }
+    Ok(None)
+}
+
 async fn admin_seal_and_check_latest(
     gateway: &str,
     epoch: u64,
     netuid: u16,
     tip: u64,
+    admin_token: Option<&str>,
 ) -> Result<(), String> {
     let http = reqwest::Client::builder()
         .timeout(Duration::from_mins(1))
         .build()
         .map_err(|e| e.to_string())?;
     let base = gateway.trim_end_matches('/');
-    let seal = http
+    let mut req = http
         .post(format!("{base}/v1/admin/seal"))
         .json(&serde_json::json!({
             "epoch": epoch,
             "netuid": netuid,
             "block_b": tip,
-        }))
+        }));
+    if let Some(token) = admin_token {
+        req = req.header("Authorization", format!("Bearer {token}"));
+    }
+    let seal = req
         .send()
         .await
         .map_err(|e| format!("admin/seal transport: {e}"))?;
@@ -305,5 +338,13 @@ async fn run() -> Result<(), String> {
         outcomes.len()
     );
 
-    admin_seal_and_check_latest(&args.gateway, epoch, args.netuid, tip).await
+    let admin_token = load_admin_token(&args)?;
+    admin_seal_and_check_latest(
+        &args.gateway,
+        epoch,
+        args.netuid,
+        tip,
+        admin_token.as_deref(),
+    )
+    .await
 }

--- a/crates/gateway-core/Cargo.toml
+++ b/crates/gateway-core/Cargo.toml
@@ -17,6 +17,7 @@ parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [lints]

--- a/crates/gateway-core/src/admin_attest.rs
+++ b/crates/gateway-core/src/admin_attest.rs
@@ -7,10 +7,11 @@
 //! `verified` attestation row with `quote = NULL` and an explicit
 //! `reason: admin-exempt: …`, under the gateway's own control-plane hotkey.
 //!
-//! Access control matches `/v1/admin/seal`: the route is only mounted on the
-//! master-plane gateway, which deploys bind it to the internal network / VPC
-//! only — possession of shell access on the master is the credential. The
-//! written row is auditable in `attestation.reason`.
+//! Access control matches `/v1/admin/seal`: Bearer token via
+//! `BASE_GATEWAY_ADMIN_TOKEN` / `_FILE` (required when
+//! `BASE_GATEWAY_REQUIRE_OWNER=1`). Do not treat network placement alone as
+//! auth — production historically published these routes on `:80`/`:443`.
+//! The written row is auditable in `attestation.reason`.
 
 use axum::extract::State;
 use axum::http::StatusCode;

--- a/crates/gateway-core/src/admin_auth.rs
+++ b/crates/gateway-core/src/admin_auth.rs
@@ -1,0 +1,186 @@
+//! Bearer auth for master-only `/v1/admin/*` control-plane routes.
+//!
+//! Prod historically published these on `:80`/`:443` with no app auth. Policy:
+//! - token env/file set → require matching `Authorization: Bearer`
+//! - `BASE_GATEWAY_REQUIRE_OWNER=1` without token → fail closed at load
+//! - otherwise (local/test) → open + warn
+
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::{header, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use thiserror::Error;
+
+/// Env: raw admin bearer token (prefer the file form in deploy).
+pub const ADMIN_TOKEN_ENV: &str = "BASE_GATEWAY_ADMIN_TOKEN";
+/// Env: path to a single-line admin bearer token file (mode 0400).
+pub const ADMIN_TOKEN_FILE_ENV: &str = "BASE_GATEWAY_ADMIN_TOKEN_FILE";
+/// Same flag the gateway uses for master-only owner check.
+pub const REQUIRE_OWNER_ENV: &str = "BASE_GATEWAY_REQUIRE_OWNER";
+
+/// Admin auth configuration errors.
+#[derive(Debug, Error)]
+pub enum AdminAuthError {
+    /// Missing/empty/unreadable token configuration.
+    #[error("{0}")]
+    Config(String),
+}
+
+/// Shared admin-auth state for the axum middleware.
+#[derive(Clone, Debug)]
+pub struct AdminAuth {
+    /// When `Some`, Bearer must match. When `None`, admin routes are open.
+    token: Option<Arc<[u8]>>,
+}
+
+impl AdminAuth {
+    /// Load from env. Fails closed when owner-check is required but no token.
+    ///
+    /// # Errors
+    ///
+    /// Missing token under `BASE_GATEWAY_REQUIRE_OWNER=1`, or unreadable file.
+    pub fn from_env() -> Result<Self, AdminAuthError> {
+        let token = load_token()?;
+        let require_owner = std::env::var(REQUIRE_OWNER_ENV)
+            .is_ok_and(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "YES"));
+        if token.is_none() {
+            if require_owner {
+                return Err(AdminAuthError::Config(format!(
+                    "{REQUIRE_OWNER_ENV}=1 requires {ADMIN_TOKEN_ENV} or {ADMIN_TOKEN_FILE_ENV} \
+                     (refusing to expose open /v1/admin/* on a public listener)"
+                )));
+            }
+            tracing::warn!(
+                event = "gateway_admin_auth_open",
+                "BASE_GATEWAY_ADMIN_TOKEN unset; /v1/admin/* is unauthenticated \
+                 (OK for local tests only)"
+            );
+        } else {
+            tracing::info!(
+                event = "gateway_admin_auth_enabled",
+                "Bearer auth required for /v1/admin/*"
+            );
+        }
+        Ok(Self {
+            token: token.map(Into::into),
+        })
+    }
+
+    /// Test helper: require this exact bearer token.
+    #[must_use]
+    pub fn require_token(token: impl Into<String>) -> Self {
+        Self {
+            token: Some(Arc::from(token.into().into_bytes().into_boxed_slice())),
+        }
+    }
+
+    /// Test helper: leave admin routes open.
+    #[must_use]
+    pub fn open() -> Self {
+        Self { token: None }
+    }
+}
+
+fn load_token() -> Result<Option<Vec<u8>>, AdminAuthError> {
+    if let Ok(raw) = std::env::var(ADMIN_TOKEN_ENV) {
+        let t = raw.trim();
+        if t.is_empty() {
+            return Err(AdminAuthError::Config(format!(
+                "{ADMIN_TOKEN_ENV} is set but empty"
+            )));
+        }
+        return Ok(Some(t.as_bytes().to_vec()));
+    }
+    if let Ok(path) = std::env::var(ADMIN_TOKEN_FILE_ENV) {
+        let raw = std::fs::read_to_string(&path).map_err(|e| {
+            AdminAuthError::Config(format!("read {ADMIN_TOKEN_FILE_ENV} ({path}): {e}"))
+        })?;
+        let t = raw.trim();
+        if t.is_empty() {
+            return Err(AdminAuthError::Config(format!(
+                "{ADMIN_TOKEN_FILE_ENV} ({path}) is empty"
+            )));
+        }
+        return Ok(Some(t.as_bytes().to_vec()));
+    }
+    Ok(None)
+}
+
+/// Axum middleware: gate `/v1/admin` and `/v1/admin/*`.
+pub async fn admin_auth_middleware(
+    State(auth): State<AdminAuth>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let path = request.uri().path();
+    if !is_admin_path(path) {
+        return next.run(request).await;
+    }
+    let Some(expected) = auth.token.as_ref() else {
+        return next.run(request).await;
+    };
+    let provided = bearer_from_headers(request.headers());
+    match provided {
+        Some(got) if ct_eq(got.as_bytes(), expected.as_ref()) => next.run(request).await,
+        _ => (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": "admin bearer token required",
+                "code": "admin_unauthorized",
+            })),
+        )
+            .into_response(),
+    }
+}
+
+fn is_admin_path(path: &str) -> bool {
+    path == "/v1/admin" || path.starts_with("/v1/admin/")
+}
+
+fn bearer_from_headers(headers: &axum::http::HeaderMap) -> Option<String> {
+    let raw = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let token = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?;
+    let token = token.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_owned())
+    }
+}
+
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ct_eq, is_admin_path};
+
+    #[test]
+    fn admin_path_prefix() {
+        assert!(is_admin_path("/v1/admin/seal"));
+        assert!(is_admin_path("/v1/admin/backends"));
+        assert!(is_admin_path("/v1/admin"));
+        assert!(!is_admin_path("/v1/weights/latest"));
+        assert!(!is_admin_path("/v1/administration"));
+    }
+
+    #[test]
+    fn ct_eq_basic() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"abc", b"ab"));
+    }
+}

--- a/crates/gateway-core/src/lib.rs
+++ b/crates/gateway-core/src/lib.rs
@@ -2,10 +2,12 @@
 //! the workspace LOC cap. `gateway` re-exports everything here; external
 //! callers should keep importing `gateway::*`.
 //!
+//! - [`admin_auth`]: Bearer gate for `/v1/admin/*`.
 //! - [`admin_attest`]: master-only owner credit for non-TEE runtimes.
 //! - [`weights_store`]: raw-weight leaf row + in-memory store + ingress errors.
 
 #![forbid(unsafe_code)]
 
 pub mod admin_attest;
+pub mod admin_auth;
 pub mod weights_store;

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -33,10 +33,13 @@ use tokio::net::TcpListener;
 
 mod gw_config;
 
-pub use api::{GatewayState, SharedChain};
+pub use api::{registry_router, GatewayState, SharedChain};
 pub use gateway_core::admin_attest::{
     admin_attest_grant_router, AttestGrantRequest, AttestGrantResponse, AttestGrantState,
     ATTEST_GRANT_ROUTE,
+};
+pub use gateway_core::admin_auth::{
+    admin_auth_middleware, AdminAuth, AdminAuthError, ADMIN_TOKEN_ENV, ADMIN_TOKEN_FILE_ENV,
 };
 pub use gateway_registry::{
     Backend, BackendView, CreateBackend, Registry, RegistryConfig, RegistryError, DEFAULT_COOLDOWN,
@@ -283,10 +286,11 @@ pub fn build_app(
     )
     .map_err(GatewayError::HttpClient)?;
     let app = app::build_router(metrics, state, tls)?;
-    Ok(match extra {
+    let app = match extra {
         Some(extra) => app.merge(extra),
         None => app,
-    })
+    };
+    apply_admin_auth(app)
 }
 
 /// Like [`build_app`] with injected trust root and weight store (tests / hydrate).
@@ -329,7 +333,21 @@ pub fn build_app_with_bundles(
 ) -> Result<Router, GatewayError> {
     let state = GatewayState::with_parts(registry, chain, challenges, weights, bundles)
         .map_err(GatewayError::HttpClient)?;
-    app::build_router(metrics, state, tls)
+    let app = app::build_router(metrics, state, tls)?;
+    apply_admin_auth(app)
+}
+
+/// Attach `/v1/admin/*` bearer middleware.
+///
+/// # Errors
+///
+/// [`AdminAuth::from_env`] fail-closed config errors.
+pub fn apply_admin_auth(app: Router) -> Result<Router, GatewayError> {
+    let auth = AdminAuth::from_env().map_err(|e| GatewayError::Config(e.to_string()))?;
+    Ok(app.layer(axum::middleware::from_fn_with_state(
+        auth,
+        admin_auth_middleware,
+    )))
 }
 
 /// Master check → telemetry → bind → axum serve until `shutdown` completes.

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -219,17 +219,37 @@ pub fn upstream_uri(base: &str, rest: &str, original: &Uri) -> String {
     upstream_url(base, rest, original.query())
 }
 
+/// Collapse `.` / empty / `..` segments the same way `url`/`reqwest` will before
+/// the upstream request — used so gateway gates cannot be skipped via `v1/./admin`.
+#[must_use]
+pub fn normalize_proxy_path(rest: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for seg in rest.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                let _ = out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out.join("/")
+}
+
 /// Operator admin surfaces are master-local only (not on the public miner path).
+///
+/// Match after path normalization: raw `v1/./admin/…` must not bypass the gate
+/// when the HTTP client collapses `.` before dialing the challenge upstream.
 #[must_use]
 pub fn is_admin_path(rest: &str) -> bool {
-    let rest_norm = rest.trim_start_matches('/');
+    let rest_norm = normalize_proxy_path(rest);
     rest_norm.starts_with("v1/admin/") || rest_norm == "v1/admin"
 }
 
 /// Miner-controlled viewer paths (`/challenge/{id}/v1/view/{run}/{page}`).
 #[must_use]
 pub fn is_view_path(rest: &str) -> bool {
-    rest.trim_start_matches('/').starts_with("v1/view/")
+    normalize_proxy_path(rest).starts_with("v1/view/")
 }
 
 /// Captured PNG screenshot under `/v1/view/{run}/{page}.png`.
@@ -293,9 +313,22 @@ mod tests {
     }
 
     #[test]
+    fn admin_paths_blocked_despite_dot_segment_confusion() {
+        // axum preserves `./` in `{*rest}`; reqwest then collapses to /v1/admin/…
+        assert!(is_admin_path("v1/./admin/rounds/1/winners"));
+        assert!(is_admin_path("v1//admin/rounds/1/candidates"));
+        assert!(is_admin_path("./v1/admin/rounds/1/winners"));
+        assert!(is_admin_path("v1/admin/../admin/rounds/1/winners"));
+        assert!(is_admin_path("foo/../v1/admin/rounds/1/winners"));
+        assert!(!is_admin_path("v1/./harness"));
+        assert!(!is_admin_path("v1/not-admin/rounds/1/winners"));
+    }
+
+    #[test]
     fn view_paths_detected() {
         assert!(is_view_path("v1/view/abc/index.html"));
         assert!(is_view_path("/v1/view/abc/pricing.html"));
+        assert!(is_view_path("v1/./view/abc/index.html"));
         assert!(!is_view_path("v1/runs/abc"));
         assert!(!is_view_path("v1/viewx/abc"));
         assert!(!is_view_path("v1/admin/view"));

--- a/crates/gateway/tests/admin_auth.rs
+++ b/crates/gateway/tests/admin_auth.rs
@@ -1,0 +1,111 @@
+//! `/v1/admin/*` bearer gate (incident: public unauthenticated seal/backends).
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use axum::Router;
+use chain::{FakeChain, FakeChainConfig};
+use gateway::{
+    admin_auth_middleware, admin_seal_router, registry_router, AdminAuth, ChallengeEntry,
+    ChallengesBody, GatewayState, MemoryBundleStore, MemoryRawWeightStore, ParticipantPolicy,
+    Registry, RegistryConfig, SharedChain, BPS_DENOM,
+};
+use tokio::net::TcpListener;
+use validator_sync::SyncChain;
+
+fn fake_chain() -> SharedChain {
+    Arc::new(SyncChain::new(FakeChain::new(FakeChainConfig {
+        hotkeys: vec![vec![1u8; 32]],
+        owner_hotkey: vec![0xA1; 32],
+        current_block: 100,
+        ..FakeChainConfig::default()
+    })))
+}
+
+fn challenges() -> Arc<ChallengesBody> {
+    Arc::new(ChallengesBody {
+        challenges: vec![ChallengeEntry {
+            id: b"c".to_vec(),
+            public_key: [9u8; 32],
+            emission_share_bps: BPS_DENOM,
+            policy: ParticipantPolicy::AllMetagraphHotkeys,
+        }],
+    })
+}
+
+async fn spawn(app: Router) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    format!("http://{addr}")
+}
+
+fn app_with_auth(auth: AdminAuth) -> Router {
+    let reg = Registry::shared(RegistryConfig::default());
+    let state = GatewayState::with_parts(
+        reg,
+        fake_chain(),
+        challenges(),
+        Arc::new(MemoryRawWeightStore::new()),
+        Arc::new(MemoryBundleStore::new()),
+    )
+    .expect("state");
+    Router::new()
+        .merge(registry_router(state.clone()))
+        .merge(admin_seal_router(state))
+        .layer(axum::middleware::from_fn_with_state(
+            auth,
+            admin_auth_middleware,
+        ))
+}
+
+#[tokio::test]
+async fn admin_backends_open_without_token_config() {
+    let base = spawn(app_with_auth(AdminAuth::open())).await;
+    let res = reqwest::get(format!("{base}/v1/admin/backends"))
+        .await
+        .expect("get");
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn admin_backends_rejects_missing_bearer() {
+    let base = spawn(app_with_auth(AdminAuth::require_token("s3cret"))).await;
+    let res = reqwest::get(format!("{base}/v1/admin/backends"))
+        .await
+        .expect("get");
+    assert_eq!(res.status(), 401);
+    let body: serde_json::Value = res.json().await.expect("json");
+    assert_eq!(body["code"], "admin_unauthorized");
+}
+
+#[tokio::test]
+async fn admin_backends_accepts_matching_bearer() {
+    let base = spawn(app_with_auth(AdminAuth::require_token("s3cret"))).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base}/v1/admin/backends"))
+        .header("Authorization", "Bearer s3cret")
+        .json(&serde_json::json!({
+            "challenge_id": "c",
+            "base_url": "http://127.0.0.1:9",
+            "weight": 1
+        }))
+        .send()
+        .await
+        .expect("post");
+    assert_eq!(res.status(), 201);
+}
+
+#[tokio::test]
+async fn non_admin_paths_stay_open() {
+    let base = spawn(app_with_auth(AdminAuth::require_token("s3cret"))).await;
+    // No weights router mounted → 404, not 401.
+    let res = reqwest::get(format!("{base}/v1/weights/latest"))
+        .await
+        .expect("get");
+    assert_eq!(res.status(), 404);
+}

--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -40,12 +40,17 @@ services:
       BASE_GATEWAY_WALLET_HOTKEY: default
       # Owner hotkey 5Gzi… installed; fail-closed master-only check.
       BASE_GATEWAY_REQUIRE_OWNER: "1"
+      # Required whenever REQUIRE_OWNER=1 — gates /v1/admin/* (seal, backends, …).
+      BASE_GATEWAY_ADMIN_TOKEN_FILE: /run/secrets/gateway_admin_token
     # Serve chain.joinbase.ai without forcing clients onto :8080 (8080 is VPC-only).
+    # Note: cleartext :80 publishes the full gateway surface; pair with host Caddy
+    # path filters / DOCKER-USER drops until ACME owns :80. Prefer HTTPS clients.
     ports:
       - "8080:8080"
       - "80:8080"
     volumes:
       - ./deploy/secrets/wallets:/run/base/wallets:ro
+      - ./deploy/secrets/gateway_admin_token:/run/secrets/gateway_admin_token:ro
   prism-challenge:
     environment:
       PRISM_FORCE_SIM: "false"

--- a/deploy/compose/env-staging.yml
+++ b/deploy/compose/env-staging.yml
@@ -35,12 +35,15 @@ services:
       BASE_GATEWAY_WALLET: base-owner
       # We do own netuid 541 on testnet, so the owner check can be strict here.
       BASE_GATEWAY_REQUIRE_OWNER: "1"
+      # Required with REQUIRE_OWNER=1 — gates /v1/admin/*.
+      BASE_GATEWAY_ADMIN_TOKEN_FILE: /run/secrets/gateway_admin_token
     # Serve the public hostname without forcing clients onto :8080.
     ports:
       - "8080:8080"
       - "80:8080"
     volumes:
       - ./deploy/secrets/wallets:/run/base/wallets:ro
+      - ./deploy/secrets/gateway_admin_token:/run/secrets/gateway_admin_token:ro
       # The sealer must sign with the same staging trust root the validator
       # verifies against (design/prism 5000/5000), or /v1/weights/latest never
       # shows design weight and the validator flags emission share mismatch (D23).

--- a/deploy/env/gateway.env.example
+++ b/deploy/env/gateway.env.example
@@ -28,3 +28,8 @@ BASE_GATEWAY_WALLET_HOTKEY=default
 # Set to 1 to refuse startup unless the resolved hotkey is the on-chain
 # SubnetOwnerHotkey for BASE_NETUID. Default (unset/0) only logs a warning.
 BASE_GATEWAY_REQUIRE_OWNER=0
+#
+# When REQUIRE_OWNER=1, one of these MUST be set (fail-closed): Bearer auth for
+# /v1/admin/* (seal, backend registry, attest-grant). Prefer the file form.
+# BASE_GATEWAY_ADMIN_TOKEN_FILE=/run/secrets/gateway_admin_token
+# BASE_GATEWAY_ADMIN_TOKEN=

--- a/deploy/scripts/prod-burn-seal.sh
+++ b/deploy/scripts/prod-burn-seal.sh
@@ -31,6 +31,11 @@ DESIGN_SK="${BASE_DESIGN_SK_FILE:-${BASE_HOME}/deploy/secrets/design_sk}"
 BIN="${WEIGHTS_SMOKE_BIN:-${BASE_HOME}/bin/weights-smoke}"
 LOG="${BURN_SEAL_LOG:-/var/log/base-burn-seal.log}"
 LOCK="${BURN_SEAL_LOCK:-/run/base-burn-seal.lock}"
+# Admin bearer for /v1/admin/seal (required once gateway enforces it).
+if [[ -z "${BASE_GATEWAY_ADMIN_TOKEN:-}" && -z "${BASE_GATEWAY_ADMIN_TOKEN_FILE:-}" \
+  && -f "${BASE_HOME}/deploy/secrets/gateway_admin_token" ]]; then
+  export BASE_GATEWAY_ADMIN_TOKEN_FILE="${BASE_HOME}/deploy/secrets/gateway_admin_token"
+fi
 
 exec 9>"${LOCK}"
 if ! flock -n 9; then

--- a/deploy/scripts/prod-real-seal.sh
+++ b/deploy/scripts/prod-real-seal.sh
@@ -70,7 +70,16 @@ fi
     echo "$(date -Is) chain read failed (last_epoch_block) key=0x${K_LAST_EPOCH_BLOCK}${netuid_hex}"
     exit 1
   }
+  auth_args=()
+  if [[ -n "${BASE_GATEWAY_ADMIN_TOKEN:-}" ]]; then
+    auth_args=(-H "Authorization: Bearer ${BASE_GATEWAY_ADMIN_TOKEN}")
+  elif [[ -n "${BASE_GATEWAY_ADMIN_TOKEN_FILE:-}" && -f "${BASE_GATEWAY_ADMIN_TOKEN_FILE}" ]]; then
+    auth_args=(-H "Authorization: Bearer $(tr -d '[:space:]' <"${BASE_GATEWAY_ADMIN_TOKEN_FILE}")")
+  elif [[ -f "${BASE_HOME}/deploy/secrets/gateway_admin_token" ]]; then
+    auth_args=(-H "Authorization: Bearer $(tr -d '[:space:]' <"${BASE_HOME}/deploy/secrets/gateway_admin_token")")
+  fi
   resp="$(curl -fsS -m 60 -X POST -H 'content-type: application/json' \
+    ${auth_args[@]+"${auth_args[@]}"} \
     -d "{\"epoch\":${epoch},\"netuid\":${NETUID},\"block_b\":${leb}}" \
     "${GATEWAY}/v1/admin/seal" 2>&1)" && rc=0 || rc=$?
   if [[ ${rc} -eq 0 ]]; then

--- a/deploy/scripts/register-challenge-backends.sh
+++ b/deploy/scripts/register-challenge-backends.sh
@@ -32,9 +32,29 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+resolve_admin_token() {
+  # Prefer env token; else file (prod: deploy/secrets/gateway_admin_token).
+  if [[ -n "${BASE_GATEWAY_ADMIN_TOKEN:-}" ]]; then
+    printf '%s' "${BASE_GATEWAY_ADMIN_TOKEN}"
+    return 0
+  fi
+  local f="${BASE_GATEWAY_ADMIN_TOKEN_FILE:-}"
+  if [[ -z "$f" && -f "${ROOT}/deploy/secrets/gateway_admin_token" ]]; then
+    f="${ROOT}/deploy/secrets/gateway_admin_token"
+  fi
+  if [[ -n "$f" && -f "$f" ]]; then
+    tr -d '[:space:]' <"$f"
+  fi
+}
+
 register_one() {
   local challenge_id="$1" base_url="$2"
-  local payload http body
+  local payload http body token
+  local -a auth=()
+  token="$(resolve_admin_token || true)"
+  if [[ -n "${token}" ]]; then
+    auth=(-H "Authorization: Bearer ${token}")
+  fi
   payload="$(printf '{"challenge_id":"%s","base_url":"%s","weight":1}' "$challenge_id" "$base_url")"
   if [[ "$COMPOSE_MODE" -eq 1 ]]; then
     body="$(docker compose -f docker-compose.yml \
@@ -42,10 +62,12 @@ register_one() {
       exec -T gateway \
       curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8080/v1/admin/backends \
       -H 'content-type: application/json' \
+      ${auth[@]+"${auth[@]}"} \
       -d "$payload" 2>/dev/null || true)"
   else
     body="$(curl -sS -w '\n%{http_code}' -X POST "${GATEWAY_URL%/}/v1/admin/backends" \
       -H 'content-type: application/json' \
+      ${auth[@]+"${auth[@]}"} \
       -d "$payload" 2>/dev/null || true)"
   fi
   http="$(printf '%s' "$body" | tail -n1)"

--- a/deploy/secrets/README.md
+++ b/deploy/secrets/README.md
@@ -14,9 +14,17 @@ Bind-mounts use the file inode; directory mode 0700 is OK.
 | Path | Used by | Notes |
 |------|---------|-------|
 | `gateway_sk` | gateway | Bundle seal mini-secret (`BASE_GATEWAY_SK_FILE`) |
+| `gateway_admin_token` | gateway + seal scripts | Bearer for `/v1/admin/*` (`BASE_GATEWAY_ADMIN_TOKEN_FILE`). **Required** when `BASE_GATEWAY_REQUIRE_OWNER=1`. Mode **0400**, uid **65532** |
 | `prism_sk` | prism-challenge | PRISM challenge mini-secret |
 | `design_sk` | design-challenge **only** | Design challenge mini-secret; never mount on egress proxy |
 | `challenge_sk` | legacy placeholder | Prefer `prism_sk` / `design_sk`; do not reuse across challenges |
+
+```bash
+# Generate once per environment; never commit the bytes.
+openssl rand -hex 32 > deploy/secrets/gateway_admin_token
+chown 65532:65532 deploy/secrets/gateway_admin_token
+chmod 0400 deploy/secrets/gateway_admin_token
+```
 
 Local dummy for development: decrypt with age:
 `age -d -i ~/.base-secrets/age-identity.txt -o deploy/secrets/design_sk ~/.base-secrets/design-dummy.age`

--- a/docs/OPERATOR_SECURITY.md
+++ b/docs/OPERATOR_SECURITY.md
@@ -53,6 +53,8 @@ cargo run -q -p trustroot-bin -- verify \
 ## 4. Gateway and TLS
 
 - [ ] Gateway hotkey equals on-chain `SubnetOwnerHotkey` (else process exits 2).
+- [ ] `BASE_GATEWAY_ADMIN_TOKEN_FILE` (or `BASE_GATEWAY_ADMIN_TOKEN`) is set whenever `BASE_GATEWAY_REQUIRE_OWNER=1` — `/v1/admin/*` must not be open on a public listener.
+- [ ] Spot-check from the public Internet: `GET /v1/admin/backends` → **401/403** (not 200). Localhost/VPC seal scripts still work with the bearer.
 - [ ] TLS terminates **only** in the gateway process (D20). No second reverse proxy claiming TLS.
 - [ ] `BASE_DOMAIN` is a real delegated zone when ACME is enabled (D25).
 - [ ] Manual failover procedure is known: [`runbooks/gateway-failover.md`](./runbooks/gateway-failover.md). HA is **not** claimed (R9).


### PR DESCRIPTION
## Summary
- Require bearer auth for gateway `/v1/admin/*` (seal, backends, attest-grant) whenever `BASE_GATEWAY_REQUIRE_OWNER=1`, so the public listener is not an open admin plane.
- Normalize challenge-proxy paths before `is_admin_path` / `is_view_path` so public `/challenge/*/v1/./admin/*` cannot bypass the master-local admin gate after reqwest collapses `.` segments.

## Test plan
- [x] `cargo test -p gateway --lib proxy::tests`
- [x] Existing admin_auth / proxy tests
- [ ] Spot-check from public Internet: `GET /challenge/design/v1/./admin/rounds/1/candidates` → **403** (not upstream 401)
- [ ] Spot-check: `GET /v1/admin/backends` → **401/403** without bearer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Bearer-token authentication for administrative gateway endpoints.
  - Supports securely loading tokens from configuration or mounted secret files.
  - Updated sealing and backend-registration tools to authenticate automatically when configured.

- **Security**
  - Administrative requests now return `401 Unauthorized` when credentials are missing or invalid.
  - Owner-protected deployments fail closed without an administrator token.
  - Improved path normalization prevents URL-formatting bypasses.

- **Documentation**
  - Added setup guidance for administrator tokens, deployment secrets, and security verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->