### PR TITLE
fix(site): surface Prism G2 benches (ARC-E + Zone-A)

### DIFF
--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -11,8 +11,9 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::prism_enrich::{
-    enrich_leaderboard_row_from_detail, enrich_submission_from_detail, pin_id_from_payload,
-    prism_reference_baselines, prism_submission_detail,
+    enrich_leaderboard_row_from_detail_with_zone, enrich_submission_from_detail_with_zone,
+    map_benchmarks, pin_id_from_payload, prism_reference_baselines,
+    prism_submission_detail_with_zone,
 };
 use crate::state::SiteState;
 use crate::upstream::{self, DESIGN, PRISM};
@@ -454,8 +455,8 @@ async fn prism_leaderboard_json(
     let details = fetch_prism_details(st, &ids).await;
     for row in &mut board {
         if let Some(id) = row.submission_id.as_ref() {
-            if let Some(detail) = details.get(id) {
-                enrich_leaderboard_row_from_detail(row, detail);
+            if let Some(fan) = details.get(id) {
+                enrich_leaderboard_row_from_detail_with_zone(row, &fan.detail, fan.zone_a.as_ref());
             }
         }
         if row.recipe_era.is_none() {
@@ -480,8 +481,14 @@ async fn prism_leaderboard_json(
     })
 }
 
+/// Detail fan-out payload (+ optional Zone-A metrics when detail lacks G2 benches).
+struct PrismDetailFanout {
+    detail: Value,
+    zone_a: Option<Value>,
+}
+
 /// Fetch bounded challenge detail payloads keyed by submission id.
-async fn fetch_prism_details(st: &SiteState, ids: &[String]) -> HashMap<String, Value> {
+async fn fetch_prism_details(st: &SiteState, ids: &[String]) -> HashMap<String, PrismDetailFanout> {
     let mut out = HashMap::new();
     for id in ids {
         if id.is_empty() {
@@ -502,10 +509,26 @@ async fn fetch_prism_details(st: &SiteState, ids: &[String]) -> HashMap<String, 
                     }
                 }
             }
-            out.insert(id.clone(), detail);
+            let zone_a = fetch_prism_zone_a_if_needed(st, id, &detail).await;
+            out.insert(id.clone(), PrismDetailFanout { detail, zone_a });
         }
     }
     out
+}
+
+/// When detail metrics omit public G2 benches, pull Zone-A rows from the eval store.
+async fn fetch_prism_zone_a_if_needed(st: &SiteState, id: &str, detail: &Value) -> Option<Value> {
+    let root = detail.get("submission").unwrap_or(detail);
+    let benches = map_benchmarks(root.get("metrics").filter(|m| !m.is_null()));
+    if !benches.is_empty() {
+        return None;
+    }
+    if let Some(battery_metrics) = root.pointer("/metrics/battery/metrics") {
+        if !map_benchmarks(Some(battery_metrics)).is_empty() {
+            return None;
+        }
+    }
+    upstream::get_json_opt(st, PRISM, &format!("/v1/submissions/{id}/metrics?zone=a")).await
 }
 
 async fn get_leaderboard(
@@ -576,8 +599,8 @@ async fn get_submissions(
             ids.truncate(PRISM_CHAMPION_DETAIL_FANOUT);
             let details = fetch_prism_details(&st, &ids).await;
             for item in &mut items {
-                if let Some(detail) = details.get(&item.id) {
-                    enrich_submission_from_detail(item, detail);
+                if let Some(fan) = details.get(&item.id) {
+                    enrich_submission_from_detail_with_zone(item, &fan.detail, fan.zone_a.as_ref());
                 } else if item.recipe_era.is_none() {
                     // Pre-2.0 / unknown → legacy so era tabs are not empty.
                     item.recipe_era = Some(RecipeEra::Legacy);
@@ -841,7 +864,8 @@ async fn get_prism_submission_detail(
             }
         }
     }
-    match prism_submission_detail(&detail) {
+    let zone_a = fetch_prism_zone_a_if_needed(&st, &id, &detail).await;
+    match prism_submission_detail_with_zone(&detail, zone_a.as_ref()) {
         Some(d) => Json(d).into_response(),
         None => json_err(
             StatusCode::NOT_FOUND,

--- a/crates/site-api/src/prism_enrich.rs
+++ b/crates/site-api/src/prism_enrich.rs
@@ -22,6 +22,8 @@ pub const GPT2_SMALL_PARAMS_M: f64 = 124.0;
 
 /// HellaSwag `acc_norm` for gpt2 (Eleuther harness; commonly cited 31.14%).
 pub const GPT2_HELLASWAG: f64 = 0.3114;
+/// ARC-Easy `acc` (zero-shot Eleuther-style gpt2).
+pub const GPT2_ARC_EASY: f64 = 0.4381;
 /// ARC-Challenge `acc_norm` (zero-shot Eleuther-style gpt2).
 pub const GPT2_ARC_CHALLENGE: f64 = 0.2270;
 /// PIQA `acc_norm` (zero-shot Eleuther-style gpt2).
@@ -41,6 +43,7 @@ pub fn prism_reference_baselines() -> Vec<PrismReferenceBaseline> {
         bpb: None,
         benchmarks: PrismBenchmarks {
             hellaswag: Some(GPT2_HELLASWAG),
+            arc_easy: Some(GPT2_ARC_EASY),
             arc_challenge: Some(GPT2_ARC_CHALLENGE),
             piqa: Some(GPT2_PIQA),
             winogrande: Some(GPT2_WINOGRANDE),
@@ -130,19 +133,99 @@ pub fn map_benchmarks(metrics: Option<&Value>) -> PrismBenchmarks {
         return PrismBenchmarks::default();
     };
     PrismBenchmarks {
-        hellaswag: metric_f64(metrics, &["org.g2.hellaswag_acc", "g2.hellaswag.acc_norm"]),
+        hellaswag: metric_f64(
+            metrics,
+            &[
+                "org.g2.hellaswag_acc",
+                "g2.hellaswag.acc_norm",
+                "g2.hellaswag.acc",
+            ],
+        ),
+        arc_easy: metric_f64(
+            metrics,
+            &[
+                "org.g2.arc_easy_acc",
+                "g2.arc_easy.acc_norm",
+                "g2.arc_easy.acc",
+            ],
+        ),
         arc_challenge: metric_f64(
             metrics,
-            &["org.g2.arc_challenge_acc", "g2.arc_challenge.acc_norm"],
+            &[
+                "org.g2.arc_challenge_acc",
+                "g2.arc_challenge.acc_norm",
+                "g2.arc_challenge.acc",
+            ],
         ),
-        piqa: metric_f64(metrics, &["org.g2.piqa_acc", "g2.piqa.acc_norm"]),
-        winogrande: metric_f64(metrics, &["org.g2.winogrande_acc", "g2.winogrande.acc"]),
-        boolq: metric_f64(metrics, &["org.g2.boolq_acc", "g2.boolq.acc"]),
+        piqa: metric_f64(
+            metrics,
+            &["org.g2.piqa_acc", "g2.piqa.acc_norm", "g2.piqa.acc"],
+        ),
+        winogrande: metric_f64(
+            metrics,
+            &[
+                "org.g2.winogrande_acc",
+                "g2.winogrande.acc_norm",
+                "g2.winogrande.acc",
+            ],
+        ),
+        boolq: metric_f64(
+            metrics,
+            &["org.g2.boolq_acc", "g2.boolq.acc_norm", "g2.boolq.acc"],
+        ),
     }
 }
 
+/// Flatten `GET /v1/submissions/{id}/metrics?zone=a` → object keyed by metric name.
+///
+/// Zone-A rows are `{ key, value | point }` arrays; challenge detail sometimes
+/// omits flattened `org.g2.*` on `submission.metrics` even when the eval store
+/// has them. Callers merge this into bench mapping so the FE still surfaces.
+#[must_use]
+pub fn metrics_object_from_zone_a(zone: &Value) -> Option<Value> {
+    let rows = zone.get("metrics")?.as_array()?;
+    let mut map = serde_json::Map::new();
+    for row in rows {
+        let key = row.get("key").and_then(Value::as_str)?;
+        let val = row
+            .get("value")
+            .cloned()
+            .or_else(|| row.get("point").cloned())
+            .filter(|v| !v.is_null())?;
+        map.insert(key.to_owned(), val);
+    }
+    if map.is_empty() {
+        return None;
+    }
+    Some(Value::Object(map))
+}
+
+/// Resolve public benches from detail metrics and optional zone-A payload.
+#[must_use]
+pub fn resolve_benchmarks(detail: &Value, zone_a: Option<&Value>) -> PrismBenchmarks {
+    let root = detail.get("submission").unwrap_or(detail);
+    let mut benches = map_benchmarks(root.get("metrics").filter(|m| !m.is_null()));
+    // Battery blob may nest under metrics without top-level org.* copies.
+    if benches.is_empty() {
+        if let Some(battery_metrics) = root.pointer("/metrics/battery/metrics") {
+            benches = map_benchmarks(Some(battery_metrics));
+        }
+    }
+    if let Some(zone) = zone_a {
+        if let Some(obj) = metrics_object_from_zone_a(zone) {
+            let from_zone = map_benchmarks(Some(&obj));
+            benches.merge_missing(&from_zone);
+        }
+    }
+    benches
+}
+
 /// Copy era / pin / eval groups / benches from a detail payload onto a board row.
-pub fn enrich_leaderboard_row_from_detail(row: &mut LeaderboardRow, detail: &Value) {
+pub fn enrich_leaderboard_row_from_detail_with_zone(
+    row: &mut LeaderboardRow,
+    detail: &Value,
+    zone_a: Option<&Value>,
+) {
     let root = detail.get("submission").unwrap_or(detail);
     let era = infer_recipe_era(detail);
     row.recipe_era = Some(era);
@@ -152,14 +235,18 @@ pub fn enrich_leaderboard_row_from_detail(row: &mut LeaderboardRow, detail: &Val
     if let Some(groups) = map_eval_groups(root.get("eval").filter(|e| !e.is_null())) {
         row.eval_groups = Some(groups);
     }
-    let benches = map_benchmarks(root.get("metrics").filter(|m| !m.is_null()));
+    let benches = resolve_benchmarks(detail, zone_a);
     if !benches.is_empty() {
         row.benchmarks = Some(benches);
     }
 }
 
 /// Apply detail fan-out fields onto a list [`Submission`].
-pub fn enrich_submission_from_detail(sub: &mut Submission, detail: &Value) {
+pub fn enrich_submission_from_detail_with_zone(
+    sub: &mut Submission,
+    detail: &Value,
+    zone_a: Option<&Value>,
+) {
     let root = detail.get("submission").unwrap_or(detail);
     let era = infer_recipe_era(detail);
     sub.recipe_era = Some(era);
@@ -172,7 +259,7 @@ pub fn enrich_submission_from_detail(sub: &mut Submission, detail: &Value) {
         sub.eval_groups = Some(groups);
     }
     let metrics = root.get("metrics").filter(|m| !m.is_null());
-    let benches = map_benchmarks(metrics);
+    let benches = resolve_benchmarks(detail, zone_a);
     if !benches.is_empty() {
         sub.benchmarks = Some(benches);
     }
@@ -196,12 +283,15 @@ pub fn enrich_submission_from_detail(sub: &mut Submission, detail: &Value) {
     }
 }
 
-/// Map challenge `GET /v1/submissions/{id}` → public [`PrismSubmissionDetail`].
+/// Map challenge `GET /v1/submissions/{id}` (+ optional Zone-A) → public detail.
 #[must_use]
-pub fn prism_submission_detail(detail: &Value) -> Option<PrismSubmissionDetail> {
+pub fn prism_submission_detail_with_zone(
+    detail: &Value,
+    zone_a: Option<&Value>,
+) -> Option<PrismSubmissionDetail> {
     let root = detail.get("submission")?;
     let mut sub = prism_submission(root)?;
-    enrich_submission_from_detail(&mut sub, detail);
+    enrich_submission_from_detail_with_zone(&mut sub, detail, zone_a);
     let eval = root
         .get("eval")
         .filter(|e| !e.is_null())
@@ -290,18 +380,15 @@ fn metric_f64(metrics: &Value, keys: &[&str]) -> Option<f64> {
         if let Some(v) = lookup_metric(metrics, key) {
             return Some(v);
         }
-        // Nested under battery.groups.g2.metrics
-        if let Some(v) = metrics
-            .pointer(&format!("/battery/groups/g2/metrics/{key}"))
-            .and_then(as_f64_val)
-        {
-            return Some(v);
-        }
-        if let Some(v) = metrics
-            .pointer(&format!("/battery/metrics/{key}"))
-            .and_then(as_f64_val)
-        {
-            return Some(v);
+        // Nested under battery.groups.g2.metrics / battery.metrics (METRICS_JSON v2).
+        for path in [
+            format!("/battery/groups/g2/metrics/{key}"),
+            format!("/battery/metrics/{key}"),
+            format!("/groups/g2/metrics/{key}"),
+        ] {
+            if let Some(v) = metrics.pointer(&path).and_then(as_metric_node) {
+                return Some(v);
+            }
         }
     }
     None
@@ -309,7 +396,13 @@ fn metric_f64(metrics: &Value, keys: &[&str]) -> Option<f64> {
 
 fn lookup_metric(metrics: &Value, key: &str) -> Option<f64> {
     let v = metrics.get(key)?;
-    as_f64_val(v).or_else(|| v.get("value").and_then(as_f64_val))
+    as_metric_node(v)
+}
+
+fn as_metric_node(v: &Value) -> Option<f64> {
+    as_f64_val(v)
+        .or_else(|| v.get("value").and_then(as_f64_val))
+        .or_else(|| v.get("point").and_then(as_f64_val))
 }
 
 fn as_f64_val(v: &Value) -> Option<f64> {
@@ -343,18 +436,46 @@ mod tests {
         let m = json!({
             "org.g2.hellaswag_acc": {"value": 0.31},
             "org.g2.piqa_acc": {"value": 0.62},
+            "org.g2.arc_easy_acc": {"value": 0.44},
             "battery": {"groups": {"g2": {"metrics": {
                 "g2.arc_challenge.acc_norm": 0.22,
-                "g2.winogrande.acc": 0.51,
+                "g2.winogrande.acc_norm": 0.51,
                 "g2.boolq.acc": 0.60
             }}}}
         });
         let b = map_benchmarks(Some(&m));
         assert!((b.hellaswag.unwrap() - 0.31).abs() < f64::EPSILON);
         assert!((b.piqa.unwrap() - 0.62).abs() < f64::EPSILON);
+        assert!((b.arc_easy.unwrap() - 0.44).abs() < f64::EPSILON);
         assert!((b.arc_challenge.unwrap() - 0.22).abs() < f64::EPSILON);
         assert!((b.winogrande.unwrap() - 0.51).abs() < f64::EPSILON);
         assert!((b.boolq.unwrap() - 0.60).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn zone_a_metrics_fill_missing_benches() {
+        let detail = json!({
+            "submission": {
+                "id": "z1",
+                "miner_hotkey": "aa".repeat(32),
+                "epoch": 1,
+                "status": "terminated",
+                "label": "z",
+                "bpb": 1.1,
+                "created_at_ms": 1u64,
+                "metrics": { "bpb": 1.1, "recipe": "2.0.0" }
+            }
+        });
+        let zone = json!({
+            "zone": "a",
+            "metrics": [
+                {"key": "org.g2.hellaswag_acc", "value": 0.33},
+                {"key": "org.g2.arc_easy_acc", "point": 0.41}
+            ]
+        });
+        let b = resolve_benchmarks(&detail, Some(&zone));
+        assert!((b.hellaswag.unwrap() - 0.33).abs() < 1e-9);
+        assert!((b.arc_easy.unwrap() - 0.41).abs() < 1e-9);
     }
 
     #[test]
@@ -418,7 +539,7 @@ mod tests {
             },
             "events": []
         });
-        let d = prism_submission_detail(&detail).unwrap();
+        let d = prism_submission_detail_with_zone(&detail, None).unwrap();
         assert_eq!(d.submission.recipe_era, Some(RecipeEra::Automodel));
         assert_eq!(d.submission.pin_id.as_deref(), Some("automodel@v0.5.0"));
         assert!((d.submission.benchmarks.as_ref().unwrap().hellaswag.unwrap() - 0.4).abs() < 1e-9);

--- a/crates/site-types/src/types.rs
+++ b/crates/site-types/src/types.rs
@@ -161,6 +161,9 @@ pub struct PrismBenchmarks {
     /// HellaSwag accuracy (prefer `acc_norm` / `org.g2.hellaswag_acc`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hellaswag: Option<f64>,
+    /// ARC-Easy accuracy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arc_easy: Option<f64>,
     /// ARC-Challenge accuracy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub arc_challenge: Option<f64>,
@@ -180,10 +183,33 @@ impl PrismBenchmarks {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.hellaswag.is_none()
+            && self.arc_easy.is_none()
             && self.arc_challenge.is_none()
             && self.piqa.is_none()
             && self.winogrande.is_none()
             && self.boolq.is_none()
+    }
+
+    /// Merge non-empty fields from `other` into `self` (fill gaps only).
+    pub fn merge_missing(&mut self, other: &Self) {
+        if self.hellaswag.is_none() {
+            self.hellaswag = other.hellaswag;
+        }
+        if self.arc_easy.is_none() {
+            self.arc_easy = other.arc_easy;
+        }
+        if self.arc_challenge.is_none() {
+            self.arc_challenge = other.arc_challenge;
+        }
+        if self.piqa.is_none() {
+            self.piqa = other.piqa;
+        }
+        if self.winogrande.is_none() {
+            self.winogrande = other.winogrande;
+        }
+        if self.boolq.is_none() {
+            self.boolq = other.boolq;
+        }
     }
 }
 

--- a/docs/SITE_API.md
+++ b/docs/SITE_API.md
@@ -51,7 +51,7 @@ Champion list / leaderboard rows may carry (when detail fan-out succeeds):
 | `recipeEra` | `"automodel"` \| `"legacy"` — AutoModel if `pin_id` / recipe major ≥ 2 / diff shape; else legacy |
 | `pinId` | AutoModel pin (`automodel@…`) when era is automodel |
 | `evalGroups` | `{ group: "g1"…"g8", g }` from composite `eval.groups` |
-| `benchmarks` | Public G2 subset: `hellaswag`, `arcChallenge`, `piqa`, `winogrande`, `boolq` from `org.g2.*` / battery keys |
+| `benchmarks` | Public G2 subset: `hellaswag`, `arcEasy`, `arcChallenge`, `piqa`, `winogrande`, `boolq` from `org.g2.*` / battery keys (Zone-A `/metrics?zone=a` fan-in when detail omits them) |
 | `submissionId` | (leaderboard) best-BPB champion id for the detail modal |
 
 Additional Prism routes:


### PR DESCRIPTION
## Summary
- Add `arcEasy` to public `PrismBenchmarks` and widen harness key aliases (`acc_norm`, nested battery paths).
- Fan in `GET /v1/submissions/{id}/metrics?zone=a` when challenge detail metrics are BPB-only so site-api does not drop benches the eval store already has.
- Document the contract in `docs/SITE_API.md`.

## Test plan
- [ ] `cargo test -p site-api --lib`
- [ ] `cargo clippy -p site-api -p site-types --all-targets -- -D warnings`
- [ ] With a submission that has Zone-A `org.g2.*` but thin `submission.metrics`, site list/detail returns `benchmarks.hellaswag` / `arcEasy` / …
- [ ] FE PR consumes the wider payload once gateway ships

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARC-Easy benchmark reporting, including GPT-2 reference comparisons.
  * Improved benchmark recovery from nested metrics and Zone-A data when primary details are incomplete.
  * Enriched leaderboard, submission lists, and submission details with additional benchmark results.

* **Documentation**
  * Updated API documentation to include the `arcEasy` benchmark in the public benchmark data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->