### PR TITLE
fix(prism): temporarily disable owner-arch emission credit

### DIFF
--- a/crates/prism-challenge/tests/arch_competition.rs
+++ b/crates/prism-challenge/tests/arch_competition.rs
@@ -312,11 +312,15 @@ async fn competition_credits_owner_and_challenger() {
     assert_eq!(rows.len(), 2, "one entry per submission (not collapsed)");
     let owners: BTreeMap<String, String> = store.arch_owners().await.unwrap().into_iter().collect();
     let scores = prism_registry::competition_scores(&rows, &owners);
-    // Owner credited for the arch's best (challenger's 900k); challenger
-    // credited for their own best — max aggregation, never summed.
+    // TEMP: owner-arch credit disabled — each hotkey keeps only own score.
+    // Re-enable OWNER_ARCH_CREDIT_ENABLED to restore owner=900k / chall=900k.
+    assert!(
+        !prism_registry::OWNER_ARCH_CREDIT_ENABLED,
+        "update expectations when restoring owner-arch credit"
+    );
     assert_eq!(
         scores.get(&"aa".repeat(32)),
-        Some(&FinalScore::Score(900_000))
+        Some(&FinalScore::Score(400_000))
     );
     assert_eq!(
         scores.get(&"bb".repeat(32)),

--- a/crates/prism-emit/src/lib.rs
+++ b/crates/prism-emit/src/lib.rs
@@ -25,8 +25,10 @@
 //!   `Score(v>0)` row keeps participating in every later epoch's
 //!   competition set until a better/valid score supersedes it via `max`.
 //!   Leaf emission then applies **WTA** ([`prism_registry::apply_wta`]) so
-//!   only the single best hotkey receives a positive Score leaf. Empty or
-//!   reject-only fresh batches therefore do not burn the prism share.
+//!   only the single best hotkey receives a positive Score leaf. Architecture-
+//!   owner credit is temporarily off ([`prism_registry::OWNER_ARCH_CREDIT_ENABLED`])
+//!   so WTA follows own BPB-derived scores. Empty or reject-only fresh batches
+//!   therefore do not burn the prism share.
 //! - Epochs during a master outage carry no *new* outbox rows; the first
 //!   epoch after recovery still includes active positive scores plus any
 //!   backlog (the seal always pins fresh epochs — stale ones can never

--- a/crates/prism-emit/tests/epoch_semantics.rs
+++ b/crates/prism-emit/tests/epoch_semantics.rs
@@ -305,15 +305,19 @@ async fn competition_credits_survive_batching() {
     assert_score(&leaf_soa(&s7, 0xAA), 400_000);
     assert_not_attempted(&leaf_soa(&s7, 0xBB));
 
-    // Challenger trains the published arch and lands in a later epoch:
-    // competition credits both to 900k; WTA tie-breaks to AA (lex smaller).
+    // Challenger trains the published arch and lands in a later epoch.
+    // TEMP: owner-arch credit off → WTA goes to the BPB/score winner (BB).
     let mut chall = scored_row("sub-chall", &hk(0xBB), 7, FinalScore::Score(900_000));
     chall.arch_id = Some("arch_0123456789abcdef".into());
     store.insert_queued(&chall).await.unwrap();
     let s8 = em.tick(8, &exp).await.unwrap().expect("epoch 8");
     assert_eq!(s8.batch, 1);
-    assert_score(&leaf_soa(&s8, 0xAA), 900_000);
-    assert_score(&leaf_soa(&s8, 0xBB), 0);
+    assert!(
+        !prism_registry::OWNER_ARCH_CREDIT_ENABLED,
+        "update expectations when restoring owner-arch credit"
+    );
+    assert_score(&leaf_soa(&s8, 0xBB), 900_000);
+    assert_score(&leaf_soa(&s8, 0xAA), 0);
 
     // Same-epoch variant: both rows in one batch → same WTA outcome.
     let store2 = Arc::new(MemoryPrismStore::new());
@@ -334,8 +338,8 @@ async fn competition_credits_survive_batching() {
     let em2 = dry_emitter(&store2);
     let s = em2.tick(7, &exp).await.unwrap().expect("emit");
     assert_eq!(s.batch, 2);
-    assert_score(&leaf_soa(&s, 0xAA), 900_000);
-    assert_score(&leaf_soa(&s, 0xBB), 0);
+    assert_score(&leaf_soa(&s, 0xBB), 900_000);
+    assert_score(&leaf_soa(&s, 0xAA), 0);
 }
 
 /// Crash recovery: a batch assigned but never cursor-completed (crashed

--- a/crates/prism-registry/src/competition.rs
+++ b/crates/prism-registry/src/competition.rs
@@ -8,15 +8,17 @@
 //! - **Challenger credit**: a hotkey's own rows — its best lattice score,
 //!   i.e. `max(Score)` over its submissions this epoch (own best training
 //!   result per arch, then across archs).
-//! - **Architecture-owner credit**: for each registered arch, the arch's
+//! - **Architecture-owner credit** *(temporarily disabled — see
+//!   [`OWNER_ARCH_CREDIT_ENABLED`])*: for each registered arch, the arch's
 //!   best epoch result (`max(Score)` over all rows linked to that arch, any
 //!   trainer) is credited to the arch's owner — the owner is rewarded when
 //!   *anyone* trains well on their architecture.
-//! - **Per-hotkey credit**: `max(own credits, owner credits)` — never
-//!   summed, so the SCORE_MAX lattice bound and the no-double-count property
-//!   hold by construction. Hotkeys whose rows are all `NoScore` keep their
-//!   absence; `Score(0)` rows (cheat / copy-gate reject) emit 0 and never
-//!   set an arch's best.
+//! - **Per-hotkey credit**: while owner credit is disabled, this is own
+//!   credit only. When re-enabled: `max(own credits, owner credits)` —
+//!   never summed, so the SCORE_MAX lattice bound and the no-double-count
+//!   property hold by construction. Hotkeys whose rows are all `NoScore`
+//!   keep their absence; `Score(0)` rows (cheat / copy-gate reject) emit 0
+//!   and never set an arch's best.
 //! - **WTA leaf emission**: [`apply_wta`] collapses the credit map to a
 //!   single positive `Score` (argmax; lexicographically smallest hotkey on
 //!   ties). Prism's emission share goes to that one winner.
@@ -25,7 +27,21 @@ use std::collections::BTreeMap;
 
 use prism_store::{EpochScoreRow, FinalScore};
 
+/// Temporary kill-switch for architecture-owner emission credit.
+///
+/// When `false` (current prod intent): leaf emission uses **own BPB-derived
+/// lattice scores only**. An arch owner is not credited when a challenger
+/// trains well on their architecture, so the BPB winner keeps the WTA leaf
+/// (and Prism's weight share) instead of losing a lex tie to a non-training
+/// owner — including owners who have left the metagraph.
+///
+/// Flip back to `true` to restore the architecture-competition owner credit
+/// documented in `docs/PRISM.md`.
+pub const OWNER_ARCH_CREDIT_ENABLED: bool = false;
+
 /// Compute per-hotkey emission for one epoch.
+///
+/// `arch_owners` is ignored while [`OWNER_ARCH_CREDIT_ENABLED`] is `false`.
 #[must_use]
 pub fn competition_scores(
     rows: &[EpochScoreRow],
@@ -43,9 +59,11 @@ pub fn competition_scores(
             FinalScore::Score(v) => {
                 let e = own.entry(r.miner_hotkey.clone()).or_insert(0);
                 *e = (*e).max(*v);
-                if let Some(a) = r.arch_id.as_deref() {
-                    let e = arch_best.entry(a).or_insert(0);
-                    *e = (*e).max(*v);
+                if OWNER_ARCH_CREDIT_ENABLED {
+                    if let Some(a) = r.arch_id.as_deref() {
+                        let e = arch_best.entry(a).or_insert(0);
+                        *e = (*e).max(*v);
+                    }
                 }
             }
             FinalScore::NoScore(reason) => {
@@ -54,13 +72,19 @@ pub fn competition_scores(
         }
     }
 
-    // Owner credits: arch epoch best → arch owner.
+    // Owner credits: arch epoch best → arch owner (gated).
     let mut owner_credit: BTreeMap<String, u64> = BTreeMap::new();
-    for (arch_id, best) in &arch_best {
-        if let Some(owner) = arch_owners.get(*arch_id) {
-            let e = owner_credit.entry(owner.clone()).or_insert(0);
-            *e = (*e).max(*best);
+    if OWNER_ARCH_CREDIT_ENABLED {
+        for (arch_id, best) in &arch_best {
+            if let Some(owner) = arch_owners.get(*arch_id) {
+                let e = owner_credit.entry(owner.clone()).or_insert(0);
+                *e = (*e).max(*best);
+            }
         }
+    } else {
+        // Silence unused-param lint while the kill-switch is off; callers
+        // still pass the registry map so re-enable is a one-line flip.
+        let _ = arch_owners;
     }
 
     let mut out: BTreeMap<String, FinalScore> = BTreeMap::new();
@@ -132,31 +156,39 @@ mod tests {
     }
 
     #[test]
-    fn owner_credited_for_challenger_result_on_their_arch() {
-        // Owner A published arch X (scored 400k on their own submission).
-        // Challenger B trains on X and scores 900k. A's emission = 900k
-        // (arch best), B's emission = 900k (own best) — max, not summed.
+    fn owner_arch_credit_temporarily_disabled() {
+        assert!(
+            !OWNER_ARCH_CREDIT_ENABLED,
+            "flip this test when restoring owner-arch credit"
+        );
+        // Challenger BB trains owner AA's arch to 900k. With owner credit
+        // off, AA keeps only their own 400k — BB (best BPB/score) wins WTA.
         let rows = vec![
             row("aa", Some("arch_x"), 400_000),
             row("bb", Some("arch_x"), 900_000),
         ];
         let out = competition_scores(&rows, &owners(&[("arch_x", "aa")]));
-        assert_eq!(out.get("aa"), Some(&FinalScore::Score(900_000)));
+        assert_eq!(out.get("aa"), Some(&FinalScore::Score(400_000)));
         assert_eq!(out.get("bb"), Some(&FinalScore::Score(900_000)));
+        let wta = apply_wta(out);
+        assert_eq!(wta.get("bb"), Some(&FinalScore::Score(900_000)));
+        assert_eq!(wta.get("aa"), Some(&FinalScore::Score(0)));
     }
 
     #[test]
-    fn owner_emission_is_max_across_archs_not_sum() {
+    fn owner_not_credited_across_archs_while_disabled() {
         let rows = vec![
             row("bb", Some("arch_x"), 300_000),
             row("cc", Some("arch_y"), 500_000),
         ];
         let out = competition_scores(&rows, &owners(&[("arch_x", "aa"), ("arch_y", "aa")]));
-        assert_eq!(out.get("aa"), Some(&FinalScore::Score(500_000)));
+        assert!(out.get("aa").is_none());
+        assert_eq!(out.get("bb"), Some(&FinalScore::Score(300_000)));
+        assert_eq!(out.get("cc"), Some(&FinalScore::Score(500_000)));
     }
 
     #[test]
-    fn zero_scores_never_set_arch_best() {
+    fn zero_scores_do_not_invent_owner_rows() {
         let rows = vec![row("bb", Some("arch_x"), 0), row("aa", Some("arch_x"), 0)];
         let out = competition_scores(&rows, &owners(&[("arch_x", "aa")]));
         assert_eq!(out.get("aa"), Some(&FinalScore::Score(0)));
@@ -187,28 +219,27 @@ mod tests {
     }
 
     #[test]
-    fn own_and_owner_credits_take_max() {
-        // A owns arch X (epoch best 300k by challenger) and also scores
-        // 800k on their own training-only entry on arch Y.
+    fn challenger_keeps_own_score_without_owner_boost() {
+        // A owns arch X but owner credit is off — only own rows count.
         let rows = vec![
             row("bb", Some("arch_x"), 300_000),
             row("aa", Some("arch_y"), 800_000),
         ];
         let out = competition_scores(&rows, &owners(&[("arch_x", "aa"), ("arch_y", "cc")]));
         assert_eq!(out.get("aa"), Some(&FinalScore::Score(800_000)));
-        // Y's epoch best is 800k (by A) → credited to Y's owner C.
-        assert_eq!(out.get("cc"), Some(&FinalScore::Score(800_000)));
+        assert_eq!(out.get("bb"), Some(&FinalScore::Score(300_000)));
+        assert!(out.get("cc").is_none());
     }
 
     #[test]
     fn wta_keeps_only_the_argmax_score() {
         let rows = vec![row("aa", None, 177_155), row("bb", Some("arch_x"), 111_595)];
         let credits = competition_scores(&rows, &owners(&[("arch_x", "cc")]));
-        // Credits: aa=177155, bb=111595, cc=111595 (owner).
+        // Own-only: aa=177155, bb=111595 — owner cc gets nothing.
         let wta = apply_wta(credits);
         assert_eq!(wta.get("aa"), Some(&FinalScore::Score(177_155)));
         assert_eq!(wta.get("bb"), Some(&FinalScore::Score(0)));
-        assert_eq!(wta.get("cc"), Some(&FinalScore::Score(0)));
+        assert!(wta.get("cc").is_none());
     }
 
     #[test]

--- a/crates/prism-registry/src/lib.rs
+++ b/crates/prism-registry/src/lib.rs
@@ -20,6 +20,6 @@ mod competition;
 mod hooks;
 mod publish;
 
-pub use competition::{apply_wta, competition_scores};
+pub use competition::{apply_wta, competition_scores, OWNER_ARCH_CREDIT_ENABLED};
 pub use hooks::post_score_hooks;
 pub use publish::{TopModelPublisher, TopModelRequest, TOPMODEL_REPO_PATH};

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -163,15 +163,14 @@ lands in, not the leaf format or the math).** Per emitted epoch set:
 
 - *challenger credit*: a hotkey's own best lattice score across its rows in
   the epoch's batch (its own best training result per arch, then across archs).
-- *architecture-owner credit*: each registered arch's best batch result
-  (`max(Score)` over all batch rows linked to that arch, any trainer) is
-  credited to the arch's **owner** — owners are rewarded when anyone trains
-  well on their architecture, including in a later epoch than their own
-  submission.
-- *per-hotkey credit*: `max(own credits, owner credits)` — **max, never
-  summed**, so the lattice bound and the no-double-count property hold by
-  construction. `Score(0)` rows (cheat/copy-gate) never set an arch's best;
-  hotkeys whose rows are all `NoScore` keep their absence.
+- *architecture-owner credit*: **temporarily disabled**
+  (`OWNER_ARCH_CREDIT_ENABLED = false` in `prism-registry`). When re-enabled,
+  each registered arch's best batch result (`max(Score)` over all batch rows
+  linked to that arch, any trainer) is credited to the arch's **owner**.
+- *per-hotkey credit*: while owner credit is off, **own score only** (so the
+  best-BPB trainer wins WTA). When re-enabled: `max(own, owner)` — never
+  summed. `Score(0)` rows (cheat/copy-gate) never set an arch's best; hotkeys
+  whose rows are all `NoScore` keep their absence.
 - *WTA emission*: argmax over positive per-hotkey credits → one Score leaf;
   Prism's emission share (50% of the subnet) goes entirely to that winner.
 

--- a/docs/external-miner/prism.md
+++ b/docs/external-miner/prism.md
@@ -153,12 +153,12 @@ baseline — not every past submission — and still exclude your own prior art
 LayerNorm, gated/parallel residual, …) are **not** plagiarism signals. LLM
 quality is coherence-only, not a grader.
 Public gallery/leaderboard show champions only.
-**Competition:** per epoch you are
-credited the max of (a) your own best training result and (b) for each arch you
-own, that arch's best result by *any* trainer — architecture owners are rewarded
-for architectures people win with. Emission is **winner-take-all**: only the
-single highest credit that epoch receives Prism's share (50% of the subnet);
-ties break by lexicographically smallest hotkey. Scores first land in the leaf
+**Competition (temporary):** emission uses **your own best training score
+only** — architecture-owner credit (rewarding arch owners when others train
+well on their code) is **disabled** for now so the best-BPB trainer keeps
+Prism's weights. Emission remains **winner-take-all**: only the single highest
+own score that epoch receives Prism's share (50% of the subnet); ties break by
+lexicographically smallest hotkey. Scores first land in the leaf
 set emitted at the first chain-epoch boundary **after** your run finalizes (a
 long train that crosses epochs is normal — outbox assignment is exactly once).
 Positive scores then keep participating in later epochs' competition sets until


### PR DESCRIPTION
## Summary
- Temporarily disable Prism **architecture-owner emission credit** (`OWNER_ARCH_CREDIT_ENABLED = false`) so WTA weights follow **own BPB-derived scores** only.
- Fixes live incident where UID 100 had best BPB (~4.3268 / score 187730) but Prism's 0.5 weight stayed on UID 109: owner credit tied the off-metagraph arch owner ahead of the trainer and zeroed the BPB winner.
- Docs (`PRISM.md`, `external-miner/prism.md`) mark the kill-switch as temporary; flip the constant to restore owner competition later.

## Test plan
- [x] `cargo test -p prism-registry`
- [x] `cargo test -p prism-emit`
- [x] `cargo test -p prism-challenge --test arch_competition`
- [ ] After deploy: confirm next Prism leaf emit / seal gives Prism share to current best-BPB hotkey (UID 100 today)