### PR TITLE
deploy: prod pins for lium rent pool + fix staging master CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
              done; echo "UNHEALTHY: $bad"; exit 1'
 
       - name: Verify live chain (no fake backend)
+        if: matrix.role == 'validator'
         run: |
           set -euo pipefail
           ssh -i "$HOME/.ssh/staging_ed25519" -o BatchMode=yes \

--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,5 +1,5 @@
 {
-  "commit_sha": "45a7b9d3368c155f575ab6063c9bdef08fa5da05",
+  "commit_sha": "02d2ab5ec93325249d306756a83be4dda21cb048",
   "env": "prod",
   "previous": {
     "commit_sha": "45a7b9d3368c155f575ab6063c9bdef08fa5da05",
@@ -34,30 +34,30 @@
   },
   "services": {
     "design-challenge": {
-      "digest": "sha256:6c57ecca59a566ca3ae5fbbbcb50e5a3101bf0f57eca319340d89b023a0e865d",
-      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:6c57ecca59a566ca3ae5fbbbcb50e5a3101bf0f57eca319340d89b023a0e865d",
+      "digest": "sha256:4f73ad35592e904a1e54f409100e9393cc064f4c8debc659f366c261ad1590c2",
+      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:4f73ad35592e904a1e54f409100e9393cc064f4c8debc659f366c261ad1590c2",
       "repository": "ghcr.io/baseintelligence/base/design-challenge"
     },
     "gateway": {
-      "digest": "sha256:7dbd29de3cd17cba932ef42b25bf13b1b2578c782f25565edc003db119051337",
-      "image": "ghcr.io/baseintelligence/base/gateway@sha256:7dbd29de3cd17cba932ef42b25bf13b1b2578c782f25565edc003db119051337",
+      "digest": "sha256:0412c407706ef0cefa8725a5d15bf5d1d913a0ae8e4d48a38c69ae37231425ba",
+      "image": "ghcr.io/baseintelligence/base/gateway@sha256:0412c407706ef0cefa8725a5d15bf5d1d913a0ae8e4d48a38c69ae37231425ba",
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
-      "digest": "sha256:e4500cb58c3ea3d12ffe520292dd496ba4ccf47b7e53de708eea692b7360ef7c",
-      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:e4500cb58c3ea3d12ffe520292dd496ba4ccf47b7e53de708eea692b7360ef7c",
+      "digest": "sha256:28fd0bb9b6676c9f79bacd2cf90b246f29157b3004ffe6141d2264294f67d250",
+      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:28fd0bb9b6676c9f79bacd2cf90b246f29157b3004ffe6141d2264294f67d250",
       "repository": "ghcr.io/baseintelligence/base/prism-challenge"
     },
     "updater": {
-      "digest": "sha256:5999d0aec6ac9548ac34f95ba7c533455bc1cd256a02898bc29025e02273e1a8",
-      "image": "ghcr.io/baseintelligence/base/updater@sha256:5999d0aec6ac9548ac34f95ba7c533455bc1cd256a02898bc29025e02273e1a8",
+      "digest": "sha256:f14b04c087addc0c222d538099e5b7b34323e9648b764b248121f5795e7b9013",
+      "image": "ghcr.io/baseintelligence/base/updater@sha256:f14b04c087addc0c222d538099e5b7b34323e9648b764b248121f5795e7b9013",
       "repository": "ghcr.io/baseintelligence/base/updater"
     },
     "validator": {
-      "digest": "sha256:58ddd12d503bc426cfdbc958e082b2934c779bd6f10612320b5aa2fbdb5714b3",
-      "image": "ghcr.io/baseintelligence/base/validator@sha256:58ddd12d503bc426cfdbc958e082b2934c779bd6f10612320b5aa2fbdb5714b3",
+      "digest": "sha256:42aeb0006a24407e2bba806a62dec643f20f6fad6dec1affb6e1e4adb55c1d2b",
+      "image": "ghcr.io/baseintelligence/base/validator@sha256:42aeb0006a24407e2bba806a62dec643f20f6fad6dec1affb6e1e4adb55c1d2b",
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-08T20:05:59Z"
+  "updated_at": "2026-08-10T08:08:28Z"
 }


### PR DESCRIPTION
## Summary
- Promote `deploy/pins/prod.json` to commit `02d2ab5e` (includes `prism-challenge@sha256:28fd0bb9…` with autonomous Lium rent pool).
- CI: run “Verify live chain” only on the staging **validator** role (master has no validator after #101).

## Test plan
- [x] Prod `base-prism-challenge-1` already recreated on digest `28fd0bb9…` and healthy
- [ ] CI green on this PR / main