### PR TITLE
feat(site): measured GPT-2 Large Prism-protocol references

### DIFF
--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -1365,10 +1365,10 @@ mod tests {
         let (s, v) = call(app.clone(), "/v1/site/arenas/prism/references").await;
         assert_eq!(s, StatusCode::OK, "{v}");
         assert_eq!(v.as_array().unwrap().len(), 1);
-        assert_eq!(v[0]["id"], "gpt2-small-124m");
-        assert_eq!(v[0]["paramsM"], 124.0);
-        assert!(v[0].get("bpb").is_none());
-        assert!(v[0]["disclaimer"].as_str().unwrap().contains("not a Prism"));
+        assert_eq!(v[0]["id"], "gpt2-large-774m");
+        assert_eq!(v[0]["paramsM"], 774.0);
+        assert!(v[0]["bpb"].as_f64().unwrap() > 1.0);
+        assert!(v[0]["disclaimer"].as_str().unwrap().contains("Prism-protocol"));
 
         let (s, v) = call(app, "/v1/site/arenas/prism/submissions/nope").await;
         assert_eq!(s, StatusCode::NOT_FOUND, "{v}");

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -1368,7 +1368,10 @@ mod tests {
         assert_eq!(v[0]["id"], "gpt2-large-774m");
         assert_eq!(v[0]["paramsM"], 774.0);
         assert!(v[0]["bpb"].as_f64().unwrap() > 1.0);
-        assert!(v[0]["disclaimer"].as_str().unwrap().contains("Prism-protocol"));
+        assert!(v[0]["disclaimer"]
+            .as_str()
+            .unwrap()
+            .contains("Prism-protocol"));
 
         let (s, v) = call(app, "/v1/site/arenas/prism/submissions/nope").await;
         assert_eq!(s, StatusCode::NOT_FOUND, "{v}");

--- a/crates/site-api/src/prism_enrich.rs
+++ b/crates/site-api/src/prism_enrich.rs
@@ -11,36 +11,39 @@ use site_types::{
 use site_data::map::{prism_submission, prism_telemetry};
 use site_types::LeaderboardRow;
 
-/// EleutherAI lm-evaluation-harness (canonical published GPT-2 Small table).
-pub const GPT2_SOURCE_URL: &str = "https://github.com/EleutherAI/lm-evaluation-harness";
+/// HuggingFace model card for the GPT-2 Large reference weights.
+pub const GPT2_SOURCE_URL: &str = "https://huggingface.co/gpt2-large";
 
-/// Public disclaimer for the GPT-2 reference row.
-pub const GPT2_DISCLAIMER: &str = "Public GPT-2 Small (124M) — literature / Eleuther-style numbers; not a Prism-protocol run. BPB omitted: published GPT-2 bit-per-byte figures are not comparable to Prism validation BPB.";
+/// Public disclaimer for the GPT-2 Large Prism-protocol reference row.
+pub const GPT2_DISCLAIMER: &str = "Public GPT-2 Large (774M) — Prism-protocol eval-only on 1×RTX 5090 (HF `gpt2-large` weights, public eval pack, `PRISM_TEST_EVAL_CAPS=0`). Not a miner train; G6 has no train probe curve; G8 µP width knob unsupported (floor 0).";
 
-/// GPT-2 Small parameter count (millions).
-pub const GPT2_SMALL_PARAMS_M: f64 = 124.0;
+/// GPT-2 Large parameter count (millions) — measured `n_params` / 1e6.
+pub const GPT2_LARGE_PARAMS_M: f64 = 774.0;
 
-/// HellaSwag `acc_norm` for gpt2 (Eleuther harness; commonly cited 31.14%).
-pub const GPT2_HELLASWAG: f64 = 0.3114;
-/// ARC-Easy `acc` (zero-shot Eleuther-style gpt2).
-pub const GPT2_ARC_EASY: f64 = 0.4381;
-/// ARC-Challenge `acc_norm` (zero-shot Eleuther-style gpt2).
-pub const GPT2_ARC_CHALLENGE: f64 = 0.2270;
-/// PIQA `acc_norm` (zero-shot Eleuther-style gpt2).
-pub const GPT2_PIQA: f64 = 0.6251;
-/// WinoGrande `acc` (zero-shot Eleuther-style gpt2).
-pub const GPT2_WINOGRANDE: f64 = 0.5162;
-/// BoolQ `acc` (zero-shot Eleuther-style gpt2).
-pub const GPT2_BOOLQ: f64 = 0.6012;
+/// Measured Prism validation BPB (frozen FineWeb-edu val cut, gpt2 tokenizer).
+pub const GPT2_BPB: f64 = 4.163_851_322_121_356_4;
+
+/// HellaSwag `org.g2.hellaswag_acc` (Prism public pack).
+pub const GPT2_HELLASWAG: f64 = 0.395;
+/// ARC-Easy `org.g2.arc_easy_acc`.
+pub const GPT2_ARC_EASY: f64 = 0.28;
+/// ARC-Challenge `org.g2.arc_challenge_acc`.
+pub const GPT2_ARC_CHALLENGE: f64 = 0.28;
+/// PIQA `org.g2.piqa_acc`.
+pub const GPT2_PIQA: f64 = 0.69;
+/// WinoGrande `org.g2.winogrande_acc`.
+pub const GPT2_WINOGRANDE: f64 = 0.545;
+/// BoolQ `org.g2.boolq_acc`.
+pub const GPT2_BOOLQ: f64 = 0.64;
 
 /// Frozen public GPT-2 baseline(s) for `GET …/references`.
 #[must_use]
 pub fn prism_reference_baselines() -> Vec<PrismReferenceBaseline> {
     vec![PrismReferenceBaseline {
-        id: "gpt2-small-124m".into(),
-        label: "Public GPT-2 Small (124M)".into(),
-        params_m: GPT2_SMALL_PARAMS_M,
-        bpb: None,
+        id: "gpt2-large-774m".into(),
+        label: "Public GPT-2 Large (774M)".into(),
+        params_m: GPT2_LARGE_PARAMS_M,
+        bpb: Some(GPT2_BPB),
         benchmarks: PrismBenchmarks {
             hellaswag: Some(GPT2_HELLASWAG),
             arc_easy: Some(GPT2_ARC_EASY),
@@ -490,13 +493,16 @@ mod tests {
     }
 
     #[test]
-    fn gpt2_baseline_has_no_prism_bpb() {
+    fn gpt2_baseline_is_prism_protocol_large() {
         let refs = prism_reference_baselines();
         assert_eq!(refs.len(), 1);
-        assert!(refs[0].bpb.is_none());
-        assert!((refs[0].params_m - 124.0).abs() < f64::EPSILON);
+        assert_eq!(refs[0].id, "gpt2-large-774m");
+        assert!(refs[0].bpb.is_some());
+        assert!((refs[0].bpb.unwrap() - GPT2_BPB).abs() < 1e-9);
+        assert!((refs[0].params_m - 774.0).abs() < f64::EPSILON);
         assert!((refs[0].benchmarks.hellaswag.unwrap() - GPT2_HELLASWAG).abs() < f64::EPSILON);
-        assert!(refs[0].disclaimer.contains("not a Prism-protocol"));
+        assert!(refs[0].disclaimer.contains("Prism-protocol"));
+        assert!(refs[0].source_url.contains("gpt2-large"));
     }
 
     #[test]

--- a/crates/site-types/src/types.rs
+++ b/crates/site-types/src/types.rs
@@ -416,22 +416,22 @@ pub struct PrismSubmissionDetail {
     pub similarity: Option<PrismPublicSimilarity>,
 }
 
-/// Frozen public literature baseline (not a miner submission).
+/// Frozen public reference baseline (not a miner submission).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrismReferenceBaseline {
-    /// Stable id (`gpt2-small-124m`).
+    /// Stable id (`gpt2-large-774m`).
     pub id: String,
     /// Display label.
     pub label: String,
     /// Parameters in millions.
     pub params_m: f64,
-    /// Prism-protocol BPB is intentionally omitted (not comparable).
+    /// Prism-protocol validation BPB when measured on the same harness.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bpb: Option<f64>,
-    /// Literature / Eleuther-style accuracies.
+    /// G2 benches (`org.g2.*`) from the Prism public pack.
     pub benchmarks: PrismBenchmarks,
-    /// Canonical source for the published numbers.
+    /// Canonical source for the weights / protocol notes.
     pub source_url: String,
     /// Short disclaimer shown under the board / in the modal.
     pub disclaimer: String,

--- a/docs/SITE_API.md
+++ b/docs/SITE_API.md
@@ -59,10 +59,10 @@ Additional Prism routes:
 | Path | Response |
 |------|----------|
 | `GET /v1/site/arenas/prism/submissions/{id}` | `PrismSubmissionDetail` — list fields + `eval` summary (status, groups, gates, composite) + telemetry + public `review` / `similarity` (quality/kind only). **No** raw patch text. |
-| `GET /v1/site/arenas/prism/references` | `PrismReferenceBaseline[]` — frozen **published** GPT-2 Small (124M) Eleuther-style accuracies + `sourceUrl` / `disclaimer`. **`bpb` omitted** (not Prism-protocol BPB). |
+| `GET /v1/site/arenas/prism/references` | `PrismReferenceBaseline[]` — frozen **Prism-protocol** GPT-2 Large (774M) reference: measured val **`bpb`** + G2 benches (`hellaswag` / `arcEasy` / …) from a 1×RTX 5090 eval-only run on the public pack + HF `gpt2-large` weights. Includes `sourceUrl` / `disclaimer`. |
 | `GET /v1/site/arenas/prism/submissions/{id}/telemetry` | Existing loss-curve payload (also embedded on detail). |
 
-GPT-2 constants live in `crates/site-api` (`prism_enrich`) so API and FE stay aligned; they are literature / Eleuther harness numbers, not a Prism battery run. List/leaderboard row shells still map in `crates/site-data`.
+GPT-2 Large constants live in `crates/site-api` (`prism_enrich`) so API and FE stay aligned; they are **measured Prism-protocol** numbers (eval-only, public pack), not Eleuther literature tables. List/leaderboard row shells still map in `crates/site-data`.
 
 `GET /v1/site/arenas/{slug}/submissions` and `/leaderboard` accept optional
 `?q=` — case-insensitive substring over miner hotkey (SS58 or hex), handle,


### PR DESCRIPTION
## Summary
- Replace literature GPT-2 Small constants in `prism_enrich` with **measured** HuggingFace `gpt2-large` (774M) Prism-protocol numbers.
- Evidence: eval-only on Lium **1×RTX 5090**, public pack, `PRISM_TEST_EVAL_CAPS=0` — val **BPB ≈ 4.164**, G2 benches (HS 0.395, ARC-E/C 0.28, PIQA 0.69, WG 0.545, BoolQ 0.64); G1–G8 reported `ok`.
- Updates `docs/SITE_API.md` + handler tests.

## Test plan
- [x] `cargo test -p site-api --lib prism_enrich`
- [x] `cargo test -p site-api --lib handlers::tests::prism_detail_references_and_era_enrichment`
- [ ] After merge/promote gateway/site path: `GET /v1/site/arenas/prism/references` returns `gpt2-large-774m` with `bpb` + benches
- [ ] joinbase.ai Prism leaderboard REF row shows Large + BPB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Prism reference baseline from GPT-2 Small to GPT-2 Large (774M).
  * Added measured validation BPB and refreshed benchmark results.
  * Added the model-card source URL and updated protocol disclaimer.
  * Clarified that reference values are measured Prism-protocol results.

* **Documentation**
  * Updated the Prism references endpoint documentation with the new baseline, metrics, source, and disclaimer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->