### PR TITLE
fix(prism): harvest full METRICS_JSON without 32KB log tail

### DIFF
--- a/crates/prism-lium-harness/src/detached.rs
+++ b/crates/prism-lium-harness/src/detached.rs
@@ -62,6 +62,25 @@ log=0
 echo "STATE=ok alive=$alive done=$done train=$train ready=$ready log=$log"
 "#;
 
+/// Harvest metrics + status markers without relying on a fixed-byte log tail.
+///
+/// v3 `METRICS_JSON=` is often a single line ≫32 KiB (G5/G2 prompts embedded).
+/// A `tail -c 32768` of `harness.log` can keep `EVAL_OK` while dropping the
+/// `METRICS_JSON=` prefix, so classify sees a failed run after hours of GPU.
+/// Prefer the harness sidecar (`metrics.json`), else `grep` the full line.
+pub const HARNESS_HARVEST_CMD: &str = r"set +e
+cd /tmp/prism_eval 2>/dev/null || exit 0
+if [ -f metrics.json ]; then
+  printf 'METRICS_JSON='
+  cat metrics.json
+  printf '\n'
+elif [ -f harness.log ]; then
+  grep -m1 '^METRICS_JSON=' harness.log 2>/dev/null || true
+fi
+grep -E '^(EVAL_OK|CAP_EXCEEDED|PHASE_TRAIN_DONE)$' harness.log 2>/dev/null || true
+tail -c 8192 harness.log 2>/dev/null || true
+";
+
 /// Parsed probe from [`HARNESS_PROBE_CMD`].
 #[derive(Debug, Clone, Copy, Default)]
 #[allow(clippy::struct_excessive_bools)]
@@ -225,5 +244,40 @@ mod tests {
         assert!(cmd.contains("setsid"));
         assert!(cmd.contains("harness.pid"));
         assert!(cmd.contains("DETACH_ALREADY"));
+    }
+
+    #[test]
+    fn classify_log_survives_huge_metrics_json_line() {
+        // Regression: v3 battery METRICS_JSON often ≫32 KiB; a log-tail harvest
+        // that keeps EVAL_OK but drops the METRICS_JSON= prefix must not happen
+        // when the full line is present (sidecar / grep harvest).
+        let pad = "x".repeat(40_000);
+        let metrics = format!(
+            r#"{{"bpb":2.5,"tokens_seen":1,"wall_clock_seconds":1.0,"gpu_type":null,"notes":"{pad}","eval_tier":"public"}}"#
+        );
+        assert!(metrics.len() > 40_000);
+        let log = format!("noise\nMETRICS_JSON={metrics}\nEVAL_OK\n");
+        match classify_log(&log, false, false) {
+            HarnessProgress::Done(m) => assert!((m.bpb - 2.5).abs() < 1e-9),
+            other => panic!("expected Done, got {other:?}"),
+        }
+        // Truncated tail that still has EVAL_OK but lost the METRICS_JSON= prefix
+        // (historical harvest bug) remains Failed — fix is harvest, not parse.
+        let truncated_tail = format!("{}\nEVAL_OK\n", &metrics[metrics.len() - 2000..]);
+        assert!(
+            matches!(
+                classify_log(&truncated_tail, false, false),
+                HarnessProgress::Failed(_)
+            ),
+            "EVAL_OK without METRICS_JSON= prefix must stay Failed"
+        );
+    }
+
+    #[test]
+    fn harvest_cmd_prefers_sidecar_and_greps_metrics() {
+        assert!(HARNESS_HARVEST_CMD.contains("metrics.json"));
+        assert!(HARNESS_HARVEST_CMD.contains("grep -m1 '^METRICS_JSON='"));
+        assert!(HARNESS_HARVEST_CMD.contains("EVAL_OK|CAP_EXCEEDED|PHASE_TRAIN_DONE"));
+        assert!(!HARNESS_HARVEST_CMD.contains("tail -c 32768"));
     }
 }

--- a/crates/prism-lium-harness/src/lib.rs
+++ b/crates/prism-lium-harness/src/lib.rs
@@ -12,7 +12,7 @@ use prism_lium_types::LiumError;
 
 pub use detached::{
     classify_log, detach_launch_cmd, parse_harness_probe, parse_metrics_output, HarnessProbe,
-    HarnessProgress, HARNESS_ABSENT, HARNESS_PROBE_CMD, TRAIN_DONE_MARKER,
+    HarnessProgress, HARNESS_ABSENT, HARNESS_HARVEST_CMD, HARNESS_PROBE_CMD, TRAIN_DONE_MARKER,
 };
 
 /// Pod-side staging directory for eval assets.

--- a/crates/prism-lium/src/client.rs
+++ b/crates/prism-lium/src/client.rs
@@ -24,8 +24,8 @@ use crate::{EvalJobBackend, HARNESS_LOG_RETAIN_BYTES, LIUM_API_BASE_URL, MIN_LIF
 use prism_lium_harness::{
     classify_log, detach_launch_cmd, eval_assets_dir, harness_env_pairs, harness_upload_tar,
     parse_harness_probe, parse_metrics_output, random_seed_hex, HarnessProgress,
-    EVAL_ASSETS_POD_DIR, HARNESS_ABSENT, HARNESS_BOOTSTRAP, HARNESS_EXTRACT_CMD, HARNESS_PROBE_CMD,
-    TRAIN_DONE_MARKER,
+    EVAL_ASSETS_POD_DIR, HARNESS_ABSENT, HARNESS_BOOTSTRAP, HARNESS_EXTRACT_CMD, HARNESS_HARVEST_CMD,
+    HARNESS_PROBE_CMD, TRAIN_DONE_MARKER,
 };
 use prism_lium_types::{CostGuardrailError, LiumError};
 use prism_lium_types::{
@@ -647,11 +647,12 @@ impl LiumClient {
     async fn harvest_logs_inner(&self, instance_id: &str) -> Result<String, LiumError> {
         let target = self.resolve_ssh_target(instance_id).await?;
         let key = resolve_private_key(self.ssh.private_key_path.as_deref())?;
-        let cmd = format!(
-            "tail -c {HARNESS_LOG_RETAIN_BYTES} /tmp/prism_eval/harness.log 2>/dev/null || true"
-        );
-        let out = ssh_exec_allow_fail(&target, &key, &cmd, 1, self.ssh.ssh_retry_secs, 45).await?;
-        Ok(truncate_tail(&out.stdout, HARNESS_LOG_RETAIN_BYTES))
+        // Do not truncate: METRICS_JSON may be ≫ HARNESS_LOG_RETAIN_BYTES.
+        // HARNESS_HARVEST_CMD pulls the full metrics line/sidecar + a small log tail.
+        let out =
+            ssh_exec_allow_fail(&target, &key, HARNESS_HARVEST_CMD, 1, self.ssh.ssh_retry_secs, 45)
+                .await?;
+        Ok(out.stdout)
     }
 
     async fn gpu_smoke(&self, target: &SshTarget, key: &Path) -> Result<String, LiumError> {

--- a/crates/prism-lium/src/client.rs
+++ b/crates/prism-lium/src/client.rs
@@ -24,8 +24,8 @@ use crate::{EvalJobBackend, HARNESS_LOG_RETAIN_BYTES, LIUM_API_BASE_URL, MIN_LIF
 use prism_lium_harness::{
     classify_log, detach_launch_cmd, eval_assets_dir, harness_env_pairs, harness_upload_tar,
     parse_harness_probe, parse_metrics_output, random_seed_hex, HarnessProgress,
-    EVAL_ASSETS_POD_DIR, HARNESS_ABSENT, HARNESS_BOOTSTRAP, HARNESS_EXTRACT_CMD, HARNESS_HARVEST_CMD,
-    HARNESS_PROBE_CMD, TRAIN_DONE_MARKER,
+    EVAL_ASSETS_POD_DIR, HARNESS_ABSENT, HARNESS_BOOTSTRAP, HARNESS_EXTRACT_CMD,
+    HARNESS_HARVEST_CMD, HARNESS_PROBE_CMD, TRAIN_DONE_MARKER,
 };
 use prism_lium_types::{CostGuardrailError, LiumError};
 use prism_lium_types::{
@@ -649,9 +649,15 @@ impl LiumClient {
         let key = resolve_private_key(self.ssh.private_key_path.as_deref())?;
         // Do not truncate: METRICS_JSON may be ≫ HARNESS_LOG_RETAIN_BYTES.
         // HARNESS_HARVEST_CMD pulls the full metrics line/sidecar + a small log tail.
-        let out =
-            ssh_exec_allow_fail(&target, &key, HARNESS_HARVEST_CMD, 1, self.ssh.ssh_retry_secs, 45)
-                .await?;
+        let out = ssh_exec_allow_fail(
+            &target,
+            &key,
+            HARNESS_HARVEST_CMD,
+            1,
+            self.ssh.ssh_retry_secs,
+            45,
+        )
+        .await?;
         Ok(out.stdout)
     }
 

--- a/crates/prism-lium/src/lib.rs
+++ b/crates/prism-lium/src/lib.rs
@@ -44,7 +44,7 @@ pub use prism_artifacts::{
 };
 pub use prism_lium_harness::{
     classify_log, parse_harness_probe, parse_metrics_output, HarnessProbe, HarnessProgress,
-    HARNESS_ABSENT, TRAIN_DONE_MARKER,
+    HARNESS_ABSENT, HARNESS_HARVEST_CMD, TRAIN_DONE_MARKER,
 };
 pub use sim::SimLiumBackend;
 pub use ssh::{parse_ssh_target, resolve_private_key, truncate_tail, SshTarget};
@@ -115,7 +115,10 @@ pub trait EvalJobBackend: Send + Sync {
     }
 }
 
-/// Tail bytes retained for harness stderr / harvested logs in error_detail.
+/// Tail bytes retained for harness stderr / error_detail snippets.
+///
+/// Live poll harvest uses [`HARNESS_HARVEST_CMD`] (sidecar / full
+/// `METRICS_JSON=` line) and must not apply this cap to the metrics blob.
 pub const HARNESS_LOG_RETAIN_BYTES: usize = 32_768;
 /// Default Lium API base URL.
 pub const LIUM_API_BASE_URL: &str = "https://lium.io/api";

--- a/crates/prism-recipe/harness/main.py
+++ b/crates/prism-recipe/harness/main.py
@@ -14,7 +14,8 @@ collect pod manifest -> spawn the miner subprocess (`unshare --net --
 python3 -m prismlib.miner_entry ctx.json` when available; plain subprocess
 fallback with a loud warning) -> read its one-line JSON result from the
 dedicated FD -> print `METRICS_JSON={...}` (v2) and `EVAL_OK` (or stage
-line + EVAL_FAIL).
+line + EVAL_FAIL). Also writes `/tmp/prism_eval/metrics.json` so Lium
+harvest can recover blobs larger than a fixed log-tail window.
 
 AutoModel fixture/sim (`PRISM_AUTOMODEL_FIXTURE=1`) exercises staging +
 entry gates only — never treat fixture markers as proof of a real train.
@@ -95,6 +96,9 @@ BUILD_TIMEOUT_S = float_env("PRISM_BUILD_TIMEOUT_S", 900.0)
 SCORE_TIMEOUT_S = float_env("PRISM_SCORE_TIMEOUT_S", 1800.0)
 EVAL_TIMEOUT_S = float_env("PRISM_EVAL_TIMEOUT_S", 3 * 3600.0)
 WORKDIR = os.environ.get("PRISM_WORKDIR", "/tmp/prism_eval")
+# Sidecar for Lium harvest: v3 METRICS_JSON lines can exceed the historical
+# 32 KiB log-tail window; master greps this file (or the full log line).
+METRICS_SIDECAR = os.path.join(WORKDIR, "metrics.json")
 # Two-phase private-tier staging (E5): with `$PRISM_EVAL_ASSETS_DIR` set the
 # parent announces train-done by printing this exact bare line (the Lium
 # client matches it as a raw line — a `log()` prefix would not match) and
@@ -211,6 +215,22 @@ def _jit_caches_reset():
         pass
 
 
+def _emit_metrics(out):
+    """Print `METRICS_JSON=` and write `metrics.json` sidecar for harvest.
+
+    Battery blobs often exceed the historical 32 KiB harness.log tail window;
+    the Lium client prefers this sidecar (else greps the full log line).
+    """
+    blob = json.dumps(out)
+    try:
+        os.makedirs(WORKDIR, exist_ok=True)
+        with open(METRICS_SIDECAR, "w", encoding="utf-8") as f:
+            f.write(blob)
+    except OSError:
+        pass
+    print("METRICS_JSON=" + blob)
+
+
 def _cap_exceeded_out(payload, manifest, t_start):
     """Miner-attributable parameter-cap breach: machine-readable terminal.
 
@@ -233,7 +253,7 @@ def _cap_exceeded_out(payload, manifest, t_start):
         "pod_manifest": manifest,
         "harness_files_sha256": manifest_mod.harness_files_sha256(),
     }
-    print("METRICS_JSON=" + json.dumps(out))
+    _emit_metrics(out)
     print("CAP_EXCEEDED")
     log(f"parameter cap exceeded: {payload.get('error', '')[:200]}")
 
@@ -397,7 +417,7 @@ def _run_v3(ctx, ctx_path, manifest, t_start, netns):
         "inference_traces": epayload.get("inference_traces") or {},
     }
     _cheatguard_call("post_eval", out)
-    print("METRICS_JSON=" + json.dumps(out))
+    _emit_metrics(out)
     print("EVAL_OK")
     log(f"v3 eval complete in {time.time()-t_start:.0f}s")
 
@@ -417,30 +437,27 @@ def _run_automodel_fixture_stub(t_start):
         fail("automodel_fixture", exc)
     manifest = prep["automodel"]
     unshare = probe_unshare()
-    print(
-        "METRICS_JSON="
-        + json.dumps(
-            {
-                "bpb": 0.0,
-                "tokens_seen": 0,
-                "wall_clock_seconds": time.time() - t_start,
-                "gpu_type": os.environ.get("PRISM_GPU_TYPE", "sim-fixture"),
-                "notes": "automodel fixture stub — not real train proof",
-                "val_rows": 0,
-                "n_params": 0,
-                "recipe": RECIPE_VERSION,
-                "metrics_version": 2,
-                "automodel_stub": True,
-                "real_train": False,
-                "netns": bool(unshare.get("available")),
-                "automodel": {
-                    "base": manifest.get("base"),
-                    "entry": manifest.get("entry"),
-                    "mode": manifest.get("mode"),
-                },
-                "harness_files_sha256": manifest_mod.harness_files_sha256(),
-            }
-        )
+    _emit_metrics(
+        {
+            "bpb": 0.0,
+            "tokens_seen": 0,
+            "wall_clock_seconds": time.time() - t_start,
+            "gpu_type": os.environ.get("PRISM_GPU_TYPE", "sim-fixture"),
+            "notes": "automodel fixture stub — not real train proof",
+            "val_rows": 0,
+            "n_params": 0,
+            "recipe": RECIPE_VERSION,
+            "metrics_version": 2,
+            "automodel_stub": True,
+            "real_train": False,
+            "netns": bool(unshare.get("available")),
+            "automodel": {
+                "base": manifest.get("base"),
+                "entry": manifest.get("entry"),
+                "mode": manifest.get("mode"),
+            },
+            "harness_files_sha256": manifest_mod.harness_files_sha256(),
+        }
     )
     print("AUTOMODEL_FIXTURE_OK")
     # Deliberately no EVAL_OK — fixture markers are not scored proof.
@@ -600,7 +617,7 @@ def main():
         "harness_files_sha256": manifest_mod.harness_files_sha256(),
         "tokenizer": payload.get("tokenizer", {}),
     }
-    print("METRICS_JSON=" + json.dumps(out))
+    _emit_metrics(out)
     print("EVAL_OK")
     log(f"eval complete in {time.time()-t_start:.0f}s")
 

--- a/crates/prism-recipe/src/lib.rs
+++ b/crates/prism-recipe/src/lib.rs
@@ -687,6 +687,8 @@ mod tests {
             "eval_tier",
             "checkpoint.pt",
             "run_battery",
+            "metrics.json",
+            "_emit_metrics",
             "cantor",
             "prism_width_multiplier",
             "cheatguard",

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -89,6 +89,17 @@ sweeper remains a **10h** backstop and skips live workers.
 `GET /v1/submissions/{id}/logs?since=` exposes harvested harness tails +
 heartbeats while a pod is measuring.
 
+**Metrics harvest (v3):** the harness writes `METRICS_JSON=` to stdout **and**
+`/tmp/prism_eval/metrics.json`. Master harvest prefers that sidecar (else
+`grep '^METRICS_JSON=' harness.log`) plus terminal markers — it must not rely
+on a fixed-byte `tail` of `harness.log` alone. Battery blobs often exceed
+32 KiB; a tail that keeps `EVAL_OK` but drops the `METRICS_JSON=` prefix
+falsely fails the run after GPU work. Failed rows whose `error_detail` only
+retains a truncated log (no recoverable `bpb` / `metrics_json`) **cannot** be
+offline-recovered from the DB — after deploying this fix, operators
+`POST /v1/submissions/{id}/retry` (admin Bearer) and
+`POST /v1/admin/gating/{hotkey}/reset` so the miner can re-run measure.
+
 Evaluation (Lium / Sim, review, agentic, leaf emit) is **master-only**.
 Validators never run `prism-challenge` — they fetch sealed weights only.
 

--- a/docs/runbooks/prism-enable-lium-and-emission.md
+++ b/docs/runbooks/prism-enable-lium-and-emission.md
@@ -19,6 +19,17 @@
    seal). Prefer rolling the challenge image when no pods are in
    `provisioning`/`running`, or accept resume after boot.
 
+## Failed measure with EVAL_OK but no metrics (ops)
+
+If `error_detail` ends with cheatguard / `EVAL_OK` but has no parseable
+`METRICS_JSON=` / `bpb` (historical 32 KiB log-tail harvest bug), the row is
+**not** recoverable from Postgres alone — `metrics_json` was never written.
+After deploying the sidecar/grep harvest fix:
+
+1. `POST /v1/submissions/{id}/retry` with Prism admin Bearer (re-queues measure).
+2. `POST /v1/admin/gating/{hotkey}/reset` if the miner is still 1-max gated.
+3. Miner (or operator with sealed BYOK vault) must fund another Lium run.
+
 ## Emission ceremony (shared with design)
 
 Trust root today: **`prism = 5000` bps**, **`design = 5000` bps** (sum must stay


### PR DESCRIPTION
## Summary
- **Bug:** Lium poll harvested `harness.log` with `tail -c 32768`. v3 battery `METRICS_JSON=` is often a single line ≫32 KiB, so harvest kept `EVAL_OK` but lost the `METRICS_JSON=` prefix → `classify_log` Failed after ~6h GPU (prod: `4642876b…`, `ac1db2a7…`, `e6a5fd61…`).
- **Fix:** Harness writes `/tmp/prism_eval/metrics.json` sidecar; SSH harvest prefers that (else `grep -m1 '^METRICS_JSON='`) plus terminal markers — no fixed-byte truncate of the metrics blob.
- **Ops:** Failed rows with truncated `error_detail` only are **not** recoverable from DB (`metrics_json` never written). After deploy: admin `POST /v1/submissions/{id}/retry` + `POST /v1/admin/gating/{hotkey}/reset`.

## Test plan
- [x] `cargo test -p prism-lium-harness` (incl. >40KB `METRICS_JSON` + `EVAL_OK` regression)
- [x] `cargo test -p prism-lium -p prism-recipe --lib`
- [x] `cargo clippy -p prism-lium-harness -p prism-lium -p prism-recipe --all-targets -- -D warnings`
- [ ] After deploy: confirm a live v3 measure harvest parses `bpb` when battery blob ≫32 KiB
- [ ] For affected failed ids: retry + gating reset (cannot offline-score from truncated `error_detail`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved metrics collection for large outputs with sidecar storage and reliable fallback harvesting.
  * Preserved complete metrics output alongside terminal markers and diagnostic log tails.

* **Bug Fixes**
  * Prevented metrics from being lost or falsely reported as missing when logs exceed size limits.

* **Documentation**
  * Added guidance for recovering failed measurements, resetting gating, and retrying submissions when metrics are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->