### PR TITLE
fix(design): tip-emit scores from latest scored round only

### DIFF
--- a/crates/design-db/src/lib.rs
+++ b/crates/design-db/src/lib.rs
@@ -885,6 +885,17 @@ pub async fn design_ratings_for_round(
 
 /// Scores for epoch (D24 leaf projection from ratings).
 ///
+/// Uses ratings from the **single latest scored round** whose `epoch <=`
+/// target (not a per-miner walk of history). Each `award_round` writes the
+/// full rolling-window projection onto that round — so tip emit matches the
+/// current `SCORING_WINDOW_ROUNDS` share. Carrying forward an older
+/// `DISTINCT ON (miner)` `SCORE_MAX` after a miner leaves the window incorrectly
+/// keeps them weighted (prod UID-94 failure mode).
+///
+/// Still allows `round.epoch <= target` so a new chain epoch can emit the
+/// previous round's projection before its first close/award (avoids
+/// zero-lock).
+///
 /// # Errors
 /// SQL error.
 pub async fn design_scores_for_epoch(
@@ -892,17 +903,17 @@ pub async fn design_scores_for_epoch(
     netuid: i32,
     epoch: i64,
 ) -> Result<Vec<(String, String, Option<i64>, Option<i16>)>, DbError> {
-    // Window semantics (scoring v3): each miner's *latest* rating is the
-    // rolling 10-round window projection, so "scores for this chain epoch"
-    // means the newest rating per miner — never filter by the round's epoch.
-    // Filtering by round epoch zero-locks every chain epoch: the first close
-    // inside it emits before any of its rounds is awarded.
     let rows: Vec<(String, String, Option<i64>, Option<i16>)> = sqlx::query_as(
-        "SELECT DISTINCT ON (r.miner_hotkey) r.miner_hotkey, r.kind, r.score, r.absence_reason \
+        "SELECT r.miner_hotkey, r.kind, r.score, r.absence_reason \
          FROM design_rating r \
          JOIN design_round dr ON dr.round_id = r.round_id \
          WHERE dr.netuid = $1 AND dr.epoch <= $2 AND r.kind IS NOT NULL \
-         ORDER BY r.miner_hotkey, r.round_id DESC",
+           AND r.round_id = ( \
+             SELECT MAX(r2.round_id) \
+             FROM design_rating r2 \
+             JOIN design_round dr2 ON dr2.round_id = r2.round_id \
+             WHERE dr2.netuid = $1 AND dr2.epoch <= $2 AND r2.kind IS NOT NULL \
+           )",
     )
     .bind(netuid)
     .bind(epoch)

--- a/crates/design-store/src/store.rs
+++ b/crates/design-store/src/store.rs
@@ -1,6 +1,6 @@
 //! Async persistence contract + in-memory impl.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::Mutex;
 
 use async_trait::async_trait;
@@ -1018,36 +1018,41 @@ impl DesignStore for MemoryDesignStore {
         netuid: u16,
         epoch: u64,
     ) -> Result<Vec<(String, FinalScore)>, StoreError> {
-        // Match PG `design_scores_for_epoch`: newest rating per miner among
-        // rounds with `round.epoch <= target` (rolling window projection).
-        let round_epoch: BTreeMap<u64, u64> = self
+        // Match PG `design_scores_for_epoch`: ratings from the single latest
+        // scored round with `round.epoch <= target` (tip window projection).
+        let eligible_rounds: BTreeSet<u64> = self
             .rounds
             .lock()
             .map_err(|_| StoreError::Backend("poison".into()))?
             .values()
             .filter(|r| r.netuid == netuid && r.epoch <= epoch)
-            .map(|r| (r.round_id, r.epoch))
+            .map(|r| r.round_id)
             .collect();
-        let mut by: BTreeMap<String, (u64, FinalScore)> = BTreeMap::new();
         let ratings = self
             .ratings
             .lock()
             .map_err(|_| StoreError::Backend("poison".into()))?;
-        for ((rid, _), row) in ratings.iter() {
-            if !round_epoch.contains_key(rid) {
-                continue;
-            }
-            let Some(fs) = &row.final_score else {
-                continue;
-            };
-            match by.get(&row.miner_hotkey) {
-                Some((prev_rid, _)) if *prev_rid >= *rid => {}
-                _ => {
-                    by.insert(row.miner_hotkey.clone(), (*rid, fs.clone()));
-                }
-            }
-        }
-        Ok(by.into_iter().map(|(hk, (_, fs))| (hk, fs)).collect())
+        let tip = ratings
+            .iter()
+            .filter_map(|((rid, _), row)| {
+                (eligible_rounds.contains(rid) && row.final_score.is_some()).then_some(*rid)
+            })
+            .max();
+        let Some(tip_rid) = tip else {
+            return Ok(Vec::new());
+        };
+        Ok(ratings
+            .iter()
+            .filter_map(|((rid, _), row)| {
+                (*rid == tip_rid)
+                    .then(|| {
+                        row.final_score
+                            .clone()
+                            .map(|fs| (row.miner_hotkey.clone(), fs))
+                    })
+                    .flatten()
+            })
+            .collect())
     }
 
     async fn set_round_award(&self, award: &RoundAward) -> Result<(), StoreError> {
@@ -1184,5 +1189,81 @@ mod tests {
             s.quota_get("aa", "2026-08-05").await.unwrap(),
             QuotaUsage::default()
         );
+    }
+
+    fn round(id: u64, epoch: u64) -> RoundRow {
+        RoundRow {
+            round_id: id,
+            epoch,
+            netuid: 100,
+            prompt_set_digest: format!("{id:064x}"),
+            status: "emitted".into(),
+            opens_at_secs: id * 100,
+            closes_at_secs: id * 100 + 50,
+        }
+    }
+
+    fn rating(round_id: u64, miner: &str, score: u64) -> RatingRow {
+        RatingRow {
+            round_id,
+            miner_hotkey: miner.into(),
+            rating: i32::try_from(score / 1000).unwrap_or(0),
+            wins: 0,
+            losses: 0,
+            final_score: Some(FinalScore::Score(score)),
+        }
+    }
+
+    /// Stale SCORE_MAX on an older round must not tip-emit after the miner
+    /// leaves the current scored tip (UID-94 carry-forward).
+    #[tokio::test]
+    async fn scores_for_epoch_uses_tip_round_only() {
+        let s = MemoryDesignStore::new();
+        s.insert_round(&round(10, 100)).await.unwrap();
+        s.insert_round(&round(20, 200)).await.unwrap();
+        // Old window tip: sole SCORE_MAX winner (stale after they leave).
+        s.upsert_rating(&rating(10, "stale_max", 1_000_000))
+            .await
+            .unwrap();
+        // Current tip projection: only live-window winners (stale_max absent).
+        s.upsert_rating(&rating(20, "live_a", 250_000))
+            .await
+            .unwrap();
+        s.upsert_rating(&rating(20, "live_b", 250_000))
+            .await
+            .unwrap();
+        s.upsert_rating(&rating(20, "live_c", 250_000))
+            .await
+            .unwrap();
+        s.upsert_rating(&rating(20, "live_d", 250_000))
+            .await
+            .unwrap();
+
+        let mut got = s.scores_for_epoch(100, 200).await.unwrap();
+        got.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            got,
+            vec![
+                ("live_a".into(), FinalScore::Score(250_000)),
+                ("live_b".into(), FinalScore::Score(250_000)),
+                ("live_c".into(), FinalScore::Score(250_000)),
+                ("live_d".into(), FinalScore::Score(250_000)),
+            ]
+        );
+        assert!(
+            !got.iter().any(|(hk, _)| hk == "stale_max"),
+            "stale SCORE_MAX outside tip round must not carry forward"
+        );
+    }
+
+    /// New chain epoch may still emit the previous tip round's projection
+    /// before any round in the new epoch is awarded (no zero-lock).
+    #[tokio::test]
+    async fn scores_for_epoch_allows_prior_epoch_tip() {
+        let s = MemoryDesignStore::new();
+        s.insert_round(&round(20, 200)).await.unwrap();
+        s.upsert_rating(&rating(20, "aa", 1_000_000)).await.unwrap();
+        let got = s.scores_for_epoch(100, 201).await.unwrap();
+        assert_eq!(got, vec![("aa".into(), FinalScore::Score(1_000_000))]);
     }
 }

--- a/docs/DESIGN_CHALLENGE.md
+++ b/docs/DESIGN_CHALLENGE.md
@@ -456,6 +456,11 @@ one **point**. The leaf projection uses a **rolling window of the last
 | No harness | `NoScore(NotAttempted)` |
 | Agentic / infra failure (retry budget spent) | `NoScore(ChallengeInternal)` |
 
+Leaf emit (`scores_for_epoch`) reads ratings from the **latest scored round**
+with `round.epoch ≤ target` only — that row set *is* the rolling-window
+projection written by `award_round`. Do **not** carry forward a miner's older
+`SCORE_MAX` after they leave the window (per-miner history walk is a bug).
+
 Proportional share uses integer floor division; the remainder is unassigned.
 
 ---


### PR DESCRIPTION
## Summary
- `scores_for_epoch` / tip leaf emit now reads ratings from the **single latest scored round** (`round.epoch ≤ target`) instead of `DISTINCT ON (miner)` across all history.
- Stops stale `SCORE_MAX` carry-forward after a miner leaves the rolling 10-round window (prod UID 94 at 0.25).
- Memory store mirrors PG; unit tests cover tip-only + prior-epoch tip (no zero-lock). Spec note in `DESIGN_CHALLENGE.md`.

## Root cause
`award_round` writes the full window projection onto the tip round, but miners who drop out are simply omitted from later rounds. The old query kept each miner's newest historical rating forever, so UID 94's round-206737 `SCORE_MAX` stayed in tip leaves.

## Test plan
- [x] `cargo test -p design-store --lib scores_for_epoch`
- [x] `cargo clippy -p design-store -p design-db -- -D warnings`
- [x] `xtask design-check`
- [ ] CI green
- [ ] After merge: deploy design(+gateway), reseal; confirm UID 94 drops from `GET /v1/weights/latest` unless back in window