### PR TITLE
feat(site): enrich prism board with detail, eras, and gpt-2 refs

### DIFF
--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -10,6 +10,10 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::prism_enrich::{
+    enrich_leaderboard_row_from_detail, enrich_submission_from_detail, pin_id_from_payload,
+    prism_reference_baselines, prism_submission_detail,
+};
 use crate::state::SiteState;
 use crate::upstream::{self, DESIGN, PRISM};
 use site_data::map::{
@@ -41,6 +45,14 @@ pub fn site_router(state: SiteState) -> Router {
             get(get_results_matrix),
         )
         .route("/v1/site/arenas/prism/window", get(get_prism_window))
+        .route(
+            "/v1/site/arenas/prism/references",
+            get(get_prism_references),
+        )
+        .route(
+            "/v1/site/arenas/prism/submissions/{id}",
+            get(get_prism_submission_detail),
+        )
         .route(
             "/v1/site/arenas/prism/submissions/{id}/telemetry",
             get(get_prism_submission_telemetry),
@@ -422,6 +434,20 @@ async fn prism_leaderboard_json(
         .cloned()
         .unwrap_or_default();
     let mut board = prism_bpb_leaderboard(&rows, epoch);
+    // Fan out detail for top champions so era / G1–G8 / G2 benches fill in.
+    let mut ids: Vec<String> = board
+        .iter()
+        .filter_map(|r| r.submission_id.clone())
+        .collect();
+    ids.truncate(PRISM_CHAMPION_DETAIL_FANOUT);
+    let details = fetch_prism_details(st, &ids).await;
+    for row in &mut board {
+        if let Some(id) = row.submission_id.as_ref() {
+            if let Some(detail) = details.get(id) {
+                enrich_leaderboard_row_from_detail(row, detail);
+            }
+        }
+    }
     decorate_leaderboard(st, &mut board);
     if let Some(needle) = q.filter(|s| !s.trim().is_empty()) {
         board.retain(|r| leaderboard_matches_query(r, needle));
@@ -437,6 +463,34 @@ async fn prism_leaderboard_json(
         "metric": "bpb",
         "updatedAt": now_iso(),
     })
+}
+
+/// Fetch bounded challenge detail payloads keyed by submission id.
+async fn fetch_prism_details(st: &SiteState, ids: &[String]) -> HashMap<String, Value> {
+    let mut out = HashMap::new();
+    for id in ids {
+        if id.is_empty() {
+            continue;
+        }
+        if let Some(mut detail) =
+            upstream::get_json_opt(st, PRISM, &format!("/v1/submissions/{id}")).await
+        {
+            // Optional /diff for pin_id when detail alone lacks era signals.
+            if pin_id_from_payload(&detail).is_none() {
+                if let Some(diff) =
+                    upstream::get_json_opt(st, PRISM, &format!("/v1/submissions/{id}/diff")).await
+                {
+                    if let Some(pin) = diff.get("pin_id").and_then(Value::as_str) {
+                        if let Some(obj) = detail.as_object_mut() {
+                            obj.insert("pin_id".into(), json!(pin));
+                        }
+                    }
+                }
+            }
+            out.insert(id.clone(), detail);
+        }
+    }
+    out
 }
 
 async fn get_leaderboard(
@@ -494,6 +548,14 @@ async fn get_submissions(
                 .filter(|r| is_prism_champion_submission(r))
                 .filter_map(prism_submission)
                 .collect();
+            let mut ids: Vec<String> = items.iter().map(|s| s.id.clone()).collect();
+            ids.truncate(PRISM_CHAMPION_DETAIL_FANOUT);
+            let details = fetch_prism_details(&st, &ids).await;
+            for item in &mut items {
+                if let Some(detail) = details.get(&item.id) {
+                    enrich_submission_from_detail(item, detail);
+                }
+            }
             decorate_submissions(&st, &mut items);
             if let Some(st_f) = status_filter {
                 items.retain(|s| match st_f {
@@ -599,6 +661,9 @@ async fn get_results_matrix() -> impl IntoResponse {
 /// Max per-submission detail fetches the window fans out for loss curves.
 const PRISM_WINDOW_TELEMETRY_FANOUT: usize = 8;
 
+/// Max champion detail fetches for board/list era + benchmark columns.
+const PRISM_CHAMPION_DETAIL_FANOUT: usize = 24;
+
 async fn get_prism_window(State(st): State<SiteState>) -> impl IntoResponse {
     let recipe = fetch_prism_recipe(&st).await;
     let status = fetch_prism_status(&st).await;
@@ -656,6 +721,46 @@ async fn get_prism_submission_telemetry(
             "unknown prism submission",
         ),
     }
+}
+
+/// Public Prism submission detail (era, eval groups, benches, telemetry).
+async fn get_prism_submission_detail(
+    State(st): State<SiteState>,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(mut detail) =
+        upstream::get_json_opt(&st, PRISM, &format!("/v1/submissions/{id}")).await
+    else {
+        return json_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "unknown prism submission",
+        );
+    };
+    if pin_id_from_payload(&detail).is_none() {
+        if let Some(diff) =
+            upstream::get_json_opt(&st, PRISM, &format!("/v1/submissions/{id}/diff")).await
+        {
+            if let Some(pin) = diff.get("pin_id").and_then(Value::as_str) {
+                if let Some(obj) = detail.as_object_mut() {
+                    obj.insert("pin_id".into(), json!(pin));
+                }
+            }
+        }
+    }
+    match prism_submission_detail(&detail) {
+        Some(d) => Json(d).into_response(),
+        None => json_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "unknown prism submission",
+        ),
+    }
+}
+
+/// Frozen public GPT-2 literature baselines (not miner submissions).
+async fn get_prism_references() -> impl IntoResponse {
+    Json(prism_reference_baselines())
 }
 
 async fn get_validators(
@@ -900,13 +1005,17 @@ mod tests {
                     "label": "base",
                     "bpb": 1.25,
                     "n_params": 12_000_000_u64,
+                    "score": {"kind":"score","value": 900},
                     "metrics": {
+                        "recipe": "2.0.0",
                         "bpb": 1.25,
                         "tokens_seen": 2048,
                         "wall_clock_seconds": 12.0,
                         "gpu_type": "SIM",
                         "n_params": 12_000_000_u64,
                         "val_rows": 256,
+                        "org.g2.hellaswag_acc": {"value": 0.31},
+                        "org.g2.piqa_acc": {"value": 0.62},
                         "telemetry": {
                             "finish_reason": "finish_evaluation",
                             "report_count": 5,
@@ -916,9 +1025,33 @@ mod tests {
                                 {"step": 3, "loss": 2.5, "grad_norm": 0.33, "at_secs": 6.0}
                             ]
                         }
+                    },
+                    "eval": {
+                        "status": "scored",
+                        "composite": 0.55,
+                        "scoring_mode": "shadow",
+                        "gates": {
+                            "complete": true, "g3_ok": true, "g8_ok": true,
+                            "budgets_ok": true, "ci_ok": true
+                        },
+                        "groups": [
+                            {"group":"g1","g":0.8},
+                            {"group":"g2","g":0.4}
+                        ]
                     }
                 },
                 "events": []
+            })))
+            .mount(prism)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/submissions/sub1/diff"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "submission_id": "sub1",
+                "pin_id": "automodel@v0.5.0",
+                "patch": "diff --git a/x b/x\n",
+                "diffstat": {"files": [{"path":"x","added":1,"deleted":0,"class":"arch"}],
+                             "total_added": 1, "total_deleted": 0}
             })))
             .mount(prism)
             .await;
@@ -1034,6 +1167,47 @@ mod tests {
                 .any(|m| m.contains("Design evaluated") || m.contains("winner")),
             "{msgs:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn prism_detail_references_and_era_enrichment() {
+        let (design, prism, st) = setup().await;
+        mount_site_mocks(&design, &prism).await;
+        let app = site_router(st);
+
+        let (s, v) = call(app.clone(), "/v1/site/arenas/prism/submissions").await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v["items"][0]["recipeEra"], "automodel");
+        assert_eq!(v["items"][0]["pinId"], "automodel@v0.5.0");
+        assert_eq!(v["items"][0]["benchmarks"]["hellaswag"], 0.31);
+        assert_eq!(v["items"][0]["evalGroups"].as_array().unwrap().len(), 2);
+
+        let (s, v) = call(app.clone(), "/v1/site/arenas/prism/leaderboard").await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v["items"][0]["submissionId"], "sub1");
+        assert_eq!(v["items"][0]["recipeEra"], "automodel");
+        assert_eq!(v["items"][0]["benchmarks"]["piqa"], 0.62);
+
+        let (s, v) = call(app.clone(), "/v1/site/arenas/prism/submissions/sub1").await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v["id"], "sub1");
+        assert_eq!(v["recipeEra"], "automodel");
+        assert_eq!(v["pinId"], "automodel@v0.5.0");
+        assert_eq!(v["eval"]["status"], "scored");
+        assert_eq!(v["eval"]["groups"].as_array().unwrap().len(), 2);
+        assert_eq!(v["telemetry"]["reportCount"], 5);
+        assert!(v.get("patch").is_none());
+
+        let (s, v) = call(app.clone(), "/v1/site/arenas/prism/references").await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["id"], "gpt2-small-124m");
+        assert_eq!(v[0]["paramsM"], 124.0);
+        assert!(v[0].get("bpb").is_none());
+        assert!(v[0]["disclaimer"].as_str().unwrap().contains("not a Prism"));
+
+        let (s, v) = call(app, "/v1/site/arenas/prism/submissions/nope").await;
+        assert_eq!(s, StatusCode::NOT_FOUND, "{v}");
     }
 
     #[tokio::test]

--- a/crates/site-api/src/lib.rs
+++ b/crates/site-api/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::doc_markdown)]
 
 mod handlers;
+mod prism_enrich;
 mod state;
 mod upstream;
 

--- a/crates/site-api/src/prism_enrich.rs
+++ b/crates/site-api/src/prism_enrich.rs
@@ -1,0 +1,436 @@
+//! Prism list/detail enrichment: recipe era, eval groups, G2 benches, GPT-2 refs.
+
+use serde_json::Value;
+
+use site_types::{
+    EvalGroupScore, PrismBenchmarks, PrismEvalSummary, PrismGateSummary, PrismPublicReview,
+    PrismPublicSimilarity, PrismReferenceBaseline, PrismSubmissionDetail, PrismTelemetry,
+    RecipeEra, Submission,
+};
+
+use site_data::map::{prism_submission, prism_telemetry};
+use site_types::LeaderboardRow;
+
+/// EleutherAI lm-evaluation-harness (canonical published GPT-2 Small table).
+pub const GPT2_SOURCE_URL: &str = "https://github.com/EleutherAI/lm-evaluation-harness";
+
+/// Public disclaimer for the GPT-2 reference row.
+pub const GPT2_DISCLAIMER: &str = "Public GPT-2 Small (124M) — literature / Eleuther-style numbers; not a Prism-protocol run. BPB omitted: published GPT-2 bit-per-byte figures are not comparable to Prism validation BPB.";
+
+/// GPT-2 Small parameter count (millions).
+pub const GPT2_SMALL_PARAMS_M: f64 = 124.0;
+
+/// HellaSwag `acc_norm` for gpt2 (Eleuther harness; commonly cited 31.14%).
+pub const GPT2_HELLASWAG: f64 = 0.3114;
+/// ARC-Challenge `acc_norm` (zero-shot Eleuther-style gpt2).
+pub const GPT2_ARC_CHALLENGE: f64 = 0.2270;
+/// PIQA `acc_norm` (zero-shot Eleuther-style gpt2).
+pub const GPT2_PIQA: f64 = 0.6251;
+/// WinoGrande `acc` (zero-shot Eleuther-style gpt2).
+pub const GPT2_WINOGRANDE: f64 = 0.5162;
+/// BoolQ `acc` (zero-shot Eleuther-style gpt2).
+pub const GPT2_BOOLQ: f64 = 0.6012;
+
+/// Frozen public GPT-2 baseline(s) for `GET …/references`.
+#[must_use]
+pub fn prism_reference_baselines() -> Vec<PrismReferenceBaseline> {
+    vec![PrismReferenceBaseline {
+        id: "gpt2-small-124m".into(),
+        label: "Public GPT-2 Small (124M)".into(),
+        params_m: GPT2_SMALL_PARAMS_M,
+        bpb: None,
+        benchmarks: PrismBenchmarks {
+            hellaswag: Some(GPT2_HELLASWAG),
+            arc_challenge: Some(GPT2_ARC_CHALLENGE),
+            piqa: Some(GPT2_PIQA),
+            winogrande: Some(GPT2_WINOGRANDE),
+            boolq: Some(GPT2_BOOLQ),
+        },
+        source_url: GPT2_SOURCE_URL.into(),
+        disclaimer: GPT2_DISCLAIMER.into(),
+    }]
+}
+
+/// Infer AutoModel vs legacy from a detail or list-shaped payload.
+///
+/// Signals (first match wins as automodel): explicit `pin_id`, AutoModel pin
+/// id string, recipe major ≥ 2 in metrics / pod manifest, or `.prism`
+/// automodel artifact paths. Otherwise legacy (incl. unknown / pre-2.0).
+#[must_use]
+pub fn infer_recipe_era(payload: &Value) -> RecipeEra {
+    let sub = payload.get("submission").unwrap_or(payload);
+    if pin_id_from_payload(payload).is_some() {
+        return RecipeEra::Automodel;
+    }
+    if recipe_major(sub).is_some_and(|m| m >= 2) {
+        return RecipeEra::Automodel;
+    }
+    // Diff / tree hints when present on a fan-in blob.
+    if payload
+        .pointer("/diffstat/files")
+        .and_then(Value::as_array)
+        .is_some_and(|a| !a.is_empty())
+    {
+        return RecipeEra::Automodel;
+    }
+    RecipeEra::Legacy
+}
+
+/// AutoModel pin id from detail, `/diff`, or metrics pod manifest.
+#[must_use]
+pub fn pin_id_from_payload(payload: &Value) -> Option<String> {
+    let sub = payload.get("submission").unwrap_or(payload);
+    for path in [
+        "/pin_id",
+        "/submission/pin_id",
+        "/metrics/pod_manifest/automodel_base",
+        "/metrics/pod_manifest/pin_id",
+        "/submission/metrics/pod_manifest/automodel_base",
+        "/submission/metrics/pod_manifest/pin_id",
+    ] {
+        if let Some(p) = payload
+            .pointer(path)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && s.starts_with("automodel@"))
+        {
+            return Some(p.to_owned());
+        }
+    }
+    sub.get("pin_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+/// Map `eval.groups` → compact `{group,g}` rows (sorted g1…g8 when possible).
+#[must_use]
+pub fn map_eval_groups(eval: Option<&Value>) -> Option<Vec<EvalGroupScore>> {
+    let groups = eval?.get("groups")?.as_array()?;
+    let mut out: Vec<EvalGroupScore> = groups
+        .iter()
+        .filter_map(|g| {
+            let group = g.get("group")?.as_str()?.to_owned();
+            let score = g.get("g").and_then(Value::as_f64)?;
+            Some(EvalGroupScore { group, g: score })
+        })
+        .collect();
+    if out.is_empty() {
+        return None;
+    }
+    out.sort_by(|a, b| a.group.cmp(&b.group));
+    Some(out)
+}
+
+/// Public G2 benches from harness `metrics` (`org.g2.*` or battery g2 keys).
+#[must_use]
+pub fn map_benchmarks(metrics: Option<&Value>) -> PrismBenchmarks {
+    let Some(metrics) = metrics.filter(|m| !m.is_null()) else {
+        return PrismBenchmarks::default();
+    };
+    PrismBenchmarks {
+        hellaswag: metric_f64(metrics, &["org.g2.hellaswag_acc", "g2.hellaswag.acc_norm"]),
+        arc_challenge: metric_f64(
+            metrics,
+            &["org.g2.arc_challenge_acc", "g2.arc_challenge.acc_norm"],
+        ),
+        piqa: metric_f64(metrics, &["org.g2.piqa_acc", "g2.piqa.acc_norm"]),
+        winogrande: metric_f64(metrics, &["org.g2.winogrande_acc", "g2.winogrande.acc"]),
+        boolq: metric_f64(metrics, &["org.g2.boolq_acc", "g2.boolq.acc"]),
+    }
+}
+
+/// Copy era / pin / eval groups / benches from a detail payload onto a board row.
+pub fn enrich_leaderboard_row_from_detail(row: &mut LeaderboardRow, detail: &Value) {
+    let root = detail.get("submission").unwrap_or(detail);
+    let era = infer_recipe_era(detail);
+    row.recipe_era = Some(era);
+    if era == RecipeEra::Automodel {
+        row.pin_id = pin_id_from_payload(detail);
+    }
+    if let Some(groups) = map_eval_groups(root.get("eval").filter(|e| !e.is_null())) {
+        row.eval_groups = Some(groups);
+    }
+    let benches = map_benchmarks(root.get("metrics").filter(|m| !m.is_null()));
+    if !benches.is_empty() {
+        row.benchmarks = Some(benches);
+    }
+}
+
+/// Apply detail fan-out fields onto a list [`Submission`].
+pub fn enrich_submission_from_detail(sub: &mut Submission, detail: &Value) {
+    let root = detail.get("submission").unwrap_or(detail);
+    let era = infer_recipe_era(detail);
+    sub.recipe_era = Some(era);
+    let pin = pin_id_from_payload(detail);
+    if era == RecipeEra::Automodel {
+        sub.pin_id = pin;
+    }
+    let eval = root.get("eval").filter(|e| !e.is_null());
+    if let Some(groups) = map_eval_groups(eval) {
+        sub.eval_groups = Some(groups);
+    }
+    let metrics = root.get("metrics").filter(|m| !m.is_null());
+    let benches = map_benchmarks(metrics);
+    if !benches.is_empty() {
+        sub.benchmarks = Some(benches);
+    }
+    // Prefer measured params / bpb from detail when the list row was thin.
+    if sub.bpb.is_none() {
+        sub.bpb = root
+            .get("bpb")
+            .and_then(Value::as_f64)
+            .or_else(|| metrics.and_then(|m| m.get("bpb")).and_then(Value::as_f64));
+    }
+    if sub.params_m.is_none() {
+        sub.params_m = root
+            .get("n_params")
+            .and_then(Value::as_u64)
+            .or_else(|| {
+                metrics
+                    .and_then(|m| m.get("n_params"))
+                    .and_then(Value::as_u64)
+            })
+            .map(|p| p as f64 / 1e6);
+    }
+}
+
+/// Map challenge `GET /v1/submissions/{id}` → public [`PrismSubmissionDetail`].
+#[must_use]
+pub fn prism_submission_detail(detail: &Value) -> Option<PrismSubmissionDetail> {
+    let root = detail.get("submission")?;
+    let mut sub = prism_submission(root)?;
+    enrich_submission_from_detail(&mut sub, detail);
+    let eval = root
+        .get("eval")
+        .filter(|e| !e.is_null())
+        .map(map_eval_summary);
+    let telemetry = prism_telemetry(detail).unwrap_or_else(|| PrismTelemetry {
+        submission_id: sub.id.clone(),
+        bpb: sub.bpb,
+        n_params: sub.params_m.map(|m| (m * 1e6) as u64),
+        val_rows: None,
+        gpu_type: None,
+        wall_clock_seconds: None,
+        finish_reason: None,
+        report_count: 0,
+        points: Vec::new(),
+    });
+    let review = root
+        .get("review")
+        .filter(|r| !r.is_null())
+        .map(|r| PrismPublicReview {
+            quality_score: r.get("quality_score").and_then(Value::as_f64),
+        });
+    let similarity = root
+        .get("similarity")
+        .filter(|s| !s.is_null())
+        .and_then(|s| {
+            let kind = s.get("kind")?.as_str()?.to_owned();
+            Some(PrismPublicSimilarity {
+                kind,
+                score: s.get("score").and_then(Value::as_f64),
+            })
+        });
+    Some(PrismSubmissionDetail {
+        submission: sub,
+        eval,
+        telemetry,
+        review,
+        similarity,
+    })
+}
+
+fn map_eval_summary(eval: &Value) -> PrismEvalSummary {
+    let status = eval
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned();
+    let groups = map_eval_groups(Some(eval)).unwrap_or_default();
+    let gates = eval.get("gates").and_then(|g| {
+        Some(PrismGateSummary {
+            complete: g.get("complete")?.as_bool()?,
+            g3_ok: g.get("g3_ok")?.as_bool()?,
+            g8_ok: g.get("g8_ok")?.as_bool()?,
+            budgets_ok: g.get("budgets_ok")?.as_bool()?,
+            ci_ok: g.get("ci_ok")?.as_bool()?,
+        })
+    });
+    PrismEvalSummary {
+        status,
+        groups,
+        gates,
+        composite: eval.get("composite").and_then(Value::as_f64),
+        scoring_mode: eval
+            .get("scoring_mode")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        eval_tier: eval
+            .get("eval_tier")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+    }
+}
+
+fn recipe_major(sub: &Value) -> Option<u32> {
+    let raw = sub
+        .pointer("/metrics/recipe")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            sub.pointer("/metrics/pod_manifest/recipe_version")
+                .and_then(Value::as_str)
+        })?;
+    raw.split('.').next()?.parse().ok()
+}
+
+fn metric_f64(metrics: &Value, keys: &[&str]) -> Option<f64> {
+    for key in keys {
+        if let Some(v) = lookup_metric(metrics, key) {
+            return Some(v);
+        }
+        // Nested under battery.groups.g2.metrics
+        if let Some(v) = metrics
+            .pointer(&format!("/battery/groups/g2/metrics/{key}"))
+            .and_then(as_f64_val)
+        {
+            return Some(v);
+        }
+        if let Some(v) = metrics
+            .pointer(&format!("/battery/metrics/{key}"))
+            .and_then(as_f64_val)
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn lookup_metric(metrics: &Value, key: &str) -> Option<f64> {
+    let v = metrics.get(key)?;
+    as_f64_val(v).or_else(|| v.get("value").and_then(as_f64_val))
+}
+
+fn as_f64_val(v: &Value) -> Option<f64> {
+    v.as_f64()
+        .or_else(|| v.as_u64().map(|u| u as f64))
+        .or_else(|| v.as_i64().map(|i| i as f64))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn era_from_recipe_major_and_pin() {
+        let legacy = json!({"metrics": {"recipe": "1.4.0"}});
+        assert_eq!(infer_recipe_era(&legacy), RecipeEra::Legacy);
+        let auto = json!({"metrics": {"recipe": "2.0.0"}});
+        assert_eq!(infer_recipe_era(&auto), RecipeEra::Automodel);
+        let pin = json!({"pin_id": "automodel@v0.5.0"});
+        assert_eq!(infer_recipe_era(&pin), RecipeEra::Automodel);
+        assert_eq!(
+            pin_id_from_payload(&pin).as_deref(),
+            Some("automodel@v0.5.0")
+        );
+    }
+
+    #[test]
+    fn benchmarks_from_org_g2_and_battery() {
+        let m = json!({
+            "org.g2.hellaswag_acc": {"value": 0.31},
+            "org.g2.piqa_acc": {"value": 0.62},
+            "battery": {"groups": {"g2": {"metrics": {
+                "g2.arc_challenge.acc_norm": 0.22,
+                "g2.winogrande.acc": 0.51,
+                "g2.boolq.acc": 0.60
+            }}}}
+        });
+        let b = map_benchmarks(Some(&m));
+        assert!((b.hellaswag.unwrap() - 0.31).abs() < f64::EPSILON);
+        assert!((b.piqa.unwrap() - 0.62).abs() < f64::EPSILON);
+        assert!((b.arc_challenge.unwrap() - 0.22).abs() < f64::EPSILON);
+        assert!((b.winogrande.unwrap() - 0.51).abs() < f64::EPSILON);
+        assert!((b.boolq.unwrap() - 0.60).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn eval_groups_sorted() {
+        let eval = json!({"groups": [
+            {"group": "g2", "g": 0.5},
+            {"group": "g1", "g": 0.9}
+        ]});
+        let g = map_eval_groups(Some(&eval)).unwrap();
+        assert_eq!(g[0].group, "g1");
+        assert_eq!(g[1].group, "g2");
+    }
+
+    #[test]
+    fn gpt2_baseline_has_no_prism_bpb() {
+        let refs = prism_reference_baselines();
+        assert_eq!(refs.len(), 1);
+        assert!(refs[0].bpb.is_none());
+        assert!((refs[0].params_m - 124.0).abs() < f64::EPSILON);
+        assert!((refs[0].benchmarks.hellaswag.unwrap() - GPT2_HELLASWAG).abs() < f64::EPSILON);
+        assert!(refs[0].disclaimer.contains("not a Prism-protocol"));
+    }
+
+    #[test]
+    fn detail_maps_public_subset() {
+        let detail = json!({
+            "submission": {
+                "id": "sub1",
+                "miner_hotkey": "bb".repeat(32),
+                "epoch": 3,
+                "status": "terminated",
+                "label": "base",
+                "bpb": 1.25,
+                "n_params": 12_000_000_u64,
+                "score": {"kind":"score","value": 900},
+                "created_at_ms": 1_700_000_000_000_u64,
+                "pin_id": "automodel@v0.5.0",
+                "metrics": {
+                    "recipe": "2.0.0",
+                    "bpb": 1.25,
+                    "n_params": 12_000_000_u64,
+                    "org.g2.hellaswag_acc": {"value": 0.4},
+                    "telemetry": {
+                        "finish_reason": "finish_evaluation",
+                        "report_count": 1,
+                        "loss_series": [{"step": 1, "loss": 2.0}]
+                    }
+                },
+                "eval": {
+                    "status": "scored",
+                    "composite": 0.55,
+                    "scoring_mode": "shadow",
+                    "gates": {
+                        "complete": true, "g3_ok": true, "g8_ok": true,
+                        "budgets_ok": true, "ci_ok": true
+                    },
+                    "groups": [{"group":"g1","g":0.8},{"group":"g2","g":0.4}]
+                },
+                "review": {"quality_score": 0.9, "issues": ["x"]},
+                "similarity": {"kind": "Clean", "score": 0.1, "evidence": "secret"}
+            },
+            "events": []
+        });
+        let d = prism_submission_detail(&detail).unwrap();
+        assert_eq!(d.submission.recipe_era, Some(RecipeEra::Automodel));
+        assert_eq!(d.submission.pin_id.as_deref(), Some("automodel@v0.5.0"));
+        assert!((d.submission.benchmarks.as_ref().unwrap().hellaswag.unwrap() - 0.4).abs() < 1e-9);
+        assert_eq!(d.eval.as_ref().unwrap().status, "scored");
+        assert_eq!(d.eval.as_ref().unwrap().groups.len(), 2);
+        assert!(d.eval.as_ref().unwrap().gates.as_ref().unwrap().complete);
+        assert_eq!(d.telemetry.points.len(), 1);
+        assert!((d.review.as_ref().unwrap().quality_score.unwrap() - 0.9).abs() < 1e-9);
+        assert_eq!(d.similarity.as_ref().unwrap().kind, "Clean");
+        // No raw patch / evidence dumps on the public contract.
+        let v = serde_json::to_value(&d).unwrap();
+        assert!(v.get("patch").is_none());
+        assert!(v.pointer("/similarity/evidence").is_none());
+    }
+}

--- a/crates/site-data/src/map.rs
+++ b/crates/site-data/src/map.rs
@@ -392,6 +392,11 @@ pub fn design_leaderboard(
                 params_m: None,
                 weight: None,
                 tao_per_day: None,
+                submission_id: None,
+                recipe_era: None,
+                pin_id: None,
+                eval_groups: None,
+                benchmarks: None,
             },
         )
         .collect()
@@ -415,6 +420,7 @@ fn run_screenshot_url(run_id: &str, run_detail: Option<&Value>) -> Option<String
 }
 
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn design_submission(
     run: &Value,
     miner_hotkey: &str,
@@ -524,6 +530,10 @@ pub fn design_submission(
             None
         },
         submitted_at: ms_to_iso(ms),
+        recipe_era: None,
+        pin_id: None,
+        eval_groups: None,
+        benchmarks: None,
     })
 }
 
@@ -598,6 +608,10 @@ pub fn prism_submission(row: &Value) -> Option<Submission> {
         params_m,
         failure_reason,
         submitted_at: ms_to_iso(ms),
+        recipe_era: None,
+        pin_id: None,
+        eval_groups: None,
+        benchmarks: None,
     })
 }
 
@@ -619,10 +633,11 @@ pub fn is_prism_champion_submission(row: &Value) -> bool {
 /// Non-top submissions are hidden from the public board. `elo` carries the BPB
 /// value so the existing leaderboard row contract can surface rankings without
 /// inventing Elo/duels; `bpb` / `paramsM` mirror the measured values explicitly
-/// for telemetry-aware clients.
+/// for telemetry-aware clients. `submissionId` is the best-BPB champion row so
+/// clients can open the detail modal; era / benches are filled by detail fan-out.
 #[must_use]
 pub fn prism_bpb_leaderboard(subs: &[Value], epoch: u64) -> Vec<LeaderboardRow> {
-    let mut best: HashMap<String, (f64, Option<u64>)> = HashMap::new();
+    let mut best: HashMap<String, (f64, Option<u64>, String)> = HashMap::new();
     let mut counts: HashMap<String, u32> = HashMap::new();
     for row in subs {
         if row.get("status").and_then(Value::as_str) != Some("terminated") {
@@ -635,6 +650,11 @@ pub fn prism_bpb_leaderboard(subs: &[Value], epoch: u64) -> Vec<LeaderboardRow> 
             continue;
         };
         let n_params = row.get("n_params").and_then(Value::as_u64);
+        let id = row
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
         let hk = row
             .get("miner_hotkey")
             .and_then(Value::as_str)
@@ -642,38 +662,46 @@ pub fn prism_bpb_leaderboard(subs: &[Value], epoch: u64) -> Vec<LeaderboardRow> 
             .to_owned();
         *counts.entry(hk.clone()).or_insert(0) += 1;
         best.entry(hk)
-            .and_modify(|(b, p)| {
+            .and_modify(|(b, p, sid)| {
                 if bpb < *b {
                     *b = bpb;
                     *p = n_params;
+                    sid.clone_from(&id);
                 }
             })
-            .or_insert((bpb, n_params));
+            .or_insert((bpb, n_params, id));
     }
-    let mut rows: Vec<(f64, String, u32, Option<u64>)> = best
+    let mut rows: Vec<(f64, String, u32, Option<u64>, String)> = best
         .into_iter()
-        .map(|(hk, (bpb, n_params))| {
+        .map(|(hk, (bpb, n_params, sid))| {
             let n = counts.get(&hk).copied().unwrap_or(1);
-            (bpb, hk, n, n_params)
+            (bpb, hk, n, n_params, sid)
         })
         .collect();
     rows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
     rows.into_iter()
         .enumerate()
-        .map(|(i, (bpb, hk, submissions, n_params))| LeaderboardRow {
-            rank: u32::try_from(i + 1).unwrap_or(u32::MAX),
-            agent: agent_from_hotkey(&hk, epoch),
-            elo: bpb,
-            wins: 0,
-            losses: 0,
-            win_rate: 0.0,
-            submissions,
-            delta7d: 0.0,
-            bpb: Some(bpb),
-            params_m: n_params.map(|p| p as f64 / 1e6),
-            weight: None,
-            tao_per_day: None,
-        })
+        .map(
+            |(i, (bpb, hk, submissions, n_params, sid))| LeaderboardRow {
+                rank: u32::try_from(i + 1).unwrap_or(u32::MAX),
+                agent: agent_from_hotkey(&hk, epoch),
+                elo: bpb,
+                wins: 0,
+                losses: 0,
+                win_rate: 0.0,
+                submissions,
+                delta7d: 0.0,
+                bpb: Some(bpb),
+                params_m: n_params.map(|p| p as f64 / 1e6),
+                weight: None,
+                tao_per_day: None,
+                submission_id: if sid.is_empty() { None } else { Some(sid) },
+                recipe_era: None,
+                pin_id: None,
+                eval_groups: None,
+                benchmarks: None,
+            },
+        )
         .collect()
 }
 
@@ -1417,8 +1445,10 @@ mod tests {
         let rows = prism_bpb_leaderboard(&subs, 3);
         assert_eq!(rows.len(), 2);
         assert!((rows[0].bpb.unwrap() - 1.0).abs() < f64::EPSILON);
+        assert_eq!(rows[0].submission_id.as_deref(), Some("b"));
         assert!(rows[0].params_m.is_none());
         assert!((rows[1].params_m.unwrap() - 12.0).abs() < f64::EPSILON);
+        assert_eq!(rows[1].submission_id.as_deref(), Some("a"));
         // Backwards compat: old payloads without the new fields still decode.
         let old: LeaderboardRow = serde_json::from_value(json!({
             "rank": 1,

--- a/crates/site-types/src/types.rs
+++ b/crates/site-types/src/types.rs
@@ -134,6 +134,59 @@ pub struct Agent {
     pub joined_epoch: u64,
 }
 
+/// Prism recipe era (`AutoModel` 2.0 vs legacy 1.x two-script / tree).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RecipeEra {
+    /// Recipe ≥ 2.0 AutoModel pin + patch.
+    Automodel,
+    /// Pre-2.0 architecture/training (or tree) layout.
+    Legacy,
+}
+
+/// One G1–G8 composite group score for marketing tables.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvalGroupScore {
+    /// Group key (`g1`…`g8`).
+    pub group: String,
+    /// Point estimate after mirror penalty.
+    pub g: f64,
+}
+
+/// Public subset of Prism G2 downstream accuracies (0..1 when present).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrismBenchmarks {
+    /// HellaSwag accuracy (prefer `acc_norm` / `org.g2.hellaswag_acc`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hellaswag: Option<f64>,
+    /// ARC-Challenge accuracy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arc_challenge: Option<f64>,
+    /// PIQA accuracy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub piqa: Option<f64>,
+    /// WinoGrande accuracy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub winogrande: Option<f64>,
+    /// BoolQ accuracy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boolq: Option<f64>,
+}
+
+impl PrismBenchmarks {
+    /// True when every public bench field is absent.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.hellaswag.is_none()
+            && self.arc_challenge.is_none()
+            && self.piqa.is_none()
+            && self.winogrande.is_none()
+            && self.boolq.is_none()
+    }
+}
+
 /// Leaderboard row (design ratings → `elo`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -166,6 +219,21 @@ pub struct LeaderboardRow {
     /// Estimated TAO/day = `weight × subnet_emission_per_day` when both known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tao_per_day: Option<f64>,
+    /// Winning Prism submission id (for detail modal); absent for design.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submission_id: Option<String>,
+    /// Prism recipe era when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe_era: Option<RecipeEra>,
+    /// AutoModel pin id when era is automodel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pin_id: Option<String>,
+    /// G1–G8 group scores when the composite eval is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval_groups: Option<Vec<EvalGroupScore>>,
+    /// Public G2 benchmark subset when measured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub benchmarks: Option<PrismBenchmarks>,
 }
 
 /// Submission status.
@@ -225,6 +293,122 @@ pub struct Submission {
     pub failure_reason: Option<String>,
     /// ISO-8601 UTC.
     pub submitted_at: String,
+    /// Prism recipe era when known (absent for design).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe_era: Option<RecipeEra>,
+    /// AutoModel pin id when era is automodel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pin_id: Option<String>,
+    /// G1–G8 group scores when the composite eval is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval_groups: Option<Vec<EvalGroupScore>>,
+    /// Public G2 benchmark subset when measured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub benchmarks: Option<PrismBenchmarks>,
+}
+
+/// Lexicographic gate flags from a Prism composite outcome (public subset).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)] // mirrors upstream GateReport flags
+pub struct PrismGateSummary {
+    /// Every declared group/metric present.
+    pub complete: bool,
+    /// g3 floor passed.
+    pub g3_ok: bool,
+    /// g8 floor passed.
+    pub g8_ok: bool,
+    /// Budget gates passed.
+    pub budgets_ok: bool,
+    /// CI-sufficiency gate passed.
+    pub ci_ok: bool,
+}
+
+/// Composite eval summary for the public Prism detail modal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrismEvalSummary {
+    /// Upstream outcome status (`scored` | `ineligible`).
+    pub status: String,
+    /// G1–G8 point estimates when present.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<EvalGroupScore>,
+    /// Gate flags when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gates: Option<PrismGateSummary>,
+    /// Composite C when computed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composite: Option<f64>,
+    /// Scoring mode (`shadow` | …) when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scoring_mode: Option<String>,
+    /// Eval tier when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval_tier: Option<String>,
+}
+
+/// Public review chip (quality only — no prompt dumps).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrismPublicReview {
+    /// Quality score when the reviewer returned one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality_score: Option<f64>,
+}
+
+/// Public similarity chip (kind + score only).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrismPublicSimilarity {
+    /// Similarity kind label from upstream.
+    pub kind: String,
+    /// Similarity score when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+}
+
+/// Full public Prism submission detail (`GET …/submissions/{id}`).
+///
+/// Safe marketing subset: list fields (incl. era / benches) + eval /
+/// telemetry / review. Raw AutoModel patch text is never included.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrismSubmissionDetail {
+    /// List-row fields (identity, stage, score, era, benches).
+    #[serde(flatten)]
+    pub submission: Submission,
+    /// Composite eval summary when finalized.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval: Option<PrismEvalSummary>,
+    /// Loss curve / harness telemetry (same shape as `…/telemetry`).
+    pub telemetry: PrismTelemetry,
+    /// Public review chip when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review: Option<PrismPublicReview>,
+    /// Public similarity chip when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub similarity: Option<PrismPublicSimilarity>,
+}
+
+/// Frozen public literature baseline (not a miner submission).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrismReferenceBaseline {
+    /// Stable id (`gpt2-small-124m`).
+    pub id: String,
+    /// Display label.
+    pub label: String,
+    /// Parameters in millions.
+    pub params_m: f64,
+    /// Prism-protocol BPB is intentionally omitted (not comparable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bpb: Option<f64>,
+    /// Literature / Eleuther-style accuracies.
+    pub benchmarks: PrismBenchmarks,
+    /// Canonical source for the published numbers.
+    pub source_url: String,
+    /// Short disclaimer shown under the board / in the modal.
+    pub disclaimer: String,
 }
 
 /// Loss series point.

--- a/docs/SITE_API.md
+++ b/docs/SITE_API.md
@@ -8,7 +8,7 @@ frontend `BaseApi` contract (`types.ts` / `contract.ts`).
 | Site path | Upstream |
 |-----------|----------|
 | `/v1/site/arenas`, `/arenas/design/*` | Registry pick `challenge_id=design` → `/v1/dashboard`, `/v1/rounds/{id}/leaderboard`, `/v1/harness/{id}`, `/v1/runs/{id}` |
-| `/v1/site/arenas/prism/*` | Registry pick `challenge_id=prism` → `/v1/status`, `/v1/submissions`, `/v1/recipe` |
+| `/v1/site/arenas/prism/*` | Registry pick `challenge_id=prism` → `/v1/status`, `/v1/submissions`, `/v1/submissions/{id}`, `/v1/submissions/{id}/diff`, `/v1/recipe` |
 | `/v1/site/network`, `/validators` | Chain tip / metagraph when available; numeric unknowns are `0` or omitted — never invented TAO price/emission |
 | `/v1/site/arenas/design/duels` | Always `[]` (admin winners model; no fabricated matchups) |
 | `/v1/site/activity` | Design `recent_runs` + round winners + prism submissions → ops-style English lines (deduped) |
@@ -38,6 +38,28 @@ x as an egalitarian “token window.” Prism public submissions + BPB
 leaderboard list **champions only** (`score.kind=score` and `value > 0` —
 current top and historical ex-tops); non-top rows stay on the operator
 challenge API.
+
+### Prism era, benches, detail, GPT-2 references
+
+Champion list / leaderboard rows may carry (when detail fan-out succeeds):
+
+| Field | Meaning |
+|-------|---------|
+| `recipeEra` | `"automodel"` \| `"legacy"` — AutoModel if `pin_id` / recipe major ≥ 2 / diff shape; else legacy |
+| `pinId` | AutoModel pin (`automodel@…`) when era is automodel |
+| `evalGroups` | `{ group: "g1"…"g8", g }` from composite `eval.groups` |
+| `benchmarks` | Public G2 subset: `hellaswag`, `arcChallenge`, `piqa`, `winogrande`, `boolq` from `org.g2.*` / battery keys |
+| `submissionId` | (leaderboard) best-BPB champion id for the detail modal |
+
+Additional Prism routes:
+
+| Path | Response |
+|------|----------|
+| `GET /v1/site/arenas/prism/submissions/{id}` | `PrismSubmissionDetail` — list fields + `eval` summary (status, groups, gates, composite) + telemetry + public `review` / `similarity` (quality/kind only). **No** raw patch text. |
+| `GET /v1/site/arenas/prism/references` | `PrismReferenceBaseline[]` — frozen **published** GPT-2 Small (124M) Eleuther-style accuracies + `sourceUrl` / `disclaimer`. **`bpb` omitted** (not Prism-protocol BPB). |
+| `GET /v1/site/arenas/prism/submissions/{id}/telemetry` | Existing loss-curve payload (also embedded on detail). |
+
+GPT-2 constants live in `crates/site-api` (`prism_enrich`) so API and FE stay aligned; they are literature / Eleuther harness numbers, not a Prism battery run. List/leaderboard row shells still map in `crates/site-data`.
 
 `GET /v1/site/arenas/{slug}/submissions` and `/leaderboard` accept optional
 `?q=` — case-insensitive substring over miner hotkey (SS58 or hex), handle,


### PR DESCRIPTION
## Summary
- Extend site Prism contract with `recipeEra`, `evalGroups`, public G2 `benchmarks`, and champion `submissionId` / `pinId` on board rows
- Add `GET /v1/site/arenas/prism/submissions/{id}` (safe public detail + telemetry/eval/review) and `GET /v1/site/arenas/prism/references` (frozen GPT-2 Small literature baseline)
- Document the new fields/routes in `docs/SITE_API.md` and cover mappers/enrich helpers with unit tests

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p site-types -p site-data -p site-api --all-targets -- -D warnings`
- [x] `cargo test -p site-types -p site-data -p site-api`
- [x] `cargo run -p xtask -- loc-cap`
- [ ] Deploy to staging/prod, then smoke:
  - `GET /v1/site/arenas/prism/references` → 200 with GPT-2 baseline
  - `GET /v1/site/arenas/prism/leaderboard` rows include `recipeEra` / optional benches
  - `GET /v1/site/arenas/prism/submissions/{id}` for a champion id

Pairs with frontend PR (Prism modal / era tabs / GPT-2 REF row). Do not merge until FE is ready to consume, or FE will soft-miss new fields until deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public Prism submission detail pages with recipe era, pinned revision, evaluation groups, benchmarks, reviews, similarity, and evaluation summaries.
  * Added Prism reference baselines, including GPT-2 benchmark results and source information.
  * Enhanced Prism leaderboards and submissions with submission IDs and enriched benchmark and evaluation data.
  * Added public telemetry access for Prism submissions.

* **Bug Fixes**
  * Missing or invalid submission details now return a clear not-found response.

* **Documentation**
  * Documented the new Prism submission, reference, telemetry, and diff endpoints and their public response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->