### PR TITLE
fix(prism-lium): hard-reject multi-GPU offers for single-GPU rent

### DIFF
--- a/crates/prism-lium-types/src/lib.rs
+++ b/crates/prism-lium-types/src/lib.rs
@@ -22,6 +22,6 @@ mod types;
 pub use error::{CostGuardrailError, LiumError};
 pub use receipt::{EvalReceipt, NoScoreGate};
 pub use types::{
-    EvalTelemetry, GpuPreference, Instance, InstanceSpec, LiumSshConfig, Offer, ProbePoint,
-    RemoteExecResult, TelemetryPoint,
+    effective_gpu_count, gpu_count_from_label, EvalTelemetry, GpuPreference, Instance,
+    InstanceSpec, LiumSshConfig, Offer, ProbePoint, RemoteExecResult, TelemetryPoint,
 };

--- a/crates/prism-lium-types/src/types.rs
+++ b/crates/prism-lium-types/src/types.rs
@@ -19,6 +19,88 @@ pub struct Offer {
     pub provider: String,
 }
 
+/// Plausible discrete GPU counts on marketplace offers (not SKU numbers).
+fn plausible_gpu_count(n: u32) -> bool {
+    (2..=16).contains(&n)
+}
+
+/// Parse a multi-GPU multiplier from a provider label (`8x RTX 5090`,
+/// `RTX 5090 x8`, `8×GeForce`, `8 x RTX`, …). Returns `None` when the label
+/// does not clearly encode a count. SKU digits like `5090` / `H100` are
+/// ignored via [`plausible_gpu_count`].
+#[must_use]
+pub fn gpu_count_from_label(label: &str) -> Option<u32> {
+    let s = label.to_ascii_lowercase().replace('×', "x");
+    let bytes = s.as_bytes();
+    let mut best: Option<u32> = None;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'x' {
+            // Leading: `8x` / `8 x`
+            let mut l = i;
+            while l > 0 && bytes[l - 1].is_ascii_whitespace() {
+                l -= 1;
+            }
+            let end_num = l;
+            while l > 0 && bytes[l - 1].is_ascii_digit() {
+                l -= 1;
+            }
+            if l < end_num {
+                if let Ok(n) = s[l..end_num].parse::<u32>() {
+                    if plausible_gpu_count(n) {
+                        best = Some(best.map_or(n, |b| b.max(n)));
+                    }
+                }
+            }
+            // Trailing: `x8` / `x 8`
+            let mut r = i + 1;
+            while r < bytes.len() && bytes[r].is_ascii_whitespace() {
+                r += 1;
+            }
+            let start_num = r;
+            while r < bytes.len() && bytes[r].is_ascii_digit() {
+                r += 1;
+            }
+            if start_num < r {
+                if let Ok(n) = s[start_num..r].parse::<u32>() {
+                    if plausible_gpu_count(n) {
+                        best = Some(best.map_or(n, |b| b.max(n)));
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    best
+}
+
+/// Effective GPU count for selection: max of the numeric field and any
+/// multiplier encoded in the type / machine label. Defaults to at least 1.
+#[must_use]
+pub fn effective_gpu_count(gpu_count: u32, gpu_type: &str) -> u32 {
+    let from_label = gpu_count_from_label(gpu_type).unwrap_or(1);
+    gpu_count.max(1).max(from_label)
+}
+
+impl Offer {
+    /// True when this offer is multi-GPU (field or label).
+    #[must_use]
+    pub fn is_multi_gpu(&self) -> bool {
+        effective_gpu_count(self.gpu_count, &self.gpu_type) > 1
+    }
+
+    /// Whether this offer may be rented for `requested` GPUs.
+    /// Prism requests exactly one GPU; multi-GPU hosts are hard-rejected.
+    #[must_use]
+    pub fn matches_gpu_count(&self, requested: u32) -> bool {
+        let effective = effective_gpu_count(self.gpu_count, &self.gpu_type);
+        if requested <= 1 {
+            return effective == 1;
+        }
+        effective == requested
+    }
+}
+
 /// Provision request with mandatory cost guardrails.
 #[derive(Debug, Clone)]
 pub struct InstanceSpec {
@@ -270,6 +352,46 @@ mod tests {
         assert!(p.rank("NVIDIA H100") < p.rank("NVIDIA A100-SXM4-80GB"));
         assert!(p.rank("NVIDIA A100") < p.rank("NVIDIA GeForce RTX 4090"));
         assert!(p.rank("NVIDIA GeForce RTX 4090") < p.rank("NVIDIA L4"));
+    }
+
+    #[test]
+    fn gpu_count_from_label_parses_multipliers() {
+        assert_eq!(gpu_count_from_label("8x RTX 5090"), Some(8));
+        assert_eq!(gpu_count_from_label("8× NVIDIA GeForce RTX 5090"), Some(8));
+        assert_eq!(gpu_count_from_label("8 x RTX 5090"), Some(8));
+        assert_eq!(gpu_count_from_label("RTX 5090 x8"), Some(8));
+        assert_eq!(gpu_count_from_label("RTX 5090 x 8"), Some(8));
+        assert_eq!(gpu_count_from_label("NVIDIA GeForce RTX 5090"), None);
+        assert_eq!(gpu_count_from_label("H100x8"), Some(8));
+    }
+
+    #[test]
+    fn offer_hard_rejects_multi_gpu_for_single_request() {
+        let single = Offer {
+            id: "1x".into(),
+            gpu_type: "NVIDIA GeForce RTX 5090".into(),
+            gpu_count: 1,
+            price_per_hour: 2.0,
+            provider: "lium".into(),
+        };
+        let eight = Offer {
+            id: "8x".into(),
+            gpu_type: "NVIDIA GeForce RTX 5090".into(),
+            gpu_count: 8,
+            price_per_hour: 0.48,
+            provider: "lium".into(),
+        };
+        let eight_label = Offer {
+            id: "8x-label".into(),
+            gpu_type: "8x RTX 5090".into(),
+            gpu_count: 1, // lying field; label wins
+            price_per_hour: 0.48,
+            provider: "lium".into(),
+        };
+        assert!(single.matches_gpu_count(1));
+        assert!(!eight.matches_gpu_count(1));
+        assert!(!eight_label.matches_gpu_count(1));
+        assert!(eight.is_multi_gpu());
     }
 
     #[test]

--- a/crates/prism-lium/src/client.rs
+++ b/crates/prism-lium/src/client.rs
@@ -712,12 +712,15 @@ fn parse_one_offer(item: &Value) -> Option<Offer> {
         .or_else(|| item.pointer("/machine/gpu_type").and_then(|x| x.as_str()))
         .unwrap_or("UNKNOWN")
         .to_owned();
-    let gpu_count = item
+    let raw_count = item
         .get("gpu_count")
         .and_then(|x| x.as_u64())
         .or_else(|| item.get("available_gpu_count").and_then(|x| x.as_u64()))
         .or_else(|| item.get("gpus").and_then(|x| x.as_u64()))
         .unwrap_or(1) as u32;
+    // Prefer the higher of the numeric field and any `8x` / `x8` label so a
+    // lying `gpu_count: 1` on a multi-GPU host cannot pass the single-GPU filter.
+    let gpu_count = prism_lium_types::effective_gpu_count(raw_count, &gpu_type);
     let price = item
         .get("price_per_hour")
         .or_else(|| item.get("price_per_gpu"))
@@ -808,27 +811,40 @@ impl EvalJobBackend for LiumClient {
         }
 
         let mut offers = self.list_offers(Some(spec.max_price_per_hour)).await?;
+        // Hard-reject multi-GPU hosts when requesting a single GPU (and exact
+        // match otherwise). The old `gpu_count >= requested` filter + rent
+        // fallback to `selected.gpu_count` could silently rent 8×5090.
+        offers.retain(|o| o.matches_gpu_count(spec.gpu_count));
         let pref = GpuPreference::default_prism();
         offers.sort_by(|a, b| {
             pref.rank(&a.gpu_type)
                 .cmp(&pref.rank(&b.gpu_type))
                 .then_with(|| {
-                    a.price_per_hour
-                        .partial_cmp(&b.price_per_hour)
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                    // Prefer true singles (effective count) then cheaper.
+                    let ac = prism_lium_types::effective_gpu_count(a.gpu_count, &a.gpu_type);
+                    let bc = prism_lium_types::effective_gpu_count(b.gpu_count, &b.gpu_type);
+                    ac.cmp(&bc).then_with(|| {
+                        a.price_per_hour
+                            .partial_cmp(&b.price_per_hour)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    })
                 })
         });
         let candidates: Vec<Offer> = match &spec.preferred_offer_id {
-            Some(pref) => offers
-                .into_iter()
-                .filter(|o| &o.id == pref)
-                .take(1)
-                .collect(),
-            None => offers
-                .into_iter()
-                .filter(|o| o.gpu_count >= spec.gpu_count)
-                .take(10)
-                .collect(),
+            Some(pref_id) => {
+                let matched: Vec<Offer> = offers
+                    .into_iter()
+                    .filter(|o| &o.id == pref_id)
+                    .take(1)
+                    .collect();
+                if matched.is_empty() {
+                    return Err(LiumError::Api(format!(
+                        "preferred offer {pref_id} missing or multi-GPU rejected"
+                    )));
+                }
+                matched
+            }
+            None => offers.into_iter().take(10).collect(),
         };
         if candidates.is_empty() {
             return Err(CostGuardrailError::NoCapacity.into());
@@ -836,12 +852,15 @@ impl EvalJobBackend for LiumClient {
 
         let lifetime = spec.max_lifetime_hours.ceil() as u64;
         let template_id = self.resolve_template_id(spec).await?;
-        let make_body = |gpu_count: u32| {
+        // Never rent more GPUs than requested — even if the marketplace
+        // offer advertises a larger host (those are filtered above).
+        let rent_gpu_count = spec.gpu_count.max(1);
+        let make_body = || {
             serde_json::json!({
                 "pod_name": spec.name,
                 "user_public_key": spec.ssh_public_keys,
                 "termination_hours": lifetime.max(1),
-                "gpu_count": gpu_count,
+                "gpu_count": rent_gpu_count,
                 "template_id": template_id,
             })
         };
@@ -851,39 +870,31 @@ impl EvalJobBackend for LiumClient {
             if selected.price_per_hour > spec.max_price_per_hour {
                 continue;
             }
+            let effective =
+                prism_lium_types::effective_gpu_count(selected.gpu_count, &selected.gpu_type);
             info!(
                 offer_id = %selected.id,
                 gpu = %selected.gpu_type,
+                gpu_count = effective,
+                rent_gpu_count,
                 price = selected.price_per_hour,
                 %template_id,
                 "lium rent"
             );
-            let mut split_choices = vec![spec.gpu_count];
-            if selected.gpu_count != spec.gpu_count {
-                split_choices.push(selected.gpu_count);
-            }
-            let mut rented: Result<Value, LiumError> = Err(LiumError::Api("unrented".into()));
-            for gcount in split_choices {
-                let body = make_body(gcount);
-                let permit = rent_pool().take().await;
-                rented = self
-                    .request(
-                        reqwest::Method::POST,
-                        &format!("/executors/{}/rent", selected.id),
-                        Some(&body),
-                    )
-                    .await;
-                if let Err(e) = &rented {
-                    let es = e.to_string();
-                    if lium_rent_pool::is_rate_limited(&es) {
-                        permit.rate_limited(&es);
-                        break;
-                    }
-                    if es.contains("splitting") {
-                        continue;
-                    }
+            let body = make_body();
+            let permit = rent_pool().take().await;
+            let rented = self
+                .request(
+                    reqwest::Method::POST,
+                    &format!("/executors/{}/rent", selected.id),
+                    Some(&body),
+                )
+                .await;
+            if let Err(e) = &rented {
+                let es = e.to_string();
+                if lium_rent_pool::is_rate_limited(&es) {
+                    permit.rate_limited(&es);
                 }
-                break;
             }
             match rented {
                 Ok(v) => {
@@ -1166,6 +1177,50 @@ mod tests {
         let c = LiumClient::with_base_url("test-key", server.uri()).unwrap();
         let inst = c.provision(&provision_spec()).await.unwrap();
         assert_eq!(inst.id, "pod-5090");
+    }
+
+    #[tokio::test]
+    async fn provision_never_selects_8x_5090_when_1x_available() {
+        let server = MockServer::start().await;
+        mount_common(
+            &server,
+            serde_json::json!([
+                {"id": "eight-5090", "gpu_type": "NVIDIA GeForce RTX 5090", "gpu_count": 8, "price_per_hour": 0.48},
+                {"id": "eight-label", "gpu_type": "8x RTX 5090", "gpu_count": 1, "price_per_hour": 0.45},
+                {"id": "one-5090", "gpu_type": "NVIDIA GeForce RTX 5090", "gpu_count": 1, "price_per_hour": 2.0}
+            ]),
+        )
+        .await;
+        mount_rent_path(&server, "one-5090", "pod-1x").await;
+        // If multi-GPU slipped through, these would be rented instead.
+        mount_rent_path(&server, "eight-5090", "pod-8x").await;
+        mount_rent_path(&server, "eight-label", "pod-8x-label").await;
+        let c = LiumClient::with_base_url("test-key", server.uri()).unwrap();
+        let inst = c.provision(&provision_spec()).await.unwrap();
+        assert_eq!(inst.id, "pod-1x");
+    }
+
+    #[tokio::test]
+    async fn provision_rejects_all_multi_gpu_offers() {
+        let server = MockServer::start().await;
+        mount_common(
+            &server,
+            serde_json::json!([
+                {"id": "eight-5090", "gpu_type": "NVIDIA GeForce RTX 5090", "gpu_count": 8, "price_per_hour": 0.48},
+                {"id": "eight-label", "gpu_type": "8× RTX 5090", "gpu_count": 1, "price_per_hour": 0.45}
+            ]),
+        )
+        .await;
+        mount_rent_path(&server, "eight-5090", "pod-8x").await;
+        mount_rent_path(&server, "eight-label", "pod-8x-label").await;
+        let c = LiumClient::with_base_url("test-key", server.uri()).unwrap();
+        let err = c.provision(&provision_spec()).await.unwrap_err();
+        assert!(
+            matches!(err, LiumError::Cost(CostGuardrailError::NoCapacity))
+                || err.to_string().contains("NoCapacity")
+                || err.to_string().to_ascii_lowercase().contains("capacity"),
+            "got {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/prism-lium/src/lib.rs
+++ b/crates/prism-lium/src/lib.rs
@@ -47,8 +47,9 @@ pub use ssh::{parse_ssh_target, resolve_private_key, truncate_tail, SshTarget};
 // The data contract lives in `prism-lium-types` (per-crate LOC cap); it is
 // re-exported wholesale so `prism_lium::…` stays the single import path.
 pub use prism_lium_types::{
-    CostGuardrailError, EvalReceipt, EvalTelemetry, GpuPreference, Instance, InstanceSpec,
-    LiumError, LiumSshConfig, NoScoreGate, Offer, ProbePoint, RemoteExecResult, TelemetryPoint,
+    effective_gpu_count, gpu_count_from_label, CostGuardrailError, EvalReceipt, EvalTelemetry,
+    GpuPreference, Instance, InstanceSpec, LiumError, LiumSshConfig, NoScoreGate, Offer,
+    ProbePoint, RemoteExecResult, TelemetryPoint,
 };
 
 use async_trait::async_trait;


### PR DESCRIPTION
## Summary
- Prism Lium provisioning previously accepted any offer with `gpu_count >= requested` and, on host-split failures, retried rent with the offer’s full GPU count — so **8× RTX 5090** hosts could be selected/billed when the spec asked for **1×**.
- Hard-reject multi-GPU offers (numeric count and `8x` / `8×` / `x8` labels); prefer exact single-GPU 5090; never rent more GPUs than `InstanceSpec.gpu_count`.
- Unit tests: 1×5090 wins over cheaper 8×5090; all-multi catalogs yield `NoCapacity`.

## Test plan
- [x] `cargo test -p prism-lium-types --lib`
- [x] `cargo test -p prism-lium --lib`
- [x] `cargo clippy -p prism-lium-types -p prism-lium --all-targets -- -D warnings`
- [ ] CI green
- [ ] After merge: deploy prod prism-challenge image before relaunching affected miner submission