### PR TITLE
chore(deploy): promote prod prism+gateway pins for c142219d

### DIFF
--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,8 +1,8 @@
 {
-  "commit_sha": "a121445b2ae57aab632aef4f6dba6f27692e24c7",
+  "commit_sha": "c142219d6fab2474eec60b58ce3fc4550c84dde6",
   "env": "prod",
   "previous": {
-    "commit_sha": "9290fa559bec443acf4dba7126df4c9d175fc128",
+    "commit_sha": "c142219d6fab2474eec60b58ce3fc4550c84dde6",
     "services": {
       "design-challenge": {
         "digest": "sha256:a0c145924c05efdce699e26218d867efbce309fe625fb7d88f6b2820c51a2c27",
@@ -15,8 +15,8 @@
         "repository": "ghcr.io/baseintelligence/base/gateway"
       },
       "prism-challenge": {
-        "digest": "sha256:919e708f83b126d35eefb63148499cd4a6c19b540811087fe4956d411bb06fdb",
-        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:919e708f83b126d35eefb63148499cd4a6c19b540811087fe4956d411bb06fdb",
+        "digest": "sha256:a12eea9b6b5b951a992500245d6d7448e6848e94b3d023823eaf5b1e5a00a4d2",
+        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:a12eea9b6b5b951a992500245d6d7448e6848e94b3d023823eaf5b1e5a00a4d2",
         "repository": "ghcr.io/baseintelligence/base/prism-challenge"
       },
       "updater": {
@@ -30,7 +30,7 @@
         "repository": "ghcr.io/baseintelligence/base/validator"
       }
     },
-    "updated_at": "2026-08-14T04:34:59Z"
+    "updated_at": "2026-08-14T15:41:22Z"
   },
   "services": {
     "design-challenge": {
@@ -39,13 +39,13 @@
       "repository": "ghcr.io/baseintelligence/base/design-challenge"
     },
     "gateway": {
-      "digest": "sha256:cd783732288dff40ca18646bf5a68c8edc8792ca109675ee6a13cea2378cf2ae",
-      "image": "ghcr.io/baseintelligence/base/gateway@sha256:cd783732288dff40ca18646bf5a68c8edc8792ca109675ee6a13cea2378cf2ae",
+      "digest": "sha256:0c8c4d91d71c3a1d97c2fbd206437b837d579d46eca58afadb6a92fcf2e9d3b8",
+      "image": "ghcr.io/baseintelligence/base/gateway@sha256:0c8c4d91d71c3a1d97c2fbd206437b837d579d46eca58afadb6a92fcf2e9d3b8",
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
-      "digest": "sha256:7c606051527d8d0555324f67a65e474960457d97b5ba22d3d44ffa7a473a1806",
-      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:7c606051527d8d0555324f67a65e474960457d97b5ba22d3d44ffa7a473a1806",
+      "digest": "sha256:a12eea9b6b5b951a992500245d6d7448e6848e94b3d023823eaf5b1e5a00a4d2",
+      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:a12eea9b6b5b951a992500245d6d7448e6848e94b3d023823eaf5b1e5a00a4d2",
       "repository": "ghcr.io/baseintelligence/base/prism-challenge"
     },
     "updater": {
@@ -59,5 +59,5 @@
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-14T08:34:45Z"
+  "updated_at": "2026-08-14T15:41:23Z"
 }


### PR DESCRIPTION
## Summary
- Promote **prism-challenge** + **gateway** prod pins to digests from `#151` / `#150` ladder (`c142219d`)
- prism: drop shared Lium RentPool (BYOK)
- gateway/site-api: measured GPT-2 Large references (`gpt2-large-774m`, bpb≈4.164)

## Test plan
- [ ] prism-only recreate on prod master (resume-first; do not kill Lium miner pods)
- [ ] gateway recreate on prod master
- [ ] `GET /v1/site/arenas/prism/references` returns `gpt2-large` with real benches
- [ ] joinbase.ai Prism leaderboard REF row shows Large when API does