### PR TITLE
fix(prism-store): fill updated_at_ms for 429 recovery window

### DIFF
--- a/crates/prism-store/src/arch.rs
+++ b/crates/prism-store/src/arch.rs
@@ -18,8 +18,8 @@ fn backend(e: sqlx::Error) -> StoreError {
     StoreError::Backend(e.to_string())
 }
 
-/// Batch-fill `arch_id` + `created_at_ms` onto states read through the plain
-/// `db::prism_store` row shape (which predates migration 0010).
+/// Batch-fill `arch_id` + `created_at_ms` + `updated_at_ms` onto states read
+/// through the plain `db::prism_store` row shape (predates migration 0010).
 pub(crate) async fn fill_arch_meta(
     pool: &PgPool,
     rows: &mut [SubmissionState],
@@ -28,20 +28,25 @@ pub(crate) async fn fill_arch_meta(
         return Ok(());
     }
     let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
-    let meta: Vec<(String, Option<String>, i64)> = sqlx::query_as(
-        "SELECT id, arch_id, (FLOOR(EXTRACT(EPOCH FROM created_at) * 1000))::BIGINT \
+    let meta: Vec<(String, Option<String>, i64, i64)> = sqlx::query_as(
+        "SELECT id, arch_id, \
+            (FLOOR(EXTRACT(EPOCH FROM created_at) * 1000))::BIGINT, \
+            (FLOOR(EXTRACT(EPOCH FROM updated_at) * 1000))::BIGINT \
          FROM prism_submission WHERE id = ANY($1)",
     )
     .bind(&ids)
     .fetch_all(pool)
     .await
     .map_err(backend)?;
-    let map: HashMap<String, (Option<String>, i64)> =
-        meta.into_iter().map(|(id, a, ms)| (id, (a, ms))).collect();
+    let map: HashMap<String, (Option<String>, i64, i64)> = meta
+        .into_iter()
+        .map(|(id, a, created, updated)| (id, (a, created, updated)))
+        .collect();
     for r in rows.iter_mut() {
-        if let Some((arch, ms)) = map.get(&r.id) {
+        if let Some((arch, created, updated)) = map.get(&r.id) {
             r.arch_id = arch.clone();
-            r.created_at_ms = (*ms).max(0).cast_unsigned();
+            r.created_at_ms = (*created).max(0).cast_unsigned();
+            r.updated_at_ms = (*updated).max(0).cast_unsigned();
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary
- `DbPrismStore` left `updated_at_ms = 0`, so `lium-rent-pool::should_recover` treated every failed row as older than 6h and never requeued.
- Fill `updated_at_ms` in `fill_arch_meta` (same query as `created_at_ms`).

## Test plan
- [x] Prod already SQL-requeued 42 last-6h 429 failures while this ships
- [ ] Merge + images + recreate prod prism so the autonomous loop works without SQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Architecture metadata now displays the latest update time alongside its ID and creation time.
  * Timestamp handling remains consistent, including safeguards for invalid or out-of-range values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->