### PR TITLE
feat(design): auto-enqueue active harnesses each round

### DIFF
--- a/crates/design-challenge/src/orchestrator.rs
+++ b/crates/design-challenge/src/orchestrator.rs
@@ -21,7 +21,7 @@ use design_challenge_task::{
     reject_awaiting_admin_run, round_id_at, round_secs, score_window, to_leaf, window_start,
     WindowScorePlan, MAX_LOG_CHARS, UNSCORED_EPOCH_LIMIT,
 };
-use design_http::{mark_awaiting_admin, AdminAwardHook};
+use design_http::{enqueue_active_harnesses_for_round, mark_awaiting_admin, AdminAwardHook};
 use design_prompts::{prompt_set_digest, select_prompts_for_round};
 use design_sandbox::{SandboxBackend, SandboxError};
 use design_sanitize::sanitize_bundle;
@@ -248,9 +248,19 @@ impl<C: ChainClient + Send + Sync + 'static> Orchestrator<C> {
                     }
                 }
             }
-            // One attempt: submit schedules next round only (no auto roll-forward).
+            // Open the round, then auto-enqueue every eligible active harness
+            // with this round's shared prompt (Scheduled origin; idempotent).
             let _ = self.ensure_round(rid).await;
-            let _ = self.current_epoch();
+            if let Err(e) = enqueue_active_harnesses_for_round(
+                self.store.as_ref(),
+                rid,
+                self.cfg.netuid,
+                self.current_epoch(),
+            )
+            .await
+            {
+                warn!(error = %e, round = rid, "auto-enqueue failed");
+            }
         }
     }
 

--- a/crates/design-http/src/api.rs
+++ b/crates/design-http/src/api.rs
@@ -452,6 +452,46 @@ async fn post_harness(
         .into_response()
 }
 
+/// Outcome of enqueueing every eligible active harness into one round.
+#[derive(Debug, Default)]
+pub struct EnqueueRoundResult {
+    pub scheduled: Vec<(String, String, Vec<String>)>,
+    pub skipped: Vec<(String, String, String)>,
+}
+
+/// Schedule every eligible active harness into `rid` ([`RunOrigin::Scheduled`]).
+///
+/// Latest active harness per hotkey (`list_active_harnesses`); eliminated rows
+/// are omitted. Idempotent per `(harness, round)`. Used by the round loop and
+/// by `POST /v1/admin/rounds/current/requeue`.
+pub async fn enqueue_active_harnesses_for_round(
+    store: &dyn DesignStore,
+    rid: u64,
+    netuid: u16,
+    epoch: u64,
+) -> Result<EnqueueRoundResult, String> {
+    let harnesses = store
+        .list_active_harnesses(rid)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut out = EnqueueRoundResult::default();
+    for harness in &harnesses {
+        match schedule_harness_for_round(store, harness, rid, netuid, epoch, RunOrigin::Scheduled)
+            .await
+        {
+            Ok(run_ids) => {
+                out.scheduled
+                    .push((harness.id.clone(), harness.miner_hotkey.clone(), run_ids));
+            }
+            Err(e) => {
+                out.skipped
+                    .push((harness.id.clone(), harness.miner_hotkey.clone(), e));
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Schedule an active harness into `rid` (create missing queued runs).
 ///
 /// Idempotent: if runs for `(harness, round)` already exist, returns those ids.
@@ -1009,54 +1049,34 @@ struct RejectBody {
 
 /// Manually schedule every active harness into the CURRENT open round.
 ///
-/// Operator escape hatch when a round opened with no/few runs (e.g. challenge
-/// restart). Idempotent for the current round: `schedule_harness_for_round`
-/// returns the existing run ids for a `(harness, round)` pair that already has
-/// runs, so a repeated call creates nothing and consumes no quota. This is
-/// organizer work, so it draws on the scheduled cap, never on the miner's
-/// submission quota. Harnesses that fail scheduling are reported under
-/// `skipped`; one bad harness never blocks the rest.
+/// Ops escape hatch (challenge restart). Same path as the round-loop
+/// auto-enqueue; idempotent; scheduled-quota only. Failures land in `skipped`.
 async fn admin_requeue_current(State(st): State<Arc<AppState>>, headers: HeaderMap) -> Response {
     if let Err(r) = check_admin(&st, &headers) {
         return r;
     }
     let rid = round_id_at(now_secs());
-    let harnesses = match st.store.list_active_harnesses(rid).await {
-        Ok(h) => h,
-        Err(e) => return json_err(StatusCode::INTERNAL_SERVER_ERROR, "store", &e.to_string()),
-    };
     let epoch = st.epoch.load(std::sync::atomic::Ordering::Relaxed);
-    let mut scheduled = Vec::new();
-    let mut skipped = Vec::new();
-    for harness in &harnesses {
-        match schedule_harness_for_round(
-            st.store.as_ref(),
-            harness,
-            rid,
-            st.netuid,
-            epoch,
-            RunOrigin::Scheduled,
-        )
-        .await
-        {
-            Ok(run_ids) => scheduled.push(json!({
-                "harness_id": harness.id,
-                "miner_hotkey": harness.miner_hotkey,
-                "run_ids": run_ids,
-            })),
-            Err(e) => skipped.push(json!({
-                "harness_id": harness.id,
-                "miner_hotkey": harness.miner_hotkey,
-                "reason": e,
-            })),
-        }
-    }
-    Json(json!({
-        "round_id": rid,
-        "scheduled": scheduled,
-        "skipped": skipped,
-    }))
-    .into_response()
+    let result =
+        match enqueue_active_harnesses_for_round(st.store.as_ref(), rid, st.netuid, epoch).await {
+            Ok(r) => r,
+            Err(e) => return json_err(StatusCode::INTERNAL_SERVER_ERROR, "store", &e),
+        };
+    let scheduled: Vec<Value> = result
+        .scheduled
+        .into_iter()
+        .map(|(harness_id, miner_hotkey, run_ids)| {
+            json!({ "harness_id": harness_id, "miner_hotkey": miner_hotkey, "run_ids": run_ids })
+        })
+        .collect();
+    let skipped: Vec<Value> = result
+        .skipped
+        .into_iter()
+        .map(|(harness_id, miner_hotkey, reason)| {
+            json!({ "harness_id": harness_id, "miner_hotkey": miner_hotkey, "reason": reason })
+        })
+        .collect();
+    Json(json!({ "round_id": rid, "scheduled": scheduled, "skipped": skipped })).into_response()
 }
 
 async fn admin_candidates(
@@ -1617,6 +1637,56 @@ mod tests {
         assert_eq!(v["error"], "gone");
         // The stored HTML must not leak into the response body.
         assert!(!v.to_string().contains("miner"));
+    }
+
+    #[tokio::test]
+    async fn auto_enqueue_queues_all_active_same_prompt_idempotent() {
+        let (st, _g) = app_state(None);
+        let a = harness_row(&hk(0xAA), "a");
+        let b = harness_row(&hk(0xBB), "b");
+        let mut elim = harness_row(&hk(0xCC), "c");
+        let rid = round_id_at(now_secs());
+        elim.eliminated_until_round = rid + 5;
+        st.store.insert_harness(&a).await.unwrap();
+        st.store.insert_harness(&b).await.unwrap();
+        st.store.insert_harness(&elim).await.unwrap();
+
+        let first = enqueue_active_harnesses_for_round(st.store.as_ref(), rid, 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(first.scheduled.len(), 2, "{first:?}");
+        assert!(first.skipped.is_empty(), "{first:?}");
+        let runs = st.store.runs_for_round(rid).await.unwrap();
+        assert_eq!(runs.len(), 2 * design_challenge_task::prompts_per_round());
+        let prompts: BTreeMap<_, _> = runs
+            .iter()
+            .map(|r| (r.harness_id.clone(), r.prompt_id.clone()))
+            .collect();
+        assert_eq!(prompts.len(), 2);
+        let prompt_ids: std::collections::BTreeSet<_> = prompts.values().cloned().collect();
+        assert_eq!(prompt_ids.len(), 1, "all harnesses share the round prompt");
+
+        let again = enqueue_active_harnesses_for_round(st.store.as_ref(), rid, 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(again.scheduled.len(), 2);
+        let again_ids: Vec<_> = again
+            .scheduled
+            .iter()
+            .flat_map(|(_, _, ids)| ids.clone())
+            .collect();
+        let first_ids: Vec<_> = first
+            .scheduled
+            .iter()
+            .flat_map(|(_, _, ids)| ids.clone())
+            .collect();
+        assert_eq!(again_ids, first_ids, "idempotent: no duplicate runs");
+        assert_eq!(
+            st.store.runs_for_round(rid).await.unwrap().len(),
+            runs.len()
+        );
+        // Eliminated harness must not appear.
+        assert!(runs.iter().all(|r| r.harness_id != elim.id));
     }
 
     #[tokio::test]

--- a/crates/design-http/src/lib.rs
+++ b/crates/design-http/src/lib.rs
@@ -16,8 +16,8 @@ mod api;
 mod stats;
 
 pub use api::{
-    design_router, mark_awaiting, mark_awaiting_admin, record_epoch, schedule_harness_for_round,
-    AdminAwardHook, AppState,
+    design_router, enqueue_active_harnesses_for_round, mark_awaiting, mark_awaiting_admin,
+    record_epoch, schedule_harness_for_round, AdminAwardHook, AppState, EnqueueRoundResult,
 };
 pub use design_challenge_task::CHALLENGE_ID;
 pub use design_challenge_task::{

--- a/docs/DESIGN_CHALLENGE.md
+++ b/docs/DESIGN_CHALLENGE.md
@@ -115,7 +115,7 @@ proxy prefixes (`DESIGN_`, `HTTP_`, `PYTHON…`, …) are rejected. Values are
 `harness_id = sha256(base-design-submission-v1 || hotkey || agent || pyproject || extras || env)`.
 `POST /v1/harness` is idempotent on that digest.
 
-### Submission gating (1-max) + one attempt
+### Submission gating (1-max) + auto round enqueue
 
 - The miner hotkey must be **in the metagraph** (bulk cached snapshot, **15m**
   TTL fail-closed; no per-UID RPC on the request path). Unknown hotkey →
@@ -125,10 +125,14 @@ proxy prefixes (`DESIGN_`, `HTTP_`, `PYTHON…`, …) are rejected. Values are
   table). While the row is `registered` / `blocked` / `rejected`, a *different*
   harness from the same hotkey → `409 submission_gated`. The identical re-POST
   stays idempotent (`200 already-queued`).
-- **One sandbox attempt** per accepted harness: submit schedules
-  `round_id(now) + 1` once. The round loop does **not** auto-roll the harness
-  into later rounds. Infra auto-retry on the *same* run id (up to 3) is not a
-  new attempt. Ops may still `POST /v1/admin/rounds/current/requeue`.
+- **Auto round enqueue**: `POST /v1/harness` schedules the harness into
+  `round_id(now) + 1` ([`RunOrigin::Manual`]). On every subsequent open round
+  the orchestrator auto-enqueues the **latest active harness per hotkey** into
+  that round with the round's shared prompt ([`RunOrigin::Scheduled`]) —
+  idempotent if already queued. Eliminated harnesses
+  (`eliminated_until_round > rid`) are skipped. Infra auto-retry on the *same*
+  run id (up to 3) is not a new schedule. Ops may still
+  `POST /v1/admin/rounds/current/requeue` (same enqueue path).
 - **Auto-retry**: infra-class failures (`install`, `ast_infra`, `llm_infra`)
   requeue automatically up to **3** times; `cheat` / `rejected` / admin reject /
   unscored timeout are terminal. Budget exhaustion → `failed` + gating
@@ -335,7 +339,9 @@ docker compose -f docker-compose.yml -f deploy/compose/role-master.yml \
   `round_id = floor(unix_secs / 8640)`.
 - **Registration waits for the next round**: an accepted harness is scheduled
   into `round_id(now) + 1` and its runs only become claimable once that round
-  opens — never into the round already in flight.
+  opens — never into the round already in flight. After that, the round loop
+  **auto-enqueues** every eligible active harness into each newly opened round
+  (same shared prompt; Scheduled origin; idempotent).
 - **Agent run timeout**: `AGENT_RUN_TIMEOUT_SECS = 1_800` (30 minutes wall clock
   for the sandbox run phase — not the round length).
 - **Prompts**: repo-pinned bank (`bank_v1.json`, no human approval API);
@@ -347,12 +353,13 @@ docker compose -f docker-compose.yml -f deploy/compose/role-master.yml \
 
   | Bucket | Charged by | Cap | Override |
   |--------|-----------|-----|----------|
-  | Manual | `POST /v1/harness` (miner-initiated) | `MANUAL_DAILY_RUN_QUOTA = 10` | `DESIGN_MANUAL_DAILY_RUN_QUOTA` |
-  | Scheduled | Submit next-round schedule + `admin/rounds/current/requeue` | `rounds/day × prompts/round × SCHEDULED_DAILY_RUN_HEADROOM` (= **20** at 10 rounds × 1 prompt) | `DESIGN_SCHEDULED_DAILY_RUN_CAP` (clamped ≥ the day's own schedule) |
+  | Manual | `POST /v1/harness` (miner-initiated next-round schedule) | `MANUAL_DAILY_RUN_QUOTA = 10` | `DESIGN_MANUAL_DAILY_RUN_QUOTA` |
+  | Scheduled | Round-loop auto-enqueue + `admin/rounds/current/requeue` | `rounds/day × prompts/round × SCHEDULED_DAILY_RUN_HEADROOM` (= **20** at 10 rounds × 1 prompt) | `DESIGN_SCHEDULED_DAILY_RUN_CAP` (clamped ≥ the day's own schedule) |
 
   Enforcement is **per bucket**: exhausting manual submissions never stops the
   round scheduler, and the scheduled cap is a runaway-scheduler guard, not a
-  participation limit. `GET /v1/quota/{hotkey}` reports both.
+  participation limit (a harness active all day stays under the floor of
+  `scheduled_runs_per_day`). `GET /v1/quota/{hotkey}` reports both.
 - **Auto-retry**: infra-class failures (`install` / `ast_infra` / `llm_infra`)
   requeue up to 3 times (`DESIGN_AUTO_RETRY_MAX`), then terminal
   `NoScore(ChallengeInternal)` + gating `blocked`.
@@ -573,7 +580,7 @@ returns 403). Operators hit `design-challenge:8093` on the master host
 | `GET /v1/admin/rounds/{id}/candidates` | Clean `awaiting_admin` runs (pages + verdict) |
 | `POST /v1/admin/rounds/{id}/winners` | Body `{ "harness_ids": ["…"] }` length 1 or 2; awards + emits leaves |
 | `POST /v1/admin/rounds/{id}/reject` | Body `{ "harness_ids": ["…"], "reason": "…" }`; terminal `rejected` + miner-visible `reject_reason` on `GET /v1/runs/{id}`; gating closed until UID leave |
-| `POST /v1/admin/rounds/current/requeue` | Schedule all active harnesses into the **current** open round (ops escape hatch; idempotent per harness; quota-blocked harnesses reported under `skipped`) |
+| `POST /v1/admin/rounds/current/requeue` | Same enqueue path as the round loop: schedule all active harnesses into the **current** open round (ops escape hatch / restart; idempotent per harness; quota-blocked harnesses reported under `skipped`) |
 | `GET /v1/rounds/{id}/leaderboard` | Round ratings |
 
 ### Annotation (deprecated; unused on leaf path)

--- a/docs/external-miner/design.md
+++ b/docs/external-miner/design.md
@@ -105,36 +105,40 @@ Minimal `harness.json` shape:
 
 `POST /v1/harness` is **idempotent** on content digest (`harness_id`).
 
-## Submission gating (1-max) + one attempt
+## Submission gating (1-max) + auto round enqueue
 
 - Your hotkey must be **registered on the subnet** (metagraph). Unknown hotkey
   → `403 hotkey_not_in_metagraph`. Intake uses a bulk metagraph cache with a
   **15 minute** fail-closed TTL (`503 metagraph_unavailable` → retry shortly).
-- **One accepted submission per hotkey** and **one sandbox attempt** for that
-  submission. While yours is `registered` / `blocked` / `rejected`, a
-  *different* harness gets `409 submission_gated`. Re-POSTing the **identical**
-  bundle is always safe (idempotent `200 already-queued`).
-- After your attempt finishes (score, cheat, admin reject, or unscored
-  timeout), you cannot submit again on the same hotkey until that hotkey
-  **leaves the metagraph** and you register a **new UID** (same hotkey is fine).
-- Infra auto-retries on the *same* run id (up to 3) are not a new attempt.
+- **One accepted submission per hotkey**. While yours is `registered` /
+  `blocked` / `rejected`, a *different* harness gets `409 submission_gated`.
+  Re-POSTing the **identical** bundle is always safe (idempotent
+  `200 already-queued`).
+- After a **terminal** outcome that closes gating (cheat / admin reject /
+  unscored timeout / budget exhaustion), you cannot submit a **new** digest on
+  the same hotkey until that hotkey **leaves the metagraph** and you register a
+  **new UID** (same hotkey is fine).
+- Infra auto-retries on the *same* run id (up to 3) are not a new schedule.
 - `env_vars` are **locked at submission**; changing them means a new digest,
   which requires a free slot.
 
 ## Quotas and rounds
 
 - **10 rounds per UTC day** (`ROUND_SECS = 8640`; `round_id = floor(unix / 8640)`).
-- An accepted harness **waits for the next round**: runs are scheduled into
-  `round_id + 1` and start when that round opens, never mid-round. You are
-  **not** auto-scheduled into later rounds.
+- An accepted harness **waits for the next round**: your `POST /v1/harness`
+  schedules into `round_id + 1` (never mid-round). After that, the organizer
+  **auto-enqueues your latest active harness every open round** with that
+  round's **shared prompt** — you do **not** need to re-POST to keep competing.
+  Eliminated miners are skipped until their cooldown ends.
 - Sandbox **run** timeout is **30 minutes** (`AGENT_RUN_TIMEOUT_SECS = 1800`).
 - Each round picks **1 shared prompt** for every harness
   (`PROMPTS_PER_ROUND = 1`).
 - Daily run quota is **split by origin**:
-  - **Manual** — **10** runs/day, charged only by your own `POST /v1/harness`.
-  - **Scheduled** — organizer next-round schedule / ops requeue (10 rounds × 1
+  - **Manual** — **10** runs/day, charged only by your own `POST /v1/harness`
+    (the initial next-round schedule).
+  - **Scheduled** — round-loop auto-enqueue / ops requeue (10 rounds × 1
     prompt = **10** runs; cap **20**). You never spend manual quota by being
-    scheduled.
+    auto-queued.
 - Infra failures (package install, review/LLM infra) **auto-retry up to 3
   times**; cheat / rejected / admin reject / unscored timeout are terminal.
   Manual retry of a failed run: `POST /v1/runs/{id}/retry`.

--- a/docs/external-miner/troubleshoot.md
+++ b/docs/external-miner/troubleshoot.md
@@ -9,7 +9,8 @@
 | Symptom | Likely cause | What to check |
 |---------|--------------|---------------|
 | `400` on `POST /v1/harness` | Invalid bundle | `agent.py` defines `run`, `pyproject.toml` non-empty, size limits |
-| `409 schedule` "daily manual run quota exceeded" | Manual anti-spam cap (10/day) — being scheduled into rounds does **not** spend it | `GET /v1/quota/{hotkey}` → `manual.remaining`; wait until next UTC day |
+| `409 schedule` "daily manual run quota exceeded" | Manual anti-spam cap (10/day) — round-loop auto-enqueue does **not** spend it | `GET /v1/quota/{hotkey}` → `manual.remaining`; wait until next UTC day |
+| Active harness but no runs this round | Rare race / restart before auto-enqueue; or eliminated cooldown | Wait for the round tick / ask ops `admin/rounds/current/requeue`; check `eliminated_until_round` |
 | `auto_retry` events, class `install` | Dep won't install (bad name/version, heavy source build) | `GET /v1/runs/{id}/logs` phase `install`; fix `pyproject.toml` deps |
 | Run `failed` / Score 0 | Missing pages, timeout, crash | `GET /v1/runs/{id}/events`; ensure three required HTML pages |
 | External call refused (`403`) | Target is internal-blocklisted (metadata IP, loopback, RFC1918/VPC, control plane) | Call public endpoints only; egress is otherwise open |


### PR DESCRIPTION
## Summary
- Round loop now auto-enqueues every eligible active harness (latest per hotkey) into each open round with that round’s shared prompt (`RunOrigin::Scheduled`), idempotent if already queued.
- Eliminated harnesses stay skipped; daily scheduled quota remains the runaway-scheduler guard (manual `POST /v1/harness` still charges the manual bucket for the initial next-round schedule).
- Admin `POST /v1/admin/rounds/current/requeue` shares the same enqueue helper; miner-facing docs (`DESIGN_CHALLENGE.md`, `docs/external-miner/`) updated for the new behavior.

## Test plan
- [x] `cargo test -p design-http --lib` (includes `auto_enqueue_queues_all_active_same_prompt_idempotent`)
- [x] `cargo clippy -p design-http -p design-challenge --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- loc-cap` / `design-check` / `external-docs-check`
- [ ] CI green on PR
- [ ] After merge: public [`design-challenge`](https://github.com/BaseIntelligence/design-challenge) miner docs updated in parallel (rounds auto-enqueue wording)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active harnesses are now automatically scheduled when each new round opens.
  * Automatic scheduling supports retries, skips eliminated harnesses, and avoids duplicate runs.
  * Manual requeueing uses the same scheduling behavior as automatic round processing.
  * Submission and scheduled-execution quotas are now handled separately.

* **Documentation**
  * Clarified scheduling rules, quota behavior, retries, cooldowns, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->