### PR TITLE
fix(prism): drop shared Lium rent queue for BYOK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,10 +3013,6 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "lium-rent-pool"
 version = "0.1.0"
-dependencies = [
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "lock_api"

--- a/crates/lium-rent-pool/Cargo.toml
+++ b/crates/lium-rent-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lium-rent-pool"
-description = "Autonomous Lium rent rate-limit pool (3/5s + 60/h) with 429-aware backoff"
+description = "Lium rent 429 helpers + autonomous recovery (no process-wide rent queue)"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,11 +9,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-tokio = { version = "1", features = ["sync", "time", "macros"] }
-tracing = "0.1"
-
-[dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 
 [lints]
 workspace = true

--- a/crates/lium-rent-pool/src/lib.rs
+++ b/crates/lium-rent-pool/src/lib.rs
@@ -1,27 +1,12 @@
-//! Autonomous Lium rent budget: **3 / 5s** burst + **60 / hour**, serialized
-//! rents, and cooldown from `429` bodies (`Please try again in N seconds`).
+//! Lium rent **helpers** for BYOK / operator clients.
+//!
+//! Live Prism eval is miner-funded (`X-Lium-Api-Key`). Each miner key has its
+//! own Lium rate budget — there is **no** process-wide rent serialize queue.
+//! This crate only classifies 429 bodies and decides autonomous recovery.
 
 #![forbid(unsafe_code)]
 #![allow(clippy::missing_errors_doc)]
 
-use std::collections::VecDeque;
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
-
-use tokio::sync::Semaphore;
-use tokio::time::sleep;
-use tracing::{info, warn};
-
-/// Lium burst ceiling on `POST /executors/{id}/rent`.
-pub const BURST_MAX: usize = 3;
-/// Burst window.
-pub const BURST_WINDOW: Duration = Duration::from_secs(5);
-/// Lium hourly rent ceiling.
-pub const HOUR_MAX: usize = 60;
-/// Hourly window.
-pub const HOUR_WINDOW: Duration = Duration::from_hours(1);
-/// Cap a single acquire sleep (hourly cooldowns are long).
-pub const MAX_ACQUIRE_WAIT: Duration = Duration::from_hours(1);
 /// Autonomous recovery looks back this far for failed 429 submissions.
 pub const RECOVERY_WINDOW_MS: u64 = 6 * 60 * 60 * 1000;
 
@@ -67,166 +52,6 @@ pub fn is_rate_limited(msg: &str) -> bool {
     l.contains("429") || l.contains("too many requests") || l.contains("rate limit")
 }
 
-struct Inner {
-    burst: VecDeque<Instant>,
-    hour: VecDeque<Instant>,
-    cooldown_until: Option<Instant>,
-}
-
-impl Inner {
-    fn purge(&mut self, now: Instant) {
-        while self
-            .burst
-            .front()
-            .is_some_and(|t| now.duration_since(*t) >= BURST_WINDOW)
-        {
-            self.burst.pop_front();
-        }
-        while self
-            .hour
-            .front()
-            .is_some_and(|t| now.duration_since(*t) >= HOUR_WINDOW)
-        {
-            self.hour.pop_front();
-        }
-        if self.cooldown_until.is_some_and(|u| now >= u) {
-            self.cooldown_until = None;
-        }
-    }
-
-    fn wait_hint(&self, now: Instant) -> Option<Duration> {
-        if let Some(until) = self.cooldown_until {
-            if now < until {
-                return Some(until.saturating_duration_since(now));
-            }
-        }
-        if self.burst.len() >= BURST_MAX {
-            if let Some(oldest) = self.burst.front() {
-                let elapsed = now.duration_since(*oldest);
-                if elapsed < BURST_WINDOW {
-                    return BURST_WINDOW.checked_sub(elapsed);
-                }
-            }
-        }
-        if self.hour.len() >= HOUR_MAX {
-            if let Some(oldest) = self.hour.front() {
-                let elapsed = now.duration_since(*oldest);
-                if elapsed < HOUR_WINDOW {
-                    return HOUR_WINDOW
-                        .checked_sub(elapsed)
-                        .map(|d| d.min(MAX_ACQUIRE_WAIT));
-                }
-            }
-        }
-        None
-    }
-
-    fn record(&mut self, now: Instant) {
-        self.burst.push_back(now);
-        self.hour.push_back(now);
-    }
-}
-
-/// Process-wide rent gate: one in-flight rent + sliding-window budgets.
-pub struct RentPool {
-    inner: Mutex<Inner>,
-    gate: Semaphore,
-}
-
-impl Default for RentPool {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RentPool {
-    /// Empty pool (budgets open).
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            inner: Mutex::new(Inner {
-                burst: VecDeque::with_capacity(BURST_MAX + 1),
-                hour: VecDeque::with_capacity(HOUR_MAX + 1),
-                cooldown_until: None,
-            }),
-            gate: Semaphore::new(1),
-        }
-    }
-
-    /// Wait until a rent is allowed; hold the serialize lock until permit drop.
-    pub async fn take(&self) -> RentPermit<'_> {
-        let owned = loop {
-            match self.gate.acquire().await {
-                Ok(p) => break p,
-                Err(_) => sleep(Duration::from_secs(1)).await,
-            }
-        };
-        loop {
-            let wait = match self.inner.lock() {
-                Ok(mut g) => {
-                    let now = Instant::now();
-                    g.purge(now);
-                    g.wait_hint(now)
-                }
-                Err(_) => Some(Duration::from_millis(50)),
-            };
-            if let Some(w) = wait {
-                let w = w.max(Duration::from_millis(200)).min(MAX_ACQUIRE_WAIT);
-                info!(wait_ms = w.as_millis(), "lium rent pool waiting");
-                sleep(w).await;
-                continue;
-            }
-            if let Ok(mut g) = self.inner.lock() {
-                g.record(Instant::now());
-            }
-            return RentPermit {
-                pool: self,
-                _permit: owned,
-            };
-        }
-    }
-
-    /// Apply a 429 cooldown (from body / Retry-After).
-    pub fn note_429(&self, retry_secs: u64) {
-        let secs = retry_secs.clamp(1, 7200);
-        if let Ok(mut g) = self.inner.lock() {
-            let until = Instant::now() + Duration::from_secs(secs);
-            g.cooldown_until = Some(match g.cooldown_until {
-                Some(prev) if prev > until => prev,
-                _ => until,
-            });
-        }
-        warn!(retry_secs = secs, "lium rent pool cooldown from 429");
-    }
-
-    /// Snapshot `(burst_used, hour_used, cooldown_secs)`.
-    #[must_use]
-    pub fn stats(&self) -> (usize, usize, Option<u64>) {
-        let Ok(mut g) = self.inner.lock() else {
-            return (0, 0, None);
-        };
-        let now = Instant::now();
-        g.purge(now);
-        let cool = g
-            .cooldown_until
-            .map(|u| u.saturating_duration_since(now).as_secs());
-        (g.burst.len(), g.hour.len(), cool)
-    }
-}
-
-/// RAII permit: drops the serialize lock when the rent HTTP call finishes.
-pub struct RentPermit<'a> {
-    pool: &'a RentPool,
-    _permit: tokio::sync::SemaphorePermit<'a>,
-}
-
-impl RentPermit<'_> {
-    /// Forward a 429 into the pool cooldown.
-    pub fn rate_limited(&self, msg: &str) {
-        self.pool.note_429(parse_retry_secs(msg).unwrap_or(5));
-    }
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
@@ -245,16 +70,5 @@ mod tests {
         ));
         assert!(should_recover("provision: 429 rate limit", 100, 100 + 1));
         assert!(!should_recover("provision: 429", 0, RECOVERY_WINDOW_MS + 1));
-    }
-
-    #[tokio::test]
-    async fn burst_forces_wait() {
-        let pool = RentPool::new();
-        for _ in 0..BURST_MAX {
-            drop(pool.take().await);
-        }
-        let start = Instant::now();
-        drop(pool.take().await);
-        assert!(start.elapsed() >= Duration::from_millis(200));
     }
 }

--- a/crates/prism-lium/src/client.rs
+++ b/crates/prism-lium/src/client.rs
@@ -1,20 +1,13 @@
 //! Real Lium HTTPS client + SSH-backed live eval.
 
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use lium_rent_pool::RentPool;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
-
-fn rent_pool() -> &'static RentPool {
-    static POOL: OnceLock<RentPool> = OnceLock::new();
-    POOL.get_or_init(RentPool::new)
-}
 
 use crate::ssh::{
     parse_ssh_target, resolve_private_key, ssh_exec, ssh_exec_allow_fail, ssh_exec_stdin,
@@ -174,14 +167,13 @@ impl LiumClient {
                 .text()
                 .await
                 .map_err(|e| LiumError::Transport(sanitize_err(&e.to_string(), &self.api_key)))?;
-            // Rent POSTs are gated by `RentPool` — do not multi-retry (each
-            // attempt burns Lium's 60/h budget). Other endpoints keep backoff.
+            // Rent POSTs: do not multi-retry here — each attempt burns that
+            // API key's Lium budget. Miner BYOK keys are independent; there is
+            // no process-wide rent serialize queue. Other endpoints backoff.
             let is_rent = path.contains("/rent");
             if status.as_u16() == 429 {
                 let secs = retry_after.or_else(|| lium_rent_pool::parse_retry_secs(&text));
-                if is_rent {
-                    rent_pool().note_429(secs.unwrap_or(5));
-                } else if attempt < RATE_LIMIT_RETRIES {
+                if !is_rent && attempt < RATE_LIMIT_RETRIES {
                     attempt = attempt.saturating_add(1);
                     let wait_ms = secs.map_or(RATE_LIMIT_BASE_MS << (attempt - 1).min(3), |s| {
                         s.saturating_mul(1000).max(50)
@@ -870,7 +862,8 @@ impl EvalJobBackend for LiumClient {
                 "lium rent"
             );
             let body = make_body();
-            let permit = rent_pool().take().await;
+            // Fire rent immediately — BYOK keys must not share a process-wide
+            // queue with each other or with an operator fallback key.
             let rented = self
                 .request(
                     reqwest::Method::POST,
@@ -878,12 +871,6 @@ impl EvalJobBackend for LiumClient {
                     Some(&body),
                 )
                 .await;
-            if let Err(e) = &rented {
-                let es = e.to_string();
-                if lium_rent_pool::is_rate_limited(&es) {
-                    permit.rate_limited(&es);
-                }
-            }
             match rented {
                 Ok(v) => {
                     let id = match extract_pod_id(&v) {
@@ -908,9 +895,8 @@ impl EvalJobBackend for LiumClient {
                     last_err = e.to_string();
                     // 429/transport can still leave a PENDING pod under our name.
                     self.reclaim_pods_named(&spec.name).await;
-                    // A rent 429 consumed one of Lium's hourly calls. The pool
-                    // already recorded the cooldown; return after orphan
-                    // cleanup instead of walking more candidates.
+                    // A rent 429 consumed one call on *this* API key's budget.
+                    // Return after orphan cleanup — do not walk more offers.
                     if lium_rent_pool::is_rate_limited(&last_err) {
                         return Err(LiumError::Api(last_err));
                     }

--- a/crates/prism-lium/src/lib.rs
+++ b/crates/prism-lium/src/lib.rs
@@ -3,9 +3,10 @@
 //! **No Phala CVM.** Live GPU eval is **miner-funded by default** (see
 //! `prism-lium-payer` for `X-Lium-Api-Key` vault + factory). The operator may
 //! still hold `LIUM_API_KEY` for Sim fallback / opt-in operator billing
-//! (`PRISM_ALLOW_OPERATOR_LIUM=1`). Cost guardrails refuse unbounded lifetime /
-//! price **before** any rent call. Every provision path terminates + verifies
-//! on failure.
+//! (`PRISM_ALLOW_OPERATOR_LIUM=1`). Rents are **not** serialized through a
+//! process-wide queue (each BYOK key has its own Lium budget). Cost guardrails
+//! refuse unbounded lifetime / price **before** any rent call. Every provision
+//! path terminates + verifies on failure.
 //!
 //! # Backends
 //!

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -115,8 +115,8 @@ verdicts are terminal `rejected` (no retry). Retries of a **post-run** failure
 (`llm_infra` / `ast_infra` after the pod job completed) resume from the
 persisted measurement — the train+eval job is never re-run for a master-side
 review failure; only `install` retries re-provision. Lium **HTTP 429** on rent is
-special: `lium-rent-pool` serializes rents (≤**3 / 5s**, ≤**60 / hour**),
-waits on `Retry-After` / body hints, and the orchestrator **requeues without
+special: each miner `X-Lium-Api-Key` has its **own** Lium budget (no shared
+process-wide rent serialize queue). The orchestrator **requeues without
 burning** `retry_count` / gating attempts. A background tick re-queues
 failed 429 rows from the last **6 hours**. After an infra `blocked`, the
 miner may **resubmit for up to 30 minutes** (new `POST /v1/submissions` or


### PR DESCRIPTION
## Summary
- Remove the process-wide `RentPool` serialize gate (3/5s + 60/h) from `prism-lium` rent POSTs.
- Miner `X-Lium-Api-Key` rents each hit Lium under that key’s own budget; a shared operator-era queue was incorrectly serializing unrelated BYOK traffic.
- Keep `lium-rent-pool` helpers only (`is_rate_limited` / `parse_retry_secs` / `should_recover`) for orchestrator 429 requeue without burning retry_count.
- Docs: `docs/PRISM.md` updated for BYOK-era behavior.
- Unchanged: 1×GPU hard-reject, cost guardrails, operator fallback via `PRISM_ALLOW_OPERATOR_LIUM`.

## Test plan
- [x] `cargo test -p lium-rent-pool --lib`
- [x] `cargo test -p prism-lium --lib` (incl. multi-GPU reject + provision mocks)
- [ ] Staging/prod: confirm concurrent miner BYOK rents no longer wait on a shared pool; 429 still auto-requeues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rent requests now execute independently per miner API key, improving concurrency.
  * Lium rate-limit responses trigger cleanup and stop further offer attempts.
  * Other rate-limit responses continue to use retry and backoff behavior.
  * Cost guardrails reject rentals with unbounded duration or pricing.

* **Documentation**
  * Updated guidance to reflect independent budgets and revised rate-limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->