### PR TITLE
fix(chain-live): dynamic runtime version for weight signing

### DIFF
--- a/crates/chain-live/src/lib.rs
+++ b/crates/chain-live/src/lib.rs
@@ -37,11 +37,11 @@ use std::time::{Duration, Instant};
 
 use parity_scale_codec::Encode;
 
-/// Lockfile-pinned spec version (`metadata/testnet.lock` → 443).
-const SPEC_VERSION: u32 = 443;
-/// Lockfile-pinned transaction version (1).
-const TRANSACTION_VERSION: u32 = 1;
 /// Lockfile-pinned commit-reveal version (CRV4 = 4).
+///
+/// `spec_version` / `transaction_version` are **not** pinned here: signing
+/// always uses the live values from `state_getRuntimeVersion` so a Finney
+/// runtime bump cannot stall weight submits waiting for a lockfile bump.
 const COMMIT_REVEAL_VERSION: u16 = 4;
 /// Default netuid (lockfile `snapshot_netuid` = 1).
 const DEFAULT_NETUID: u16 = 1;
@@ -91,8 +91,6 @@ struct MetagraphCache {
 pub struct LiveChainClient {
     rpc: LiveChainRpc,
     netuid: u16,
-    spec_version: u32,
-    tx_version: u32,
     signing_key: Option<[u8; 32]>,
     metagraph_cache: Mutex<MetagraphCache>,
     /// Overrideable for tests; production always uses [`METAGRAPH_CACHE_TTL`].
@@ -103,8 +101,6 @@ impl std::fmt::Debug for LiveChainClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LiveChainClient")
             .field("netuid", &self.netuid)
-            .field("spec_version", &self.spec_version)
-            .field("tx_version", &self.tx_version)
             .field(
                 "signing_key",
                 &self.signing_key.as_ref().map(|_| "<redacted>"),
@@ -130,8 +126,6 @@ impl LiveChainClient {
         Ok(Self {
             rpc,
             netuid: DEFAULT_NETUID,
-            spec_version: SPEC_VERSION,
-            tx_version: TRANSACTION_VERSION,
             signing_key: None,
             metagraph_cache: Mutex::new(MetagraphCache::default()),
             metagraph_cache_ttl: METAGRAPH_CACHE_TTL,
@@ -255,27 +249,19 @@ impl LiveChainClient {
             .ok_or_else(|| ChainError::Other("no signing key loaded (use with_signing_key)".into()))
     }
 
-    /// Check live runtime version against lockfile pins before signing.
-    fn check_runtime_version(&self) -> Result<(), ChainError> {
+    /// Fetch live `(spec_version, transaction_version)` for signed extrinsics.
+    ///
+    /// Always trusts the chain tip — never compares against a local pin. Call
+    /// indices / CRV4 shape still come from the committed lockfile; only the
+    /// additional-signed runtime versions are dynamic.
+    fn live_runtime_version(&self) -> Result<(u32, u32), ChainError> {
         let rt = self.rpc.state_get_runtime_version()?;
         tracing::debug!(
             spec = rt.spec_version,
             tx = rt.transaction_version,
-            "runtime version check"
+            "live runtime version for signing"
         );
-        if rt.spec_version != self.spec_version {
-            return Err(ChainError::Other(format!(
-                "spec_version mismatch: live {} vs lockfile {} — refusing to sign",
-                rt.spec_version, self.spec_version
-            )));
-        }
-        if rt.transaction_version != self.tx_version {
-            return Err(ChainError::Other(format!(
-                "transaction_version mismatch: live {} vs lockfile {} — refusing to sign",
-                rt.transaction_version, self.tx_version
-            )));
-        }
-        Ok(())
+        Ok((rt.spec_version, rt.transaction_version))
     }
 
     /// Read `commit_reveal_weights_enabled` from hyperparams v3 runtime API.
@@ -442,9 +428,9 @@ impl LiveChainClient {
     /// Returns the extrinsic hash / subscription ID from the node.
     ///
     /// # Errors
-    /// Runtime-version drift, missing signing key, transport failure.
+    /// Missing signing key, transport failure, or runtime-version RPC failure.
     pub fn serve_axon(&self, params: &extrinsic::ServeAxonParams) -> Result<String, ChainError> {
-        self.check_runtime_version()?;
+        let (spec_version, tx_version) = self.live_runtime_version()?;
         let key = self.require_key()?;
         let genesis_hash = self.block_hash(0)?;
         let pubkey = extrinsic::derive_public_key(&key)?;
@@ -455,8 +441,8 @@ impl LiveChainClient {
             &Era::Immortal,
             &genesis_hash,
             &genesis_hash,
-            self.spec_version,
-            self.tx_version,
+            spec_version,
+            tx_version,
             params,
         )?;
         self.submit_extrinsic(&ext)
@@ -568,7 +554,7 @@ pub(crate) fn parse_commit_reveal_enabled_v3(bytes: &[u8]) -> Option<bool> {
     let after = pos.checked_add(NEEDLE.len())?;
     let tag = *bytes.get(after)?;
     let val = *bytes.get(after.checked_add(1)?)?;
-    // Variant 0 = Bool in the hyperparam value enum (verified on Finney v443).
+    // Variant 0 = Bool in the hyperparam value enum (verified on Finney v445).
     if tag != 0 {
         return None;
     }
@@ -713,7 +699,7 @@ impl ChainClient for LiveChainClient {
                 alternate: "set_weights",
             });
         }
-        self.check_runtime_version()?;
+        let (spec_version, tx_version) = self.live_runtime_version()?;
         let key = self.require_key()?;
 
         // CRV4: encrypt SCALE WeightsTlockPayload with Drand TLE (same wire
@@ -735,8 +721,8 @@ impl ChainClient for LiveChainClient {
             &Era::Immortal,
             &genesis_hash,
             &genesis_hash,
-            self.spec_version,
-            self.tx_version,
+            spec_version,
+            tx_version,
             self.netuid,
             mecid,
             &commit,
@@ -782,7 +768,7 @@ impl ChainClient for LiveChainClient {
                 "set_weights refused: commit_reveal is enabled — never downgrade".into(),
             ));
         }
-        self.check_runtime_version()?;
+        let (spec_version, tx_version) = self.live_runtime_version()?;
         let key = self.require_key()?;
         let genesis_hash = self.block_hash(0)?;
         let pubkey = extrinsic::derive_public_key(&key)?;
@@ -793,8 +779,8 @@ impl ChainClient for LiveChainClient {
             &Era::Immortal,
             &genesis_hash,
             &genesis_hash,
-            self.spec_version,
-            self.tx_version,
+            spec_version,
+            tx_version,
             netuid,
             &uids,
             &values,

--- a/crates/chain-live/src/tests.rs
+++ b/crates/chain-live/src/tests.rs
@@ -381,7 +381,7 @@ async fn mock_runtime_version_ok() {
             "jsonrpc": "2.0", "id": 1,
             "result": {
                 "specName": "node-subtensor",
-                "specVersion": 443,
+                "specVersion": 445,
                 "transactionVersion": 1
             }
         })))
@@ -396,7 +396,7 @@ async fn mock_runtime_version_ok() {
     .await
     .expect("spawn_blocking")
     .expect("runtime version");
-    assert_eq!(rt.spec_version, 443);
+    assert_eq!(rt.spec_version, 445);
     assert_eq!(rt.transaction_version, 1);
 }
 
@@ -490,7 +490,7 @@ async fn set_weights_rejected_when_cr_enabled() {
 }
 
 #[tokio::test]
-async fn set_weights_refuses_on_spec_version_mismatch() {
+async fn set_weights_accepts_any_live_spec_version() {
     let server = MockServer::start().await;
 
     // Mock CommitRevealWeightsEnabled(1) → false (0x00)
@@ -508,7 +508,7 @@ async fn set_weights_refuses_on_spec_version_mismatch() {
         .mount(&server)
         .await;
 
-    // Mock runtime version with mismatched spec_version (441 instead of 443)
+    // Live tip can be any spec_version — signing must not fail-closed on pin drift.
     Mock::given(method("POST"))
         .and(body_partial_json(
             json!({"method": "state_getRuntimeVersion"}),
@@ -517,8 +517,8 @@ async fn set_weights_refuses_on_spec_version_mismatch() {
             "jsonrpc": "2.0", "id": 1,
             "result": {
                 "specName": "node-subtensor",
-                "specVersion": 441,
-                "transactionVersion": 1
+                "specVersion": 999_001,
+                "transactionVersion": 7
             }
         })))
         .mount(&server)
@@ -532,10 +532,19 @@ async fn set_weights_refuses_on_spec_version_mismatch() {
     .await
     .expect("spawn_blocking");
 
-    let err = result.expect_err("must refuse");
+    // Without a signing key we still fail, but never on spec_version mismatch.
+    let err = result.expect_err("must fail closed without signing key");
     match err {
         ChainError::Other(msg) => {
-            assert!(msg.contains("spec_version mismatch"), "msg: {msg}");
+            assert!(
+                !msg.contains("spec_version mismatch")
+                    && !msg.contains("transaction_version mismatch"),
+                "must accept live runtime versions; got: {msg}"
+            );
+            assert!(
+                msg.contains("no signing key"),
+                "expected missing-key failure after live version fetch; got: {msg}"
+            );
         }
         other => panic!("expected Other, got {other}"),
     }
@@ -1271,7 +1280,7 @@ async fn submit_timelocked_ok_only_after_dispatch_confirmation() {
             "jsonrpc": "2.0", "id": 1,
             "result": {
                 "specName": "node-subtensor",
-                "specVersion": 443,
+                "specVersion": 445,
                 "transactionVersion": 1
             }
         })))
@@ -1515,7 +1524,7 @@ async fn mount_signing_path(server: &MockServer) {
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "jsonrpc": "2.0", "id": 1,
-            "result": {"specName": "node-subtensor", "specVersion": 443, "transactionVersion": 1}
+            "result": {"specName": "node-subtensor", "specVersion": 445, "transactionVersion": 1}
         })))
         .mount(server)
         .await;

--- a/metadata/testnet.lock
+++ b/metadata/testnet.lock
@@ -5,11 +5,11 @@
   "snapshot_netuid": 1,
   "chain": {
     "spec_name": "node-subtensor",
-    "spec_version": 443,
+    "spec_version": 445,
     "transaction_version": 1,
     "ss58_prefix": 42
   },
-  "metadata_digest": "0x5d603ac2a84552035cc0434cd7a7b56781a26eab47245542dd43ef1c8ce9b046",
+  "metadata_digest": "0x25b0d497f71c915c622efe3a55a4d3b5d6aa405856df193bca7df0791cae5497",
   "call_indices": {
     "set_weights": {
       "pallet": "SubtensorModule",

--- a/xtask/src/metadata_snapshot.rs
+++ b/xtask/src/metadata_snapshot.rs
@@ -976,7 +976,7 @@ mod tests {
             snapshot_netuid: 1,
             chain: ChainSnapshot {
                 spec_name: "node-subtensor".into(),
-                spec_version: 443,
+                spec_version: 445,
                 transaction_version: 1,
                 ss58_prefix: 42,
             },


### PR DESCRIPTION
## Summary
- Prod validator stopped submitting weights after Finney bumped `spec_version` 443 → 445; `LiveChainClient` fail-closed on lockfile pin mismatch and refused every CRV4/`set_weights` sign.
- Signing now fetches live `spec_version` / `transaction_version` from `state_getRuntimeVersion` at submit time (accept any tip version). Call indices / CRV4 shape stay lockfile-pinned.
- Refresh `metadata/testnet.lock` to the current tip snapshot for drift CI.

## Test plan
- [x] `cargo test -p chain-live --lib`
- [ ] Merge → deploy prod validator → confirm `submit_timelocked ok` and new on-chain LastUpdate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transactions now use the chain’s current runtime versions, improving compatibility after runtime upgrades.
  - Runtime-version changes no longer cause valid submissions to be rejected solely due to outdated pinned values.
  - Updated runtime-version handling across weight submission and confirmation flows.

- **Tests**
  - Updated runtime fixtures and coverage for newer runtime versions.
  - Added verification that submissions proceed despite differing runtime-version values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->