### PR TITLE
fix(prism): silence clippy on OWNER_ARCH_CREDIT const asserts

### DIFF
--- a/crates/prism-challenge/tests/arch_competition.rs
+++ b/crates/prism-challenge/tests/arch_competition.rs
@@ -314,10 +314,12 @@ async fn competition_credits_owner_and_challenger() {
     let scores = prism_registry::competition_scores(&rows, &owners);
     // TEMP: owner-arch credit disabled — each hotkey keeps only own score.
     // Re-enable OWNER_ARCH_CREDIT_ENABLED to restore owner=900k / chall=900k.
-    assert!(
-        !prism_registry::OWNER_ARCH_CREDIT_ENABLED,
-        "update expectations when restoring owner-arch credit"
-    );
+    const {
+        assert!(
+            !prism_registry::OWNER_ARCH_CREDIT_ENABLED,
+            "update expectations when restoring owner-arch credit"
+        );
+    }
     assert_eq!(
         scores.get(&"aa".repeat(32)),
         Some(&FinalScore::Score(400_000))

--- a/crates/prism-emit/tests/epoch_semantics.rs
+++ b/crates/prism-emit/tests/epoch_semantics.rs
@@ -312,10 +312,12 @@ async fn competition_credits_survive_batching() {
     store.insert_queued(&chall).await.unwrap();
     let s8 = em.tick(8, &exp).await.unwrap().expect("epoch 8");
     assert_eq!(s8.batch, 1);
-    assert!(
-        !prism_registry::OWNER_ARCH_CREDIT_ENABLED,
-        "update expectations when restoring owner-arch credit"
-    );
+    const {
+        assert!(
+            !prism_registry::OWNER_ARCH_CREDIT_ENABLED,
+            "update expectations when restoring owner-arch credit"
+        );
+    }
     assert_score(&leaf_soa(&s8, 0xBB), 900_000);
     assert_score(&leaf_soa(&s8, 0xAA), 0);
 

--- a/crates/prism-registry/src/competition.rs
+++ b/crates/prism-registry/src/competition.rs
@@ -157,10 +157,12 @@ mod tests {
 
     #[test]
     fn owner_arch_credit_temporarily_disabled() {
-        assert!(
-            !OWNER_ARCH_CREDIT_ENABLED,
-            "flip this test when restoring owner-arch credit"
-        );
+        const {
+            assert!(
+                !OWNER_ARCH_CREDIT_ENABLED,
+                "flip this test when restoring owner-arch credit"
+            );
+        }
         // Challenger BB trains owner AA's arch to 900k. With owner credit
         // off, AA keeps only their own 400k — BB (best BPB/score) wins WTA.
         let rows = vec![
@@ -182,7 +184,7 @@ mod tests {
             row("cc", Some("arch_y"), 500_000),
         ];
         let out = competition_scores(&rows, &owners(&[("arch_x", "aa"), ("arch_y", "aa")]));
-        assert!(out.get("aa").is_none());
+        assert!(!out.contains_key("aa"));
         assert_eq!(out.get("bb"), Some(&FinalScore::Score(300_000)));
         assert_eq!(out.get("cc"), Some(&FinalScore::Score(500_000)));
     }
@@ -228,7 +230,7 @@ mod tests {
         let out = competition_scores(&rows, &owners(&[("arch_x", "aa"), ("arch_y", "cc")]));
         assert_eq!(out.get("aa"), Some(&FinalScore::Score(800_000)));
         assert_eq!(out.get("bb"), Some(&FinalScore::Score(300_000)));
-        assert!(out.get("cc").is_none());
+        assert!(!out.contains_key("cc"));
     }
 
     #[test]
@@ -239,7 +241,7 @@ mod tests {
         let wta = apply_wta(credits);
         assert_eq!(wta.get("aa"), Some(&FinalScore::Score(177_155)));
         assert_eq!(wta.get("bb"), Some(&FinalScore::Score(0)));
-        assert!(wta.get("cc").is_none());
+        assert!(!wta.contains_key("cc"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Unblock CI after #114 so the OWNER_ARCH_CREDIT temp-disable can ship to prod
- Use `const { assert!(…) }` for the flag guards; swap `get().is_none()` for `contains_key`

## Test plan
- [x] `cargo clippy -p prism-registry -p prism-challenge -p prism-emit --tests -- -D warnings`
- [x] `cargo test -p prism-registry owner_arch_credit`
- [ ] CI green on this PR
- [ ] Tag + deploy-prod after merge (images + staging pins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test assertions for compile-time evaluation and clearer key-presence checks.
  * Preserved existing score expectations and feature-gate validation behavior.
* **Refactor**
  * Simplified test logic without changing application behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->