### PR TITLE
chore(deploy): promote prod gateway pin for 027d1100 (#135)

### DIFF
--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,5 +1,5 @@
 {
-  "commit_sha": "b05a75f8d67758c3679c51bf5e30b3ab1f24d03e",
+  "commit_sha": "027d11007c0ea3247378f233fd09408bec719950",
   "env": "prod",
   "previous": {
     "commit_sha": "b05a75f8d67758c3679c51bf5e30b3ab1f24d03e",
@@ -25,8 +25,8 @@
         "repository": "ghcr.io/baseintelligence/base/updater"
       },
       "validator": {
-        "digest": "sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
-        "image": "ghcr.io/baseintelligence/base/validator@sha256:8fcec85caa8c0dd990b40e728545f1acb2beda7facf54b947093ceb5b052644a",
+        "digest": "sha256:85fff99d0220888ee073d60a625c1b0b190f8e0fa5a4429a912d8fdf00e5028d",
+        "image": "ghcr.io/baseintelligence/base/validator@sha256:85fff99d0220888ee073d60a625c1b0b190f8e0fa5a4429a912d8fdf00e5028d",
         "repository": "ghcr.io/baseintelligence/base/validator"
       }
     },
@@ -39,8 +39,8 @@
       "repository": "ghcr.io/baseintelligence/base/design-challenge"
     },
     "gateway": {
-      "digest": "sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
-      "image": "ghcr.io/baseintelligence/base/gateway@sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
+      "digest": "sha256:89c7a1bf2d77619907be1edabb5fe0ea985570cb3c4470578bb516037e595fa9",
+      "image": "ghcr.io/baseintelligence/base/gateway@sha256:89c7a1bf2d77619907be1edabb5fe0ea985570cb3c4470578bb516037e595fa9",
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
@@ -59,5 +59,5 @@
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-12T15:25:21Z"
+  "updated_at": "2026-08-13T05:10:34Z"
 }


### PR DESCRIPTION
## Summary
- Promote staging gateway digest for `027d1100` (#135 site-api G2/ARC-E + Zone-A fan-in) into `deploy/pins/prod.json`.
- **Does not** move prism-challenge / validator / design pins (GPU jobs still running).
- Pre-promote local dump taken at `/tmp/base-prod-pre-gateway-027d1100.sql.gz` (Spaces upload skipped from this host).

## Deploy notes
- Surgical master roll already applied: pull + `compose up -d --no-deps gateway` only; prism image left at `2e37d3b9…`; AutoModel pin preserved.
- Challenge backends reseeded to `prism-challenge:8092` / `design-challenge:8093`.

## Test plan
- [x] `GET https://chain.joinbase.ai/v1/site/arenas/prism/references` includes `benchmarks.arcEasy`
- [x] gateway healthz + `/challenge/prism/health` 200
- [x] prism container image unchanged across roll
- [ ] Merge pin commit for bookkeeping