### PR TITLE
docs(prism): lock WTA to best-BPB submitter

### DIFF
--- a/crates/prism-emit/src/lib.rs
+++ b/crates/prism-emit/src/lib.rs
@@ -25,10 +25,11 @@
 //!   `Score(v>0)` row keeps participating in every later epoch's
 //!   competition set until a better/valid score supersedes it via `max`.
 //!   Leaf emission then applies **WTA** ([`prism_registry::apply_wta`]) so
-//!   only the single best hotkey receives a positive Score leaf. Architecture-
-//!   owner credit is temporarily off ([`prism_registry::OWNER_ARCH_CREDIT_ENABLED`])
-//!   so WTA follows own BPB-derived scores. Empty or reject-only fresh batches
-//!   therefore do not burn the prism share.
+//!   only the single best **submitter** receives a positive Score leaf.
+//!   Architecture-owner credit stays off
+//!   ([`prism_registry::OWNER_ARCH_CREDIT_ENABLED`] = `false`) — WTA follows
+//!   the miner hotkey that posted the best-BPB run. Empty or reject-only
+//!   fresh batches therefore do not burn the prism share (active carry).
 //! - Epochs during a master outage carry no *new* outbox rows; the first
 //!   epoch after recovery still includes active positive scores plus any
 //!   backlog (the seal always pins fresh epochs — stale ones can never
@@ -198,11 +199,11 @@ fn merge_competition_rows(batch: &[EpochScoreRow], active: &[EpochScoreRow]) -> 
     out
 }
 
-/// Build the signed D24 set for `epoch`: the batch competition-aggregated
-/// (owner + challenger credits, max lattice) plus `NoScore(NotAttempted)`
-/// for every expected participant without a score this epoch. Batch rows
-/// whose hotkey left the metagraph are dropped from the set (D24 forbids
-/// extra leaves) but stay assigned.
+/// Build the signed D24 set for `epoch`: competition-aggregated submitter
+/// credits (own BPB lattice → WTA; arch-owner credit disabled) plus
+/// `NoScore(NotAttempted)` for every expected participant without a score
+/// this epoch. Batch rows whose hotkey left the metagraph are dropped from
+/// the set (D24 forbids extra leaves) but stay assigned.
 pub fn build_epoch_leaves(
     secret: &[u8; KEY_LEN],
     epoch: u64,

--- a/crates/prism-registry/src/competition.rs
+++ b/crates/prism-registry/src/competition.rs
@@ -1,42 +1,35 @@
-//! Architecture competition emission math (epoch-local, lattice-preserving).
+//! Prism emission competition math (epoch-local, lattice-preserving).
 //!
-//! Exact rule (mirrors `docs/PRISM.md` § Architecture competition):
+//! Exact rule (mirrors `docs/PRISM.md` § competition / WTA):
 //!
-//! - Input: every scored submission row of the epoch (multiple rows per
-//!   hotkey are possible: 1 architecture submission + 1 training-only entry
-//!   per published arch) plus the registry ownership map.
-//! - **Challenger credit**: a hotkey's own rows — its best lattice score,
-//!   i.e. `max(Score)` over its submissions this epoch (own best training
-//!   result per arch, then across archs).
-//! - **Architecture-owner credit** *(temporarily disabled — see
-//!   [`OWNER_ARCH_CREDIT_ENABLED`])*: for each registered arch, the arch's
-//!   best epoch result (`max(Score)` over all rows linked to that arch, any
-//!   trainer) is credited to the arch's owner — the owner is rewarded when
-//!   *anyone* trains well on their architecture.
-//! - **Per-hotkey credit**: while owner credit is disabled, this is own
-//!   credit only. When re-enabled: `max(own credits, owner credits)` —
-//!   never summed, so the SCORE_MAX lattice bound and the no-double-count
-//!   property hold by construction. Hotkeys whose rows are all `NoScore`
-//!   keep their absence; `Score(0)` rows (cheat / copy-gate reject) emit 0
-//!   and never set an arch's best.
-//! - **WTA leaf emission**: [`apply_wta`] collapses the credit map to a
-//!   single positive `Score` (argmax; lexicographically smallest hotkey on
-//!   ties). Prism's emission share goes to that one winner.
+//! - Input: every scored submission row in the competition set (fresh outbox
+//!   + active positive carry). Multiple rows per hotkey are possible.
+//! - **Submitter credit** (normative): a hotkey's own rows — `max(Score)`
+//!   over submissions posted by that `miner_hotkey`. Best BPB ⇒ highest
+//!   lattice score ⇒ that **submitter** wins.
+//! - **Architecture-owner credit**: gated off by
+//!   [`OWNER_ARCH_CREDIT_ENABLED`] (`false`). Arch owners must not receive
+//!   emission credit for challenger trains; the dead path remains only so a
+//!   future explicit product flip can restore it.
+//! - **Per-hotkey credit**: own score only while the flag is false.
+//! - **WTA leaf emission**: [`apply_wta`] keeps a single positive `Score`
+//!   (argmax; lexicographically smallest hotkey on ties). Prism's emission
+//!   share goes to that submitter.
 
 use std::collections::BTreeMap;
 
 use prism_store::{EpochScoreRow, FinalScore};
 
-/// Temporary kill-switch for architecture-owner emission credit.
+/// Architecture-owner emission credit — **must stay `false`**.
 ///
-/// When `false` (current prod intent): leaf emission uses **own BPB-derived
-/// lattice scores only**. An arch owner is not credited when a challenger
-/// trains well on their architecture, so the BPB winner keeps the WTA leaf
-/// (and Prism's weight share) instead of losing a lex tie to a non-training
-/// owner — including owners who have left the metagraph.
+/// Product rule: Prism WTA goes to the **submitter** of the best-BPB run
+/// (`miner_hotkey` on the scored row), never the architecture registry owner.
+/// With this flag `false`, leaf emission uses own BPB-derived lattice scores
+/// only, so a non-training / off-metagraph arch owner cannot steal or burn
+/// Prism's share via lex-tie.
 ///
-/// Flip back to `true` to restore the architecture-competition owner credit
-/// documented in `docs/PRISM.md`.
+/// Do not flip to `true` without an explicit product decision; `docs/PRISM.md`
+/// documents owner credit as disabled for emission.
 pub const OWNER_ARCH_CREDIT_ENABLED: bool = false;
 
 /// Compute per-hotkey emission for one epoch.

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -161,18 +161,20 @@ emitter instance per netuid (single master topology).
 existing lattice, and epoch-close batching changes only *which* epoch a score
 lands in, not the leaf format or the math).** Per emitted epoch set:
 
-- *challenger credit*: a hotkey's own best lattice score across its rows in
-  the epoch's batch (its own best training result per arch, then across archs).
-- *architecture-owner credit*: **temporarily disabled**
-  (`OWNER_ARCH_CREDIT_ENABLED = false` in `prism-registry`). When re-enabled,
-  each registered arch's best batch result (`max(Score)` over all batch rows
-  linked to that arch, any trainer) is credited to the arch's **owner**.
-- *per-hotkey credit*: while owner credit is off, **own score only** (so the
-  best-BPB trainer wins WTA). When re-enabled: `max(own, owner)` — never
-  summed. `Score(0)` rows (cheat/copy-gate) never set an arch's best; hotkeys
-  whose rows are all `NoScore` keep their absence.
+- *submitter credit* (normative): a hotkey's own best lattice score across its
+  rows in the epoch's competition set (fresh outbox + active carry). Credit
+  attaches to `miner_hotkey` on the scored submission — the UID that **posted**
+  the run — never to the architecture registry owner.
+- *architecture-owner credit*: **disabled for emission**
+  (`OWNER_ARCH_CREDIT_ENABLED = false` in `prism-registry`). Arch ownership
+  still exists for top-model / publish bookkeeping, but it must **not** divert
+  Prism weight. Do not re-enable without an explicit product change.
+- *per-hotkey credit*: **own score only** (best-BPB submitter). `Score(0)`
+  rows (cheat/copy-gate) never win; hotkeys whose rows are all `NoScore` keep
+  their absence.
 - *WTA emission*: argmax over positive per-hotkey credits → one Score leaf;
-  Prism's emission share (50% of the subnet) goes entirely to that winner.
+  Prism's emission share (50% of the subnet) goes entirely to that **submitter**
+  (best BPB → that submission's miner UID).
 
 **Top-model publish.** The master tracks the global best bpb across all
 scored submissions. On a new global best (≤ best ever and < last published),


### PR DESCRIPTION
## Summary
- Normative product rule: Prism WTA = **submitter** of the best-BPB run (`miner_hotkey`), never architecture-owner credit
- Keep `OWNER_ARCH_CREDIT_ENABLED = false`; document that re-enable needs an explicit product decision
- Align `docs/PRISM.md`, `prism-registry`, and `prism-emit` comments with that rule

## Test plan
- [x] No behavior change (flag already false since #114)
- [ ] CI green
- [ ] After v3.3.14 prod deploy: sealed weights give Prism ~50% to best-BPB submitter UID (not uid0 burn)