### PR TITLE
fix(prism): AutoModel pin mount + in-flight site submissions

### DIFF
--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -933,6 +933,12 @@ mod tests {
     }
 
     async fn mount_site_mocks(design: &MockServer, prism: &MockServer) {
+        mount_design_site_mocks(design).await;
+        mount_prism_list_mocks(prism).await;
+        mount_prism_detail_mock(prism).await;
+    }
+
+    async fn mount_design_site_mocks(design: &MockServer) {
         Mock::given(method("GET"))
             .and(path("/v1/dashboard"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -983,6 +989,9 @@ mod tests {
             })))
             .mount(design)
             .await;
+    }
+
+    async fn mount_prism_list_mocks(prism: &MockServer) {
         Mock::given(method("GET"))
             .and(path("/v1/status"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -1035,7 +1044,6 @@ mod tests {
             })))
             .mount(prism)
             .await;
-        mount_prism_detail_mock(prism).await;
     }
 
     async fn mount_prism_detail_mock(prism: &MockServer) {

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -27,7 +27,7 @@ use site_types::coding_arena;
 use site_types::page_slice;
 use site_types::{
     ArenaSlug, Governance, LandingSummary, MetricsEmission, MetricsPassRate, MetricsPopulation,
-    NetworkMetrics, NetworkStats, ResultsMatrix, Validator,
+    NetworkMetrics, NetworkStats, RecipeEra, ResultsMatrix, Validator,
 };
 
 /// Mount marketing site routes under `/v1/site`.
@@ -73,6 +73,9 @@ struct PageQuery {
     status: Option<String>,
     /// Hotkey / handle / prompt substring filter (SS58 or hex).
     q: Option<String>,
+    /// Prism submissions only: `all` (default) includes in-flight / failed;
+    /// `champions` keeps Score>0 gallery rows.
+    scope: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -447,6 +450,10 @@ async fn prism_leaderboard_json(
                 enrich_leaderboard_row_from_detail(row, detail);
             }
         }
+        if row.recipe_era.is_none() {
+            // Historical 1.x champions without AutoModel signals → legacy tab.
+            row.recipe_era = Some(RecipeEra::Legacy);
+        }
     }
     decorate_leaderboard(st, &mut board);
     if let Some(needle) = q.filter(|s| !s.trim().is_empty()) {
@@ -542,18 +549,30 @@ async fn get_submissions(
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
-            // Public gallery: champions only (current top + Score>0 ex-tops).
+            // Default `scope=all` so the FE can show pending/running; leaderboard
+            // stays champions-only. Opt into the scored gallery with champions.
+            let scope = q
+                .scope
+                .as_deref()
+                .unwrap_or("all")
+                .trim()
+                .to_ascii_lowercase();
+            let champions_only = matches!(scope.as_str(), "champions" | "champion");
             let mut items: Vec<_> = rows
                 .iter()
-                .filter(|r| is_prism_champion_submission(r))
+                .filter(|r| !champions_only || is_prism_champion_submission(r))
                 .filter_map(prism_submission)
                 .collect();
+            // Prefer in-flight + recent rows for detail fan-out (era / benches).
             let mut ids: Vec<String> = items.iter().map(|s| s.id.clone()).collect();
             ids.truncate(PRISM_CHAMPION_DETAIL_FANOUT);
             let details = fetch_prism_details(&st, &ids).await;
             for item in &mut items {
                 if let Some(detail) = details.get(&item.id) {
                     enrich_submission_from_detail(item, detail);
+                } else if item.recipe_era.is_none() {
+                    // Pre-2.0 / unknown → legacy so era tabs are not empty.
+                    item.recipe_era = Some(RecipeEra::Legacy);
                 }
             }
             decorate_submissions(&st, &mut items);
@@ -986,7 +1005,33 @@ mod tests {
                     "score": {"kind":"score","value": 900},
                     "created_at_ms": 1_700_000_000_000_u64,
                     "updated_at_ms": 1_700_000_000_000_u64
+                }, {
+                    "id": "sub-running",
+                    "miner_hotkey": "cc".repeat(32),
+                    "epoch": 3,
+                    "status": "running",
+                    "label": "inflight",
+                    "created_at_ms": 1_700_000_100_000_u64,
+                    "updated_at_ms": 1_700_000_100_000_u64
                 }]
+            })))
+            .mount(prism)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/submissions/sub-running"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "submission": {
+                    "id": "sub-running",
+                    "miner_hotkey": "cc".repeat(32),
+                    "epoch": 3,
+                    "status": "running",
+                    "label": "inflight",
+                    "architecture_sha256": "aa".repeat(32),
+                    "training_sha256": "bb".repeat(32),
+                    "created_at_ms": 1_700_000_100_000_u64,
+                    "updated_at_ms": 1_700_000_100_000_u64
+                },
+                "events": []
             })))
             .mount(prism)
             .await;
@@ -1177,10 +1222,23 @@ mod tests {
 
         let (s, v) = call(app.clone(), "/v1/site/arenas/prism/submissions").await;
         assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v["total"], 2, "default scope=all includes in-flight: {v}");
         assert_eq!(v["items"][0]["recipeEra"], "automodel");
         assert_eq!(v["items"][0]["pinId"], "automodel@v0.5.0");
         assert_eq!(v["items"][0]["benchmarks"]["hellaswag"], 0.31);
         assert_eq!(v["items"][0]["evalGroups"].as_array().unwrap().len(), 2);
+        assert_eq!(v["items"][1]["id"], "sub-running");
+        assert_eq!(v["items"][1]["status"], "pending");
+        assert_eq!(v["items"][1]["recipeEra"], "legacy");
+
+        // scope=champions keeps Score>0 gallery; default scope=all includes in-flight.
+        let (s, v) = call(
+            app.clone(),
+            "/v1/site/arenas/prism/submissions?scope=champions",
+        )
+        .await;
+        assert_eq!(s, StatusCode::OK, "{v}");
+        assert_eq!(v["total"], 1, "{v}");
 
         let (s, v) = call(app.clone(), "/v1/site/arenas/prism/leaderboard").await;
         assert_eq!(s, StatusCode::OK, "{v}");

--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -56,10 +56,15 @@ services:
   prism-challenge:
     environment:
       PRISM_FORCE_SIM: "false"
+      # Recipe 2.0 AutoModel pin (stage with deploy/scripts/stage-automodel-pin.sh).
+      # Fail-closed intake when unset/unmounted — miners see code=pin.
+      PRISM_AUTOMODEL_PIN_DIR: "/var/lib/prism/automodel-pin"
       # Horizontal scale: N orchestrator workers each claim_next under a semaphore.
       PRISM_MAX_CONCURRENT_EVALS: "8"
       # Emitter/gating/epoch-feed chain reads share the gateway failover list.
       BASE_CHAIN_ENDPOINTS: "wss://bittensor-finney.api.onfinality.io/public-ws,wss://entrypoint-finney.opentensor.ai:443"
+    volumes:
+      - /var/lib/prism/automodel-pin:/var/lib/prism/automodel-pin:ro
   design-challenge:
     environment:
       # Docker-only on prod. Never set BASE_ALLOW_HOST_SIM / DESIGN_FORCE_SIM here.

--- a/deploy/compose/env-staging.yml
+++ b/deploy/compose/env-staging.yml
@@ -60,6 +60,12 @@ services:
       PRISM_FORCE_SIM: "true"
       PRISM_TEST_TRAIN_MINUTES: "15"
       PRISM_TEST_MAX_PARAMS: "2000000"
+      # Same pin path as prod when testing live AutoModel intake on staging
+      # (stage with deploy/scripts/stage-automodel-pin.sh). Sim/fixture pins
+      # still work when miners submit automodel@fixture-v1.
+      PRISM_AUTOMODEL_PIN_DIR: "/var/lib/prism/automodel-pin"
+    volumes:
+      - /var/lib/prism/automodel-pin:/var/lib/prism/automodel-pin:ro
   design-challenge:
     environment:
       BASE_CHAIN_ENDPOINT: "wss://test.chain.opentensor.ai:443"

--- a/deploy/scripts/remote-deploy.sh
+++ b/deploy/scripts/remote-deploy.sh
@@ -255,6 +255,19 @@ case "$ENV" in
   prod)    COMPOSE_FILES+=(-f deploy/compose/env-prod.yml) ;;
 esac
 
+# Recipe 2.0 AutoModel pin: env-*/yml mounts /var/lib/prism/automodel-pin into
+# prism-challenge. Fail loud on master when the staged tree is missing so a
+# redeploy does not silently return code=pin to miners.
+if [[ "$ROLE" == "master" ]]; then
+  if ssh_h "test -d /var/lib/prism/automodel-pin/.git"; then
+    echo "remote-deploy: AutoModel pin present at /var/lib/prism/automodel-pin"
+  else
+    echo "remote-deploy: WARNING: AutoModel pin missing at /var/lib/prism/automodel-pin" >&2
+    echo "remote-deploy:   stage with: ./deploy/scripts/stage-automodel-pin.sh --dir /var/lib/prism/automodel-pin" >&2
+    echo "remote-deploy:   (Prism AutoModel intake fails closed with code=pin until staged)" >&2
+  fi
+fi
+
 GE_EXPORT=""
 if [[ -n "$GATEWAY_ENDPOINT" ]]; then
   GE_EXPORT="export BASE_GATEWAY_ENDPOINT='$GATEWAY_ENDPOINT';"

--- a/deploy/scripts/remote-deploy.sh
+++ b/deploy/scripts/remote-deploy.sh
@@ -257,7 +257,8 @@ esac
 
 # Recipe 2.0 AutoModel pin: env-*/yml mounts /var/lib/prism/automodel-pin into
 # prism-challenge. Fail loud on master when the staged tree is missing so a
-# redeploy does not silently return code=pin to miners.
+# redeploy does not silently return code=pin to miners. Also pick up a
+# host-local overlay outside the rsync tree (survives --delete) when present.
 if [[ "$ROLE" == "master" ]]; then
   if ssh_h "test -d /var/lib/prism/automodel-pin/.git"; then
     echo "remote-deploy: AutoModel pin present at /var/lib/prism/automodel-pin"
@@ -265,6 +266,10 @@ if [[ "$ROLE" == "master" ]]; then
     echo "remote-deploy: WARNING: AutoModel pin missing at /var/lib/prism/automodel-pin" >&2
     echo "remote-deploy:   stage with: ./deploy/scripts/stage-automodel-pin.sh --dir /var/lib/prism/automodel-pin" >&2
     echo "remote-deploy:   (Prism AutoModel intake fails closed with code=pin until staged)" >&2
+  fi
+  if ssh_h "test -f /var/lib/prism/docker-compose.automodel-pin.yml"; then
+    COMPOSE_FILES+=(-f /var/lib/prism/docker-compose.automodel-pin.yml)
+    echo "remote-deploy: including host AutoModel pin overlay"
   fi
 fi
 

--- a/docs/PRISM_RECIPE.md
+++ b/docs/PRISM_RECIPE.md
@@ -74,6 +74,14 @@ staged checkout.
 clean checkout of `automodel_git_commit`. Use
 `deploy/scripts/stage-automodel-pin.sh` (clone + hash verify). Intake
 fail-closes when the dir is missing or the content SHA mismatches.
+Prod/staging Compose (`deploy/compose/env-prod.yml` / `env-staging.yml`)
+mount `/var/lib/prism/automodel-pin` read-only into `prism-challenge` and set
+the env var; stage the tree **before** `remote-deploy` recreates the service:
+
+```bash
+sudo ./deploy/scripts/stage-automodel-pin.sh --dir /var/lib/prism/automodel-pin
+# then recreate prism-challenge (or full remote-deploy)
+```
 
 **CI / Sim fixture (not live):** pin id `automodel@fixture-v1` + vendored tree
 `crates/prism-automodel/fixtures/automodel-pin/` + `fixtures/patches/happy.patch`.

--- a/docs/SITE_API.md
+++ b/docs/SITE_API.md
@@ -34,10 +34,13 @@ no step curve is stored. `PrismWindow.tokenBudget` is **0** unless a recipe
 publishes a fixed token quota (prism ≥1.2 does not — caps are wall-clock /
 steps / params). Chart x-values still come from miner telemetry
 (`layer_stats.tokens` when present); clients must not label the max observed
-x as an egalitarian “token window.” Prism public submissions + BPB
-leaderboard list **champions only** (`score.kind=score` and `value > 0` —
-current top and historical ex-tops); non-top rows stay on the operator
-challenge API.
+x as an egalitarian “token window.” Prism **leaderboard** lists **champions
+only** (`score.kind=score` and `value > 0` — current top and historical
+ex-tops). Prism **`/submissions`** defaults to **`scope=all`** (in-flight +
+terminal, including Score=0 / failed) so the marketing FE can show live
+progress; pass `?scope=champions` for the scored gallery only. Missing
+`recipeEra` on a row is filled as **`legacy`** after detail fan-out (or when
+no AutoModel signals exist).
 
 ### Prism era, benches, detail, GPT-2 references
 


### PR DESCRIPTION
## Summary
- Mount `/var/lib/prism/automodel-pin` into `prism-challenge` on prod/staging compose and set `PRISM_AUTOMODEL_PIN_DIR` so AutoModel 2.0 intake no longer fail-closes with `code=pin` after redeploy.
- Change `GET /v1/site/arenas/prism/submissions` default to `scope=all` (in-flight + failed + scored); keep `?scope=champions` for the Score>0 gallery. Leaderboard stays champions-only.
- Default missing `recipeEra` to `legacy` after detail fan-out so Legacy/All tabs are not empty when enrichment is thin.
- `remote-deploy` warns when the staged pin tree is missing on master.

## Ops already done on prod
- Staged pin at `/var/lib/prism/automodel-pin` (commit `d02f49cb…`, content sha matches freeze).
- Recreated `prism-challenge` with pin mount; intake now reaches metagraph/auth checks instead of `code=pin`.

## Test plan
- [x] `cargo test -p site-api --lib`
- [ ] After merge: promote/deploy gateway image including this commit + #126 site enrichment to prod
- [ ] Confirm `GET /v1/site/arenas/prism/submissions` includes `status=pending` rows and `recipeEra`
- [ ] Confirm `GET …/submissions?scope=champions` still Score>0 only
- [ ] On next `remote-deploy --env prod --role master`, pin warning is silent when `/var/lib/prism/automodel-pin` exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Submission listings now support filtering between all submissions and champions-only results.
  - All-submission listings include in-flight, completed, zero-score, and failed submissions.
  - Missing submission era information is now labeled as “legacy.”
- **Documentation**
  - Added deployment guidance for configuring and staging AutoModel pin data.
  - Updated API documentation to describe submission scopes, leaderboard behavior, and legacy-era handling.
- **Deployment**
  - Production and staging environments now support read-only AutoModel pin data configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->