### PR TITLE
fix(deploy): smoke gateway on master, not validator

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -413,19 +413,39 @@ jobs:
           set -euo pipefail
           export BASE_SSH_IDENTITY="$HOME/.ssh/deploy_ed25519"
           HOST="root@${{ steps.host.outputs.value }}"
+          ROLE="${{ matrix.role }}"
+          COMPOSE="docker compose -f docker-compose.yml -f deploy/compose/role-${ROLE}.yml -f deploy/compose/env-prod.yml"
           ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
             "$HOST" \
-            'cd /opt/base && docker compose -f docker-compose.yml -f deploy/compose/role-${{ matrix.role }}.yml -f deploy/compose/env-prod.yml ps --format "table {{.Service}}\t{{.Status}}"'
-          # Health probe
-          ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
-            "$HOST" \
-            'for i in $(seq 1 12); do \
-               if docker exec $(docker ps -q --filter name=validator) curl -fsS -m 5 http://127.0.0.1:8080/healthz 2>/dev/null; then \
-                 echo "validator health: ok"; exit 0; \
+            "cd /opt/base && ${COMPOSE} ps --format 'table {{.Service}}\t{{.Status}}'"
+          # Master has no on-chain validator (sole submitter = validator host).
+          # Probe gateway on master; probe validator only on validator role.
+          if [[ "$ROLE" == "master" ]]; then
+            ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+              "$HOST" \
+              "cd /opt/base && \
+               if ${COMPOSE} ps --status running --services 2>/dev/null | grep -qx validator; then \
+                 echo 'master smoke: ERROR validator running on master (dual submitter)'; exit 1; \
                fi; \
-               sleep 5; \
-             done; \
-             echo "validator health: FAILED"; exit 1'
+               for i in \$(seq 1 12); do \
+                 if ${COMPOSE} exec -T gateway curl -fsS -m 5 http://127.0.0.1:8080/healthz 2>/dev/null; then \
+                   echo 'gateway health: ok'; exit 0; \
+                 fi; \
+                 sleep 5; \
+               done; \
+               echo 'gateway health: FAILED'; exit 1"
+          else
+            ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+              "$HOST" \
+              "cd /opt/base && \
+               for i in \$(seq 1 12); do \
+                 if ${COMPOSE} exec -T validator curl -fsS -m 5 http://127.0.0.1:8080/healthz 2>/dev/null; then \
+                   echo 'validator health: ok'; exit 0; \
+                 fi; \
+                 sleep 5; \
+               done; \
+               echo 'validator health: FAILED'; exit 1"
+          fi
 
       - name: Close firewall for this runner
         if: always() && steps.fw.outputs.ip != ''

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -118,20 +118,40 @@ jobs:
           set -euo pipefail
           export BASE_SSH_IDENTITY="$HOME/.ssh/staging_ed25519"
           HOST="root@${{ steps.host.outputs.value }}"
+          ROLE="${{ matrix.role }}"
+          COMPOSE="docker compose -f docker-compose.yml -f deploy/compose/role-${ROLE}.yml -f deploy/compose/env-staging.yml"
           # Verify containers are up
           ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
             "$HOST" \
-            'cd /opt/base && docker compose -f docker-compose.yml -f deploy/compose/role-${{ matrix.role }}.yml -f deploy/compose/env-staging.yml ps --format "table {{.Service}}\t{{.Status}}"'
-          # Health probe: validator must respond within 60s
-          ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
-            "$HOST" \
-            'for i in $(seq 1 12); do \
-               if docker exec $(docker ps -q --filter name=validator) curl -fsS -m 5 http://127.0.0.1:8080/healthz 2>/dev/null; then \
-                 echo "validator health: ok"; exit 0; \
+            "cd /opt/base && ${COMPOSE} ps --format 'table {{.Service}}\t{{.Status}}'"
+          # Master has no on-chain validator (sole submitter = validator host).
+          # Probe gateway on master; probe validator only on validator role.
+          if [[ "$ROLE" == "master" ]]; then
+            ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+              "$HOST" \
+              "cd /opt/base && \
+               if ${COMPOSE} ps --status running --services 2>/dev/null | grep -qx validator; then \
+                 echo 'master smoke: ERROR validator running on master (dual submitter)'; exit 1; \
                fi; \
-               sleep 5; \
-             done; \
-             echo "validator health: FAILED (no /healthz within 60s)"; exit 1'
+               for i in \$(seq 1 12); do \
+                 if ${COMPOSE} exec -T gateway curl -fsS -m 5 http://127.0.0.1:8080/healthz 2>/dev/null; then \
+                   echo 'gateway health: ok'; exit 0; \
+                 fi; \
+                 sleep 5; \
+               done; \
+               echo 'gateway health: FAILED (no /healthz within 60s)'; exit 1"
+          else
+            ssh -i "$BASE_SSH_IDENTITY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+              "$HOST" \
+              "cd /opt/base && \
+               for i in \$(seq 1 12); do \
+                 if ${COMPOSE} exec -T validator curl -fsS -m 5 http://127.0.0.1:8080/healthz 2>/dev/null; then \
+                   echo 'validator health: ok'; exit 0; \
+                 fi; \
+                 sleep 5; \
+               done; \
+               echo 'validator health: FAILED (no /healthz within 60s)'; exit 1"
+          fi
 
       - name: Post-deploy Match gate (validator only)
         if: steps.gate.outputs.run == 'true' && matrix.role == 'validator'


### PR DESCRIPTION
## Summary
- Prod master deploy for `v3.3.17` failed only at CI smoke: compose showed healthy gateway/design/prism, but smoke probed a local `validator` container that `role-master` intentionally does not run.
- Make staging + prod smoke role-aware: master probes gateway `/healthz` and fails closed if a validator is still running; validator role keeps validator `/healthz`.

## Test plan
- [ ] Merge to `main`
- [ ] `workflow_dispatch` `deploy-prod` with `commit_sha=f46129ea18744d50f8e46d64e36cc69df9f06028` (staging/prod pins already match)
- [ ] Approve `production` environment as echobt if prompted
- [ ] Confirm `deploy prod master` smoke prints `gateway health: ok`
- [ ] Confirm `https://chain.joinbase.ai/healthz` + `/v1/weights/latest` (`sealed: true`)