### PR TITLE
chore(deploy): promote prod pins for a38dad2b

### DIFF
--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,27 +1,27 @@
 {
-  "commit_sha": "027d11007c0ea3247378f233fd09408bec719950",
+  "commit_sha": "a38dad2ba8a1f161aa42baab0dc154a48e4829d2",
   "env": "prod",
   "previous": {
-    "commit_sha": "b05a75f8d67758c3679c51bf5e30b3ab1f24d03e",
+    "commit_sha": "a38dad2ba8a1f161aa42baab0dc154a48e4829d2",
     "services": {
       "design-challenge": {
-        "digest": "sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
-        "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
+        "digest": "sha256:d02828b70affbf405fc9b38f518b59cbf8a589ad2ed6535320a120e6a98078ea",
+        "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:d02828b70affbf405fc9b38f518b59cbf8a589ad2ed6535320a120e6a98078ea",
         "repository": "ghcr.io/baseintelligence/base/design-challenge"
       },
       "gateway": {
-        "digest": "sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
-        "image": "ghcr.io/baseintelligence/base/gateway@sha256:7b989f38dbbdc456e8679953b39e09872c83596855091f197217749f627f12df",
+        "digest": "sha256:8f3f7d84f0affc5c8d2a2e95372f33ed6d14ecd03c7971a7d92c7cfe3308d2bd",
+        "image": "ghcr.io/baseintelligence/base/gateway@sha256:8f3f7d84f0affc5c8d2a2e95372f33ed6d14ecd03c7971a7d92c7cfe3308d2bd",
         "repository": "ghcr.io/baseintelligence/base/gateway"
       },
       "prism-challenge": {
-        "digest": "sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
-        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
+        "digest": "sha256:e8d9914a355067a6cb791f6095430bab7b77975f47972382ef5cbad6e598ab70",
+        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:e8d9914a355067a6cb791f6095430bab7b77975f47972382ef5cbad6e598ab70",
         "repository": "ghcr.io/baseintelligence/base/prism-challenge"
       },
       "updater": {
-        "digest": "sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
-        "image": "ghcr.io/baseintelligence/base/updater@sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
+        "digest": "sha256:aba1e9eb7d8873a35be861897afc8a9e989fcc82ce39c81d14a0cbc0bb4737ce",
+        "image": "ghcr.io/baseintelligence/base/updater@sha256:aba1e9eb7d8873a35be861897afc8a9e989fcc82ce39c81d14a0cbc0bb4737ce",
         "repository": "ghcr.io/baseintelligence/base/updater"
       },
       "validator": {
@@ -30,34 +30,34 @@
         "repository": "ghcr.io/baseintelligence/base/validator"
       }
     },
-    "updated_at": "2026-08-12T15:25:21Z"
+    "updated_at": "2026-08-13T12:56:47Z"
   },
   "services": {
     "design-challenge": {
-      "digest": "sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
-      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:fb859980db169762ffac5d46023fe8d4d610c016defe2b2e49d404d4b70c4a74",
+      "digest": "sha256:d02828b70affbf405fc9b38f518b59cbf8a589ad2ed6535320a120e6a98078ea",
+      "image": "ghcr.io/baseintelligence/base/design-challenge@sha256:d02828b70affbf405fc9b38f518b59cbf8a589ad2ed6535320a120e6a98078ea",
       "repository": "ghcr.io/baseintelligence/base/design-challenge"
     },
     "gateway": {
-      "digest": "sha256:89c7a1bf2d77619907be1edabb5fe0ea985570cb3c4470578bb516037e595fa9",
-      "image": "ghcr.io/baseintelligence/base/gateway@sha256:89c7a1bf2d77619907be1edabb5fe0ea985570cb3c4470578bb516037e595fa9",
+      "digest": "sha256:8f3f7d84f0affc5c8d2a2e95372f33ed6d14ecd03c7971a7d92c7cfe3308d2bd",
+      "image": "ghcr.io/baseintelligence/base/gateway@sha256:8f3f7d84f0affc5c8d2a2e95372f33ed6d14ecd03c7971a7d92c7cfe3308d2bd",
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
-      "digest": "sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
-      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:e137aba29a224425fcd4821cbe6d781e5d04ee53998788b0b82bde317d5e23ae",
+      "digest": "sha256:e8d9914a355067a6cb791f6095430bab7b77975f47972382ef5cbad6e598ab70",
+      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:e8d9914a355067a6cb791f6095430bab7b77975f47972382ef5cbad6e598ab70",
       "repository": "ghcr.io/baseintelligence/base/prism-challenge"
     },
     "updater": {
-      "digest": "sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
-      "image": "ghcr.io/baseintelligence/base/updater@sha256:9668afa5f074606dacf4fbf0aedbf249baf547d08ab9e27e31798d2bb5dfabd4",
+      "digest": "sha256:aba1e9eb7d8873a35be861897afc8a9e989fcc82ce39c81d14a0cbc0bb4737ce",
+      "image": "ghcr.io/baseintelligence/base/updater@sha256:aba1e9eb7d8873a35be861897afc8a9e989fcc82ce39c81d14a0cbc0bb4737ce",
       "repository": "ghcr.io/baseintelligence/base/updater"
     },
     "validator": {
-      "digest": "sha256:85fff99d0220888ee073d60a625c1b0b190f8e0fa5a4429a912d8fdf00e5028d",
-      "image": "ghcr.io/baseintelligence/base/validator@sha256:85fff99d0220888ee073d60a625c1b0b190f8e0fa5a4429a912d8fdf00e5028d",
+      "digest": "sha256:49a1e4f1c7912b17eb1eda08fc78e556f17aacec79c23eaec5c5b894da619e64",
+      "image": "ghcr.io/baseintelligence/base/validator@sha256:49a1e4f1c7912b17eb1eda08fc78e556f17aacec79c23eaec5c5b894da619e64",
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-13T05:10:34Z"
+  "updated_at": "2026-08-13T12:56:47Z"
 }


### PR DESCRIPTION
## Summary
- Promote full staging tip `a38dad2b` digests to prod pins (#136+#138+#139+#140).
- Operator took local Postgres dump before pin write; Spaces backup remains with deploy-prod.yml.

## Test plan
- [x] `running==0` after Lium terminate
- [ ] remote-deploy master+validator `--build-from registry`
- [ ] Post-deploy: PRISM_FLOW=v3, EVAL_CAPS=0, mounts + digest verify
- [ ] Relaunch sealed BYOK jobs via `/v1/submissions/{id}/retry`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration and service versions.
  * Refreshed deployment metadata to support consistent production releases.
  * No user-facing features or functionality were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->