### PR TITLE
fix(prism): G8 µP sweep from reduced probe base

### DIFF
--- a/crates/prism-recipe/baselines/hybrid_delta/NOTES.md
+++ b/crates/prism-recipe/baselines/hybrid_delta/NOTES.md
@@ -43,7 +43,10 @@ carries 6 square projections vs attention's 4; both baselines land at
 G8 µP LR-transfer honors `ctx["prism_width_multiplier"]`: scales
 `d_model` / `mlp_hidden` / `delta_{key,value}_dim` (and `attn_heads` to
 keep head_dim) so a 4× build exceeds 1.5× base params. Multiplier `1.0`
-(default / absent) leaves the anchor unchanged (still ≤350M).
+(default / absent) leaves the anchor unchanged (still ≤350M). The harness
+µP sweep starts from a fixed small probe geometry (not the scored ≤350M
+config) before applying the multiplier; honor top-level / `arch`
+width-depth overrides as well.
 
 ## The delta block (canonical formulation, appendix 03 §2)
 

--- a/crates/prism-recipe/baselines/transformer_pp/NOTES.md
+++ b/crates/prism-recipe/baselines/transformer_pp/NOTES.md
@@ -97,7 +97,11 @@ constraint; accumulation would trade steps for tokens 1:1).
 7. G8 µP LR-transfer honors `ctx["prism_width_multiplier"]`: scales
    `d_model` / `mlp_hidden` (and `n_head` to keep head_dim) so a 4×
    build exceeds 1.5× base params. Multiplier `1.0` (default / absent)
-   leaves the anchor config unchanged (still ≤350M).
+   leaves the anchor config unchanged (still ≤350M). The harness µP
+   sweep overlays a fixed small probe geometry (`d_model=128`,
+   `n_layer=4`, …) before applying the multiplier — not the scored
+   ≤350M config — so 4× stays on-GPU; honor top-level / `arch`
+   width-depth overrides as well.
 
 ## lib.rs registration snippet (for the integrator — do NOT apply here)
 

--- a/crates/prism-recipe/harness/eval/g8_stability.py
+++ b/crates/prism-recipe/harness/eval/g8_stability.py
@@ -9,6 +9,14 @@ fresh 1× and 4×-width builds of the miner's architecture (via the
 handful of steps at 3 LRs each on the harness micro stream; the metric
 is |log2(best_lr_wide / best_lr_base)| — 0 means perfect LR transfer.
 
+**Probe base (not full submission size).** The sweep does **not** start from
+production `build_ctx` width/depth. Near the 350M cap, 4× width is
+unbuildable on the eval GPU (~multi-billion params / ~100GB AdamW). Instead
+the harness overlays a fixed small width/depth probe (`_MUP_PROBE_ARCH`) so
+1× and 4× stay on-device for any submission size. Miners must honor
+top-level / `arch` width-depth overrides **and** `prism_width_multiplier`
+(reference baselines do).
+
 Semantics for `org.g8.mup_lr_stability` (via rollup):
 - sweep succeeds → `1/(1+|log2 ratio|)` in [0, 1]
 - sweep **ran** but diverged / build failed / width unsupported / budget →
@@ -23,6 +31,39 @@ import math
 from . import common
 
 _SPIKE_MAD_K = 6.0
+
+# Fixed µP probe geometry — independent of the scored submission's size.
+# 4× width (~2× linear dims on d_model/mlp) must remain buildable on the
+# eval GPU for every submission under the 350M cap. Keep vocab/tokenizer/
+# device/seed from production build_ctx; only width/depth are replaced.
+_MUP_PROBE_ARCH = {
+    "d_model": 128,
+    "n_layer": 4,
+    "n_head": 4,
+    "mlp_hidden": 320,  # 2.5 × 128 (Transformer++ SwiGLU ratio)
+    # Hybrid delta-net extras (ignored by pure Transformer builds).
+    "attn_heads": 4,
+    "delta_key_dim": 64,
+    "delta_value_dim": 128,
+}
+
+
+def mup_probe_base_ctx(build_ctx):
+    """Overlay fixed small width/depth on production build_ctx for the µP sweep.
+
+    Preserves vocab_size / tokenizer / device / seed and any non-geometry keys.
+    Writes both top-level keys and an `arch` dict so baselines and miners that
+    read either path see the probe geometry.
+    """
+    base = dict(build_ctx or {})
+    arch = dict(base.get("arch") or {}) if isinstance(base.get("arch"), dict) else {}
+    arch.update(_MUP_PROBE_ARCH)
+    base["arch"] = arch
+    for key, value in _MUP_PROBE_ARCH.items():
+        base[key] = value
+    # Never inherit a stale multiplier from a prior probe attempt.
+    base.pop("prism_width_multiplier", None)
+    return base
 
 
 def _median(xs):
@@ -86,7 +127,8 @@ def _mup_sweep(ctx, budget):
     if build is None or stream is None or not callable(build):
         return None, "no_build_model"
     device = ctx["device"]
-    base_ctx = dict(ctx.get("build_ctx") or {})
+    # Reduced fixed probe base — not full production build_ctx geometry.
+    base_ctx = mup_probe_base_ctx(ctx.get("build_ctx"))
     lrs = [3e-4, 1e-3, 3e-3]
     steps = 4 if common.tiny_caps() else 10
     best_by_width = {}

--- a/crates/prism-recipe/harness/prismlib/scoring.py
+++ b/crates/prism-recipe/harness/prismlib/scoring.py
@@ -10,7 +10,10 @@ Unit note (modular tokenizer): `bpb` is bits per **token** of the submitted
 tokenizer and stays the v1/v2 scoring key, bit-identical for a submission
 that keeps the pinned default. The additional `bits_per_byte` is total bits
 over the UTF-8 bytes actually scored — the tokenizer-neutral number to
-compare submissions that chose different vocabularies.
+compare submissions that chose different vocabularies. Shadow leaf ranking
+still uses per-token `bpb` (v2 contract); G1 composite anchors already use
+`bits_per_byte`. A shadow-leaf flip to bits/byte needs an explicit
+scoring-version / governance change (see docs/PRISM.md § shadow leaf unit).
 """
 
 from . import LN2

--- a/crates/prism-recipe/harness/tests/smoke_battery.py
+++ b/crates/prism-recipe/harness/tests/smoke_battery.py
@@ -627,6 +627,14 @@ def check_v3_flow(arch_src=STUB_ARCH, tokenizer_source="default", vocab_size=Non
         )
 
 
+def check_g8_mup_contracts():
+    """µP rollup fail-closed + reduced probe-base geometry (no full GPU sweep)."""
+    for script in ("test_g8_mup_rollup.py", "test_g8_mup_probe_base.py"):
+        path = Path(__file__).resolve().parent / script
+        r = subprocess.run([sys.executable, str(path)], cwd=str(HARNESS_ROOT))
+        assert r.returncode == 0, f"{script} failed with {r.returncode}"
+
+
 def main():
     check_py_compile()
     check_generator_determinism()
@@ -638,6 +646,8 @@ def main():
     except ImportError as exc:
         print(f"BATTERY SMOKE SKIP (torch parts): {exc}")
         return 2
+    # Probe-base test builds Transformer++ at tiny width (needs torch).
+    check_g8_mup_contracts()
     check_full_battery()
     check_v3_flow()
     # Same flow on a submission that ships its own tokenizer via the

--- a/crates/prism-recipe/harness/tests/test_g8_mup_probe_base.py
+++ b/crates/prism-recipe/harness/tests/test_g8_mup_probe_base.py
@@ -1,0 +1,83 @@
+"""G8 µP sweep uses a reduced fixed probe base, not full production geometry."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from eval import g8_stability  # noqa: E402
+
+
+def main():
+    production = {
+        "d_model": 1024,
+        "n_layer": 24,
+        "n_head": 16,
+        "mlp_hidden": 2560,
+        "vocab_size": 50257,
+        "device": "cuda",
+        "seed": 7,
+        "arch": {"d_model": 1024, "n_layer": 24, "extra_ignored": True},
+        "prism_width_multiplier": 99.0,  # must be stripped before sweep
+        "tokenizer": object(),
+    }
+    probe = g8_stability.mup_probe_base_ctx(production)
+
+    # Width/depth replaced by fixed probe; vocab/device/seed preserved.
+    assert probe["d_model"] == 128, probe
+    assert probe["n_layer"] == 4, probe
+    assert probe["n_head"] == 4, probe
+    assert probe["mlp_hidden"] == 320, probe
+    assert probe["vocab_size"] == 50257, probe
+    assert probe["device"] == "cuda", probe
+    assert probe["seed"] == 7, probe
+    assert "prism_width_multiplier" not in probe, probe
+    assert probe["arch"]["d_model"] == 128, probe["arch"]
+    assert probe["arch"]["n_layer"] == 4, probe["arch"]
+    # Non-geometry arch keys survive.
+    assert probe["arch"].get("extra_ignored") is True, probe["arch"]
+
+    # Production build_ctx must not be mutated.
+    assert production["d_model"] == 1024
+    assert production["arch"]["d_model"] == 1024
+    assert production["prism_width_multiplier"] == 99.0
+
+    # Empty / None build_ctx still yields a usable probe.
+    bare = g8_stability.mup_probe_base_ctx(None)
+    assert bare["d_model"] == 128
+    assert bare["arch"]["d_model"] == 128
+
+    # Reference baseline honors probe overrides + width multiplier without OOM
+    # geometry (CPU, no train): 4× params must exceed 1.5× of 1×.
+    sys.path.insert(
+        0,
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "baselines",
+            "transformer_pp",
+        ),
+    )
+    import architecture as tpp  # noqa: E402
+
+    b1 = dict(probe)
+    b1["prism_width_multiplier"] = 1.0
+    b1["vocab_size"] = 256
+    m1 = tpp.build_model(b1)
+    n1 = sum(p.numel() for p in m1.parameters())
+
+    b4 = dict(probe)
+    b4["prism_width_multiplier"] = 4.0
+    b4["vocab_size"] = 256
+    m4 = tpp.build_model(b4)
+    n4 = sum(p.numel() for p in m4.parameters())
+    assert n4 > int(1.5 * n1), (n1, n4)
+    # Sanity: probe 4× stays far under the 350M submission cap.
+    assert n4 < 50_000_000, n4
+
+    print(f"g8 mup probe base OK (1x={n1} 4x={n4})")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -329,7 +329,12 @@ Zone A `org.*` metrics):
 `1/(1+|log2(best_lr_wide/best_lr_base)|)` when the sweep converges; **0.0
 fail-closed** when the sweep path runs but diverges / build fails / width
 knob unsupported / budget cuts it short (so the G8 composite always sees
-the key after a real sweep). Tiny-caps test skips omit the key.
+the key after a real sweep). Tiny-caps test skips omit the key. The sweep
+builds from a **fixed small width/depth probe** (`d_model=128`, `n_layer=4`,
+… — see harness `eval/g8_stability.py`), **not** the scored submission's
+full geometry: 4× of a near-cap 350M model is unbuildable on the eval GPU.
+`build_model` must honor top-level / `arch` width-depth overrides **and**
+`ctx["prism_width_multiplier"]` (reference baselines do).
 
 **G5 scored keys (recipe ≥ 1.4.0).** The battery is an evaluation of
 **pretrained base LMs** — completion / few-shot base prompts, short EM or
@@ -351,13 +356,18 @@ internal G5 weights (group weight stays 0.15):
 per-metric fixed-anchor normalization clipped to `[0,1]` against the
 pre-registered anchor set (`prism-recipe/anchors/v0.json`; versioned,
 hash-committed via `/v1/preregistration`, placeholder until measured on the
-baselines); two-level means → group scores (G5 uses the unequal internal
-weights above; other groups default equal); mirror-gap penalty
+baselines); **within each group**: weighted **arithmetic** mean of
+normalized sub-metrics → `g_k` (G5 uses the unequal internal weights above;
+other groups default equal weight 1 — a single zero sub-metric lowers `g_k`
+proportionally, it does **not** zero the whole group); mirror-gap penalty
 `max(0, (x_public − x_mirror) − 0.05)` deducted from G2/G4/G5; lexicographic
 gates (`g3 ≥ 0.25`, `g8 ≥ 0.5`, budget caps `350M` params / `6h`, CI
-half-width ≤ `0.05`); weighted geometric mean `C = ∏ g_k^{w_k}`; clustered
-bootstrap (B = 1000) → `SE(C)`; **LCB ranking**:
-`lattice = round(SCORE_MAX × max(0, C − 1.645·SE))`.
+half-width ≤ `0.05`); **across groups**: weighted **geometric** mean
+`C = ∏ g_k^{w_k}` (a **group** score of exactly 0 collapses `C` to 0 — that
+is intentional no-compensation; individual G5 zeros such as
+`helmet_rag_acc=0` / `lstar=0` only dilute G5 arithmetically unless the
+whole G5 mean hits 0); clustered bootstrap (B = 1000) → `SE(C)`; **LCB
+ranking**: `lattice = round(SCORE_MAX × max(0, C − 1.645·SE))`.
 
 **Zone A vs Zone B.** Every metric lives in exactly one zone. Zone A
 (`org.*`) is organizer-measured and feeds scoring. Zone B
@@ -400,6 +410,19 @@ no auto-retry.
 measured (no `placeholder` statuses) and pre-registered; from then rows
 carry `scoring_version 3` (`SCORING_VERSION_V3`). The v2 bpb column is
 still recorded on every v3 run (it is a G1 input and the shadow score).
+
+**Shadow leaf unit (tokenizer-dependent).** Live `PRISM_SCORING_MODE=shadow`
+still maps **per-token** `bpb = CE / ln 2` through `score_from_bpb`. That
+unit is comparable only within one tokenizer; a byte-level vocab
+(`MIN_VOCAB=256`) can look artificially strong on bits/token. Tokenizer-
+neutral `bits_per_byte` is already computed on every run and drives **G1**
+anchors (`org.g1.bits_per_byte_*`). Switching the shadow leaf itself to
+`bits_per_byte` would break the v2 bit-identical contract and needs an
+explicit scoring-version / governance change — tracked as a follow-up
+(plan: keep recording both; add `score_from_bits_per_byte`; flip shadow
+leaf + public board primary sort together, or wait for `composite`).
+Public UI should prefer G2 benches / group scores as the hero display
+while shadow emissions remain bpb.
 
 ## Agentic anti-cheat + AST + metrics gate
 

--- a/docs/external-miner/prism.md
+++ b/docs/external-miner/prism.md
@@ -269,17 +269,29 @@ terminal-loss band) and the cross-miner cohort, and land a stored verdict
 (`ok` / `flagged` / `quarantined`) — verdicts are evidence, never an
 auto-zero. Malformed or over-cap envelopes reject `422` and store nothing.
 
-While `PRISM_SCORING_MODE=shadow` (default) the leaf score stays pure bpb,
-bit-identical to v2. After the reference baselines (**Transformer++** and
+While `PRISM_SCORING_MODE=shadow` (default) the leaf score stays pure bpb
+(**bits/token** = CE / ln 2 — tokenizer-dependent; byte-level vocabs can look
+artificially strong). Tokenizer-neutral `bits_per_byte` is recorded on every
+run and already feeds G1; a shadow-leaf switch to bits/byte is deferred until
+an explicit scoring-version / governance change (see [`PRISM.md`](../PRISM.md)
+§ shadow leaf unit). After the reference baselines (**Transformer++** and
 **hybrid delta** — published in-repo under `crates/prism-recipe/baselines/`)
 are measured and the anchor set is pre-registered, governance may flip to
-`composite`: group scores are anchor-normalized, gate-filtered
+`composite`: group scores are anchor-normalized (**arithmetic** mean within
+each group; a single zero sub-metric does not zero the group), gate-filtered
 (`g3 ≥ 0.25`, `g8 ≥ 0.5`, budget + CI gates), combined as a weighted
-geometric mean, and ranked by the bootstrap lower-confidence bound
+**geometric** mean across groups (`C = ∏ g_k^{w_k}` — a full group score of 0
+collapses C), and ranked by the bootstrap lower-confidence bound
 (`lattice = round(SCORE_MAX × max(0, C − 1.645·SE))`). Inspect the anchor
 registry and pre-registration commits at `GET /v1/anchors` and
 `GET /v1/preregistration`; per-run Zone A / Zone B rows at
 `GET /v1/submissions/{id}/metrics?zone=a|b`.
+
+**G8 µP probe.** The stability sweep builds 1× and 4× width from a **fixed
+small** width/depth base (not your full ≤350M scored model), then scales with
+`ctx["prism_width_multiplier"]`. Honor top-level / `arch` geometry overrides
+and that multiplier in `build_model` (reference baselines do) or the sweep
+fail-closes `org.g8.mup_lr_stability = 0.0`.
 
 ## Useful routes
 


### PR DESCRIPTION
## Summary
- G8 µP LR-stability sweep no longer scales from full production `build_ctx` (near-cap 4× OOMs → `org.g8.mup_lr_stability=0.0` for everyone). Overlay a fixed small width/depth probe before `prism_width_multiplier`.
- Document aggregation clearly: **arithmetic** within-group means, **geometric** across-group composite (G5 individual zeros do not zero C unless the whole group hits 0).
- Document shadow leaf tokenizer-dependent `bpb` deferral (G1 already uses `bits_per_byte`; leaf flip needs governance).
- Tests: `test_g8_mup_probe_base.py` + wired into `smoke_battery.py`.

## Deploy
- Build/push images, then **resume-first** promote `prism-challenge` (do not tear down live measure pods).

## Test plan
- [ ] `python crates/prism-recipe/harness/tests/test_g8_mup_probe_base.py`
- [ ] `python crates/prism-recipe/harness/tests/test_g8_mup_rollup.py`
- [ ] `python crates/prism-recipe/harness/tests/smoke_battery.py` (CI harness-smoke)
- [ ] After promote: sample overnight/prod metrics — `org.g8.mup_lr_stability` no longer universally 0.0 / no `stub_reason_width_knob_unsupported` from OOM geometry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified µP width-scaling requirements, including fixed probe geometry and support for configuration overrides.
  * Documented composite scoring aggregation and tokenizer-dependent shadow scoring units.
  * Added guidance for fail-closed behavior when model construction does not honor probe settings.

* **Tests**
  * Added validation for µP probe construction, scaling behavior, configuration preservation, and smoke-test integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->