### PR TITLE
chore(deploy): promote prod prism pin for G8 µP probe base

### DIFF
--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,8 +1,8 @@
 {
-  "commit_sha": "900d66945f706f02c9048fb00e88fa12cf0f463e",
+  "commit_sha": "5d44ea63dffbfd98c78c90541c3c3258696d0cff",
   "env": "prod",
   "previous": {
-    "commit_sha": "c142219d6fab2474eec60b58ce3fc4550c84dde6",
+    "commit_sha": "900d66945f706f02c9048fb00e88fa12cf0f463e",
     "services": {
       "design-challenge": {
         "digest": "sha256:a0c145924c05efdce699e26218d867efbce309fe625fb7d88f6b2820c51a2c27",
@@ -15,8 +15,8 @@
         "repository": "ghcr.io/baseintelligence/base/gateway"
       },
       "prism-challenge": {
-        "digest": "sha256:a12eea9b6b5b951a992500245d6d7448e6848e94b3d023823eaf5b1e5a00a4d2",
-        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:a12eea9b6b5b951a992500245d6d7448e6848e94b3d023823eaf5b1e5a00a4d2",
+        "digest": "sha256:64b898d03011a472ea4e3e9898ca30277d908938b7575d1d5459602e6f9bca52",
+        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:64b898d03011a472ea4e3e9898ca30277d908938b7575d1d5459602e6f9bca52",
         "repository": "ghcr.io/baseintelligence/base/prism-challenge"
       },
       "updater": {
@@ -30,7 +30,7 @@
         "repository": "ghcr.io/baseintelligence/base/validator"
       }
     },
-    "updated_at": "2026-08-14T15:41:23Z"
+    "updated_at": "2026-08-14T17:12:53Z"
   },
   "services": {
     "design-challenge": {
@@ -44,8 +44,8 @@
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
-      "digest": "sha256:64b898d03011a472ea4e3e9898ca30277d908938b7575d1d5459602e6f9bca52",
-      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:64b898d03011a472ea4e3e9898ca30277d908938b7575d1d5459602e6f9bca52",
+      "digest": "sha256:3fb469f990cacfdefe79173378b74499a3cafd733a4e6e482521df98fb88cf22",
+      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:3fb469f990cacfdefe79173378b74499a3cafd733a4e6e482521df98fb88cf22",
       "repository": "ghcr.io/baseintelligence/base/prism-challenge"
     },
     "updater": {
@@ -59,5 +59,5 @@
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-14T17:12:53Z"
+  "updated_at": "2026-08-15T02:45:51Z"
 }


### PR DESCRIPTION
## Summary
- Promote `prism-challenge` prod pin to digest `sha256:3fb469f990ca…` from merge `#155` (`5d44ea63`)
- Unblocks miners: G8 µP sweep uses reduced probe base (no universal `org.g8.mup_lr_stability=0.0` from OOM geometry)

## Test plan
- [x] Pin ladder: staging digest matches
- [ ] resume-first prism-only recreate on prod master (no Lium kill; skip full remote-deploy if updater→validator breaks)
- [ ] Confirm prism healthz + seals intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment metadata to reference the latest application build.
  * Refreshed recorded container image versions and integrity details for production services.
  * Updated deployment timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->