### PR TITLE
chore(deploy): promote prod pins for b05a75f8

### DIFF
--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,27 +1,27 @@
 {
-  "commit_sha": "c1ad3721dfc6377bae582eb44cea09ca64dbc435",
+  "commit_sha": "b05a75f8d67758c3679c51bf5e30b3ab1f24d03e",
   "env": "prod",
   "previous": {
-    "commit_sha": "c1ad3721dfc6377bae582eb44cea09ca64dbc435",
+    "commit_sha": "b05a75f8d67758c3679c51bf5e30b3ab1f24d03e",
     "services": {
       "design-challenge": {
-        "digest": "sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
-        "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
+        "digest": "sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
+        "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
         "repository": "ghcr.io/baseintelligence/base/design-challenge"
       },
       "gateway": {
-        "digest": "sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
-        "image": "ghcr.io/baseintelligence/base/gateway@sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
+        "digest": "sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
+        "image": "ghcr.io/baseintelligence/base/gateway@sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
         "repository": "ghcr.io/baseintelligence/base/gateway"
       },
       "prism-challenge": {
-        "digest": "sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
-        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
+        "digest": "sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
+        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
         "repository": "ghcr.io/baseintelligence/base/prism-challenge"
       },
       "updater": {
-        "digest": "sha256:c18a2a3e2e8ff1d4d5397aa388797dcd77d252c954a28e16ed5d1b1e9a6bb1e8",
-        "image": "ghcr.io/baseintelligence/base/updater@sha256:c18a2a3e2e8ff1d4d5397aa388797dcd77d252c954a28e16ed5d1b1e9a6bb1e8",
+        "digest": "sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
+        "image": "ghcr.io/baseintelligence/base/updater@sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
         "repository": "ghcr.io/baseintelligence/base/updater"
       },
       "validator": {
@@ -30,34 +30,34 @@
         "repository": "ghcr.io/baseintelligence/base/validator"
       }
     },
-    "updated_at": "2026-08-12T11:29:10Z"
+    "updated_at": "2026-08-12T15:25:21Z"
   },
   "services": {
     "design-challenge": {
-      "digest": "sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
-      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:ff8fda1fde9c7f2e95dbed8ff8f8d5237d1310d4c2580170e1172bc3a740203b",
+      "digest": "sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
+      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
       "repository": "ghcr.io/baseintelligence/base/design-challenge"
     },
     "gateway": {
-      "digest": "sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
-      "image": "ghcr.io/baseintelligence/base/gateway@sha256:b4a795a7589e20c161f8e4b71a0c2282ba9cad70df6b072c0fc1ec245cdda86f",
+      "digest": "sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
+      "image": "ghcr.io/baseintelligence/base/gateway@sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
-      "digest": "sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
-      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:2e37d3b9e425427b07f41561ac509310134b30056bbabb1bd9a39430bca0f229",
+      "digest": "sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
+      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
       "repository": "ghcr.io/baseintelligence/base/prism-challenge"
     },
     "updater": {
-      "digest": "sha256:f7cb8d40f575888bfad536c20f1045db73a73e5e3b2253caff59974bde556320",
-      "image": "ghcr.io/baseintelligence/base/updater@sha256:f7cb8d40f575888bfad536c20f1045db73a73e5e3b2253caff59974bde556320",
+      "digest": "sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
+      "image": "ghcr.io/baseintelligence/base/updater@sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
       "repository": "ghcr.io/baseintelligence/base/updater"
     },
     "validator": {
-      "digest": "sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
-      "image": "ghcr.io/baseintelligence/base/validator@sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
+      "digest": "sha256:85fff99d0220888ee073d60a625c1b0b190f8e0fa5a4429a912d8fdf00e5028d",
+      "image": "ghcr.io/baseintelligence/base/validator@sha256:85fff99d0220888ee073d60a625c1b0b190f8e0fa5a4429a912d8fdf00e5028d",
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-12T11:29:10Z"
+  "updated_at": "2026-08-12T15:25:21Z"
 }


### PR DESCRIPTION
## Summary
- Promote staging digests for `b05a75f8` (prism sealed BYOK retry reuse) to `deploy/pins/prod.json`.

## Test plan
- [ ] Merge → remote-deploy prod master/validator with registry pins
- [ ] Confirm OpenRouter similarity gate stays 200; recovered cohort not re-orphaned mid-train (deploy after GPU drain if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment metadata and service image references.
  * Refreshed deployment version information and timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->