### PR TITLE
chore(deploy): promote prod pins for c1ad3721

### DIFF
--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,22 +1,22 @@
 {
-  "commit_sha": "86e47a8b13580055253381f94f278dd067521b22",
+  "commit_sha": "c1ad3721dfc6377bae582eb44cea09ca64dbc435",
   "env": "prod",
   "previous": {
-    "commit_sha": "86e47a8b13580055253381f94f278dd067521b22",
+    "commit_sha": "c1ad3721dfc6377bae582eb44cea09ca64dbc435",
     "services": {
       "design-challenge": {
-        "digest": "sha256:5e4011c5f09a5b1bd03784ebfcbb0e659377dfa6be14ff60af69ca2501daca2f",
-        "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:5e4011c5f09a5b1bd03784ebfcbb0e659377dfa6be14ff60af69ca2501daca2f",
+        "digest": "sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
+        "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
         "repository": "ghcr.io/baseintelligence/base/design-challenge"
       },
       "gateway": {
-        "digest": "sha256:6db91a84f6531b147a8b4ab0755bc94065ad973f52373d331470465e5f4a3637",
-        "image": "ghcr.io/baseintelligence/base/gateway@sha256:6db91a84f6531b147a8b4ab0755bc94065ad973f52373d331470465e5f4a3637",
+        "digest": "sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
+        "image": "ghcr.io/baseintelligence/base/gateway@sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
         "repository": "ghcr.io/baseintelligence/base/gateway"
       },
       "prism-challenge": {
-        "digest": "sha256:b249e292debf901e2b288ee2449fb4903e8b286fdbb53ee6e1e7eb9587c05bed",
-        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:b249e292debf901e2b288ee2449fb4903e8b286fdbb53ee6e1e7eb9587c05bed",
+        "digest": "sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
+        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
         "repository": "ghcr.io/baseintelligence/base/prism-challenge"
       },
       "updater": {
@@ -25,39 +25,39 @@
         "repository": "ghcr.io/baseintelligence/base/updater"
       },
       "validator": {
-        "digest": "sha256:7ea77d4ae249f6ddc3ce7b1889286d4489bdd965f1dcdcc02533f163ca729d36",
-        "image": "ghcr.io/baseintelligence/base/validator@sha256:7ea77d4ae249f6ddc3ce7b1889286d4489bdd965f1dcdcc02533f163ca729d36",
+        "digest": "sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
+        "image": "ghcr.io/baseintelligence/base/validator@sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
         "repository": "ghcr.io/baseintelligence/base/validator"
       }
     },
-    "updated_at": "2026-08-12T10:10:06Z"
+    "updated_at": "2026-08-12T11:29:10Z"
   },
   "services": {
     "design-challenge": {
-      "digest": "sha256:5e4011c5f09a5b1bd03784ebfcbb0e659377dfa6be14ff60af69ca2501daca2f",
-      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:5e4011c5f09a5b1bd03784ebfcbb0e659377dfa6be14ff60af69ca2501daca2f",
+      "digest": "sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
+      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
       "repository": "ghcr.io/baseintelligence/base/design-challenge"
     },
     "gateway": {
-      "digest": "sha256:6db91a84f6531b147a8b4ab0755bc94065ad973f52373d331470465e5f4a3637",
-      "image": "ghcr.io/baseintelligence/base/gateway@sha256:6db91a84f6531b147a8b4ab0755bc94065ad973f52373d331470465e5f4a3637",
+      "digest": "sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
+      "image": "ghcr.io/baseintelligence/base/gateway@sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
-      "digest": "sha256:b249e292debf901e2b288ee2449fb4903e8b286fdbb53ee6e1e7eb9587c05bed",
-      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:b249e292debf901e2b288ee2449fb4903e8b286fdbb53ee6e1e7eb9587c05bed",
+      "digest": "sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
+      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
       "repository": "ghcr.io/baseintelligence/base/prism-challenge"
     },
     "updater": {
-      "digest": "sha256:c18a2a3e2e8ff1d4d5397aa388797dcd77d252c954a28e16ed5d1b1e9a6bb1e8",
-      "image": "ghcr.io/baseintelligence/base/updater@sha256:c18a2a3e2e8ff1d4d5397aa388797dcd77d252c954a28e16ed5d1b1e9a6bb1e8",
+      "digest": "sha256:f7cb8d40f575888bfad536c20f1045db73a73e5e3b2253caff59974bde556320",
+      "image": "ghcr.io/baseintelligence/base/updater@sha256:f7cb8d40f575888bfad536c20f1045db73a73e5e3b2253caff59974bde556320",
       "repository": "ghcr.io/baseintelligence/base/updater"
     },
     "validator": {
-      "digest": "sha256:f50dd45c1601641af94fb01106397c4d85d68d85fddd3bd8c1d87d21ec34dc97",
-      "image": "ghcr.io/baseintelligence/base/validator@sha256:f50dd45c1601641af94fb01106397c4d85d68d85fddd3bd8c1d87d21ec34dc97",
+      "digest": "sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
+      "image": "ghcr.io/baseintelligence/base/validator@sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-12T10:10:06Z"
+  "updated_at": "2026-08-12T11:29:10Z"
 }


### PR DESCRIPTION
## Summary
- Promote staging digests for `c1ad3721` (orphan reconcile + sealed BYOK + logs) to `deploy/pins/prod.json`.

## Test plan
- [ ] Merge → remote-deploy prod master/validator with registry pins
- [ ] Ensure `/var/lib/prism/automodel-pin` and `payer_vault_key` exist on prod master before compose up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production deployment manifest to reference refreshed service images.
  * Synchronized current and previous production service records.
  * Updated the deployment timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->