### PR TITLE
fix(prism): hf top-model benches, weights, and gpt-2 refs

### DIFF
--- a/crates/prism-registry/src/hf.rs
+++ b/crates/prism-registry/src/hf.rs
@@ -897,15 +897,9 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::await_holding_lock)]
     use super::*;
     use crate::publish::require_topmodel_weights;
-    use std::sync::{Mutex, PoisonError};
+    use crate::publish::topmodel_env_lock;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
-    }
 
     fn req() -> TopModelRequest {
         TopModelRequest {
@@ -947,7 +941,7 @@ mod tests {
 
     #[tokio::test]
     async fn commits_custom_arch_pack() {
-        let _lock = env_lock();
+        let _lock = topmodel_env_lock();
         std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "0");
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -984,7 +978,7 @@ mod tests {
     #[test]
     fn require_weights_defaults_closed() {
         // Serialize env mutation across this crate's HF tests.
-        let _lock = env_lock();
+        let _lock = topmodel_env_lock();
         let prev = std::env::var("PRISM_TOPMODEL_REQUIRE_WEIGHTS").ok();
         std::env::remove_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS");
         assert!(require_topmodel_weights());
@@ -1000,7 +994,7 @@ mod tests {
 
     #[tokio::test]
     async fn refuses_without_checkpoint_when_weights_required() {
-        let _lock = env_lock();
+        let _lock = topmodel_env_lock();
         std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "1");
         let server = MockServer::start().await;
         let p = HfTopModelPublisher::with_config(

--- a/crates/prism-registry/src/hf.rs
+++ b/crates/prism-registry/src/hf.rs
@@ -15,6 +15,7 @@
 //! text). Absent/empty → graceful no-op.
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::path::Path;
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
@@ -482,6 +483,7 @@ fn sanitize_hub_path(rel: &str) -> String {
     }
 }
 
+#[allow(clippy::too_many_lines)] // Hub markdown card template
 fn hub_readme(req: &TopModelRequest, arch: &str, has_ckpt: bool) -> String {
     let benches = extract_g2(req.metrics_json.as_ref());
     let n_params = metric_u64(req.metrics_json.as_ref(), &["n_params"]);
@@ -518,15 +520,18 @@ fn hub_readme(req: &TopModelRequest, arch: &str, has_ckpt: bool) -> String {
     out.push_str("license: apache-2.0\n");
     out.push_str("---\n\n");
     out.push_str("<div align=\"center\">\n\n");
-    out.push_str(&format!("![BASE Banner]({BANNER_URL})\n\n"));
+    let _ = writeln!(out, "![BASE Banner]({BANNER_URL})");
+    out.push('\n');
     out.push_str("<h1 align=\"center\">PRISM top architecture</h1>\n\n");
     out.push_str("<p align=\"center\"><b>Global-best miner architecture on Base PRISM — benchmarks vs GPT-2 Large</b></p>\n\n");
     out.push_str("</div>\n\n---\n\n");
     out.push_str("## Benchmarks vs GPT-2 Large\n\n");
     out.push_str("Prism-protocol **public** eval pack. Accuracy: **↑ higher better**. BPB: **↓ lower better**. ");
-    out.push_str(&format!(
-        "Reference: [{GPT2_LABEL}]({GPT2_SOURCE}) (eval-only; not a miner train).\n\n"
-    ));
+    let _ = writeln!(
+        out,
+        "Reference: [{GPT2_LABEL}]({GPT2_SOURCE}) (eval-only; not a miner train)."
+    );
+    out.push('\n');
     out.push_str("| Metric | This model | GPT-2 Large | Δ | vs GPT-2 Large |\n");
     out.push_str("|---|---:|---:|---:|:---|\n");
     out.push_str(&bench_row_lower("Val BPB (G1)", Some(req.bpb), GPT2_BPB, 4));
@@ -544,39 +549,43 @@ fn hub_readme(req: &TopModelRequest, arch: &str, has_ckpt: bool) -> String {
     }
     out.push_str("\n### Compute notes\n\n");
     out.push_str("| | This model | GPT-2 Large |\n|---|---|---|\n");
-    out.push_str(&format!("| Parameters | {params_cell} | {gpt2_params} |\n"));
-    out.push_str(&format!("| Size vs reference | {params_vs} | 1× |\n"));
-    out.push_str(&format!(
-        "| Train tokens | {tokens_cell} | _(eval-only reference)_ |\n"
-    ));
-    out.push_str(&format!(
-        "| Wall clock | {wall_cell} | _(eval-only reference)_ |\n"
-    ));
-    out.push_str(&format!(
-        "| Sustained train throughput | {tflops_cell} | n/a (no Prism train) |\n"
-    ));
-    out.push_str(&format!(
-        "| GPU (harness) | `{gpu}` | 1×RTX 5090 (eval) |\n"
-    ));
+    let _ = writeln!(out, "| Parameters | {params_cell} | {gpt2_params} |");
+    let _ = writeln!(out, "| Size vs reference | {params_vs} | 1× |");
+    let _ = writeln!(
+        out,
+        "| Train tokens | {tokens_cell} | _(eval-only reference)_ |"
+    );
+    let _ = writeln!(
+        out,
+        "| Wall clock | {wall_cell} | _(eval-only reference)_ |"
+    );
+    let _ = writeln!(
+        out,
+        "| Sustained train throughput | {tflops_cell} | n/a (no Prism train) |"
+    );
+    let _ = writeln!(out, "| GPU (harness) | `{gpu}` | 1×RTX 5090 (eval) |");
     out.push_str(
         "\nThroughput ≈ `6 × N × D / wall` TFLOPS (dense transformer train FLOPs rule of thumb).\n\n",
     );
     out.push_str("## Model card\n\n");
     out.push_str("| field | value |\n|---|---|\n");
-    out.push_str(&format!("| arch_id | `{arch}` |\n"));
-    out.push_str(&format!("| bpb | `{:.6}` |\n", req.bpb));
-    out.push_str(&format!("| submission | `{}` |\n", req.submission_id));
-    out.push_str(&format!("| owner_hotkey | `{hotkey}…` |\n"));
-    out.push_str(&format!("| hub repo | `{DEFAULT_REPO}` |\n\n"));
+    let _ = writeln!(out, "| arch_id | `{arch}` |");
+    let _ = writeln!(out, "| bpb | `{:.6}` |", req.bpb);
+    let _ = writeln!(out, "| submission | `{}` |", req.submission_id);
+    let _ = writeln!(out, "| owner_hotkey | `{hotkey}…` |");
+    let _ = writeln!(out, "| hub repo | `{DEFAULT_REPO}` |");
+    out.push('\n');
     out.push_str("## Load (trust_remote_code)\n\n");
     out.push_str("```python\n");
     out.push_str("from transformers import AutoModel, AutoConfig\n");
-    out.push_str(&format!(
-        "cfg = AutoConfig.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)\n"
-    ));
-    out.push_str(&format!(
-        "model = AutoModel.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)\n"
-    ));
+    let _ = writeln!(
+        out,
+        "cfg = AutoConfig.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)"
+    );
+    let _ = writeln!(
+        out,
+        "model = AutoModel.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)"
+    );
     out.push_str("```\n\n");
     out.push_str(ckpt_note);
     out.push_str("\n\nCompanion GitHub publish (when configured) lives under `BaseIntelligence/prism` `top-model/`.\n");
@@ -675,7 +684,16 @@ fn metric_f64(metrics: Option<&serde_json::Value>, keys: &[&str]) -> Option<f64>
 }
 
 fn metric_u64(metrics: Option<&serde_json::Value>, keys: &[&str]) -> Option<u64> {
-    metric_f64(metrics, keys).map(|f| f as u64)
+    metric_f64(metrics, keys).and_then(|f| {
+        if !f.is_finite() || f < 0.0 || f > u64::MAX as f64 {
+            return None;
+        }
+        // Truncate toward zero after finite/range gate (JSON numbers arrive as f64).
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        {
+            Some(f as u64)
+        }
+    })
 }
 
 fn metric_str(metrics: Option<&serde_json::Value>, keys: &[&str]) -> Option<String> {
@@ -876,14 +894,18 @@ fn is_publishable_source(path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::await_holding_lock)]
     use super::*;
     use crate::publish::require_topmodel_weights;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, PoisonError};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
+    }
 
     fn req() -> TopModelRequest {
         TopModelRequest {
@@ -925,7 +947,7 @@ mod tests {
 
     #[tokio::test]
     async fn commits_custom_arch_pack() {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = env_lock();
         std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "0");
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -962,7 +984,7 @@ mod tests {
     #[test]
     fn require_weights_defaults_closed() {
         // Serialize env mutation across this crate's HF tests.
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = env_lock();
         let prev = std::env::var("PRISM_TOPMODEL_REQUIRE_WEIGHTS").ok();
         std::env::remove_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS");
         assert!(require_topmodel_weights());
@@ -978,7 +1000,7 @@ mod tests {
 
     #[tokio::test]
     async fn refuses_without_checkpoint_when_weights_required() {
-        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = env_lock();
         std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "1");
         let server = MockServer::start().await;
         let p = HfTopModelPublisher::with_config(

--- a/crates/prism-registry/src/hf.rs
+++ b/crates/prism-registry/src/hf.rs
@@ -8,7 +8,8 @@
 //!   `training.py`, plus touched `.py` / patch files from `tree_blob`)
 //! - `config.json` + thin `configuration_prism.py` / `modeling_prism.py`
 //!   wrappers so `trust_remote_code=True` consumers can locate the code
-//! - trained `checkpoint.pt` (LFS when large) when secure-receive parked it
+//! - trained `checkpoint.pt` (LFS when large) — required when
+//!   `PRISM_TOPMODEL_REQUIRE_WEIGHTS=1` (default)
 //!
 //! Token discipline: read from `PRISM_TOPMODEL_HF_TOKEN_FILE` only (never env
 //! text). Absent/empty → graceful no-op.
@@ -20,13 +21,30 @@ use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use sha2::{Digest, Sha256};
 use tracing::info;
 
-use crate::publish::{PublishError, TopModelRequest};
+use crate::publish::{require_topmodel_weights, PublishError, TopModelRequest};
 
 const DEFAULT_API_BASE: &str = "https://huggingface.co";
 const DEFAULT_REPO: &str = "BaseIntelligence/top-prism-architecture";
 const DEFAULT_REVISION: &str = "main";
 /// Hub regular (non-LFS) file ceiling used by the ndjson commit API.
 const REGULAR_FILE_MAX: usize = 5 * 1024 * 1024;
+/// Org banner mirrored from the Base monorepo (model card + org profile).
+const BANNER_URL: &str = "https://github.com/BaseIntelligence/base/raw/main/assets/banner.jpg";
+
+/// GPT-2 Large (774M) Prism-protocol public-pack reference (eval-only).
+const GPT2_LABEL: &str = "GPT-2 Large (774M)";
+const GPT2_PARAMS_M: f64 = 774.0;
+const GPT2_BPB: f64 = 4.163_851_322_121_356_4;
+const GPT2_HELLASWAG: f64 = 0.395;
+const GPT2_ARC_EASY: f64 = 0.28;
+const GPT2_ARC_CHALLENGE: f64 = 0.28;
+const GPT2_PIQA: f64 = 0.69;
+const GPT2_WINOGRANDE: f64 = 0.545;
+const GPT2_BOOLQ: f64 = 0.64;
+/// Prism-protocol Lium 1×5090 public pack (not OpenAI paper LAMBADA 60.12%).
+const GPT2_LAMBADA: f64 = 0.985;
+const GPT2_OPENBOOKQA: f64 = 0.335;
+const GPT2_SOURCE: &str = "https://huggingface.co/gpt2-large";
 
 /// HuggingFace Hub publisher (token never `Debug`/`Display`'d).
 pub struct HfTopModelPublisher {
@@ -103,9 +121,18 @@ impl HfTopModelPublisher {
 
     /// Ensure the model repo exists, then commit a reloadable custom-arch pack.
     ///
+    /// With `PRISM_TOPMODEL_REQUIRE_WEIGHTS=1` (default), refuses to publish
+    /// without a master-parked checkpoint (same fail-closed policy as GitHub).
+    ///
     /// # Errors
-    /// Transport / Hub API failures.
+    /// Transport / Hub API failures, or missing required weights.
     pub async fn publish(&self, req: &TopModelRequest) -> Result<String, PublishError> {
+        if require_topmodel_weights() && req.checkpoint_path.is_none() {
+            return Err(PublishError::Transport(
+                "checkpoint missing: secure receive (SSH harvest or admin /v1/admin/artifacts/.../receive) required, or set PRISM_TOPMODEL_REQUIRE_WEIGHTS=0"
+                    .into(),
+            ));
+        }
         self.ensure_repo().await?;
         let files = build_hub_files(req)?;
         let oid = self
@@ -283,9 +310,18 @@ impl HfTopModelPublisher {
             .get("href")
             .and_then(|h| h.as_str())
             .ok_or_else(|| PublishError::Api("hf lfs upload href missing".into()))?;
-        let mut req = self.http.put(href).body(bytes.to_vec());
+        // Pre-signed S3 URLs reject a second Authorization header. Use a bare
+        // client (no default Bearer) and only the LFS action headers.
+        let bare = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_mins(30))
+            .build()
+            .map_err(|e| PublishError::Transport(e.to_string()))?;
+        let mut req = bare.put(href).body(bytes.to_vec());
         if let Some(headers) = upload.get("header").and_then(|h| h.as_object()) {
             for (k, val) in headers {
+                if k.eq_ignore_ascii_case("authorization") {
+                    continue;
+                }
                 if let Some(s) = val.as_str() {
                     req = req.header(k.as_str(), s);
                 }
@@ -300,7 +336,7 @@ impl HfTopModelPublisher {
             let t = put.text().await.unwrap_or_default();
             return Err(PublishError::Api(format!("hf lfs put {st} ({path}): {t}")));
         }
-        // Optional verify action.
+        // Optional verify action (Hub endpoint — keep authenticated client).
         if let Some(verify) = actions.get("verify") {
             if let Some(vhref) = verify.get("href").and_then(|h| h.as_str()) {
                 let mut vreq = self.http.post(vhref).json(&serde_json::json!({
@@ -447,43 +483,252 @@ fn sanitize_hub_path(rel: &str) -> String {
 }
 
 fn hub_readme(req: &TopModelRequest, arch: &str, has_ckpt: bool) -> String {
+    let benches = extract_g2(req.metrics_json.as_ref());
+    let n_params = metric_u64(req.metrics_json.as_ref(), &["n_params"]);
+    let params_m = n_params.map(|n| n as f64 / 1e6);
+    let tokens = train_tokens(req.metrics_json.as_ref());
+    let wall = metric_f64(req.metrics_json.as_ref(), &["wall_clock_seconds"])
+        .or_else(|| metric_f64(req.metrics_json.as_ref(), &["train_metrics.wall_seconds"]));
+    let gpu = metric_str(req.metrics_json.as_ref(), &["gpu_type"]).unwrap_or_else(|| "n/a".into());
+    let tflops = match (n_params, tokens, wall) {
+        (Some(n), Some(t), Some(w)) if w > 0.0 => Some((6.0 * n as f64 * t as f64) / w / 1e12),
+        _ => None,
+    };
     let ckpt_note = if has_ckpt {
-        "Weights: `checkpoint.pt` (LFS when large). Load via `PrismCustomModel.from_pretrained` with `trust_remote_code=True`, or apply `sources/.prism/automodel.patch` onto the live AutoModel pin and `torch.load` the checkpoint."
+        "Weights: `checkpoint.pt` (Hub LFS when large). Load via `PrismCustomModel.from_pretrained` with `trust_remote_code=True`."
     } else {
         "Weights were not parked on the master for this champion — sources/config only."
     };
-    format!(
-        "---\n\
-         library_name: transformers\n\
-         tags:\n\
-         - prism\n\
-         - custom-architecture\n\
-         - trust-remote-code\n\
-         ---\n\n\
-         # PRISM top model — custom architecture\n\n\
-         Global-best champion published by the Base master. Novel Prism / AutoModel\n\
-         modules are included under `sources/` (and seam files at repo root) so the\n\
-         Hub card is reloadable even when the arch is **not** a stock transformers\n\
-         GPT-2-like config.\n\n\
-         | field | value |\n|---|---|\n\
-         | arch_id | `{arch}` |\n\
-         | bpb | `{:.6}` |\n\
-         | submission | `{}` |\n\
-         | owner_hotkey | `{}…` |\n\
-         | hub repo | `{DEFAULT_REPO}` (override via `PRISM_TOPMODEL_HF_REPO`) |\n\n\
-         ## Load (trust_remote_code)\n\n\
-         ```python\n\
-         from transformers import AutoModel, AutoConfig\n\
-         cfg = AutoConfig.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)\n\
-         model = AutoModel.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)\n\
-         ```\n\n\
-         {ckpt_note}\n\n\
-         Companion GitHub publish (when configured) lives under\n\
-         `BaseIntelligence/prism` `top-model/`.\n",
-        req.bpb,
-        req.submission_id,
-        req.owner_hotkey.chars().take(12).collect::<String>(),
-    )
+    let params_cell = params_m.map_or_else(|| "—".into(), |p| format!("{p:.1}M"));
+    let gpt2_params = format!("{GPT2_PARAMS_M:.0}M");
+    let params_vs = match params_m {
+        Some(p) if p > 0.0 => format!("{:.2}× vs {GPT2_LABEL}", GPT2_PARAMS_M / p),
+        _ => "—".into(),
+    };
+    let tflops_cell = tflops.map_or_else(|| "—".into(), |t| format!("{t:.1} TFLOPS (est.)"));
+    let tokens_cell = tokens.map_or_else(|| "—".into(), |t| format!("{t}"));
+    let wall_cell = wall.map_or_else(|| "—".into(), |w| format!("{w:.0}s"));
+    let hotkey: String = req.owner_hotkey.chars().take(12).collect();
+
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str("library_name: transformers\n");
+    out.push_str("pipeline_tag: text-generation\n");
+    out.push_str("tags:\n- prism\n- custom-architecture\n- trust-remote-code\n- neural-architecture-search\n");
+    out.push_str("license: apache-2.0\n");
+    out.push_str("---\n\n");
+    out.push_str("<div align=\"center\">\n\n");
+    out.push_str(&format!("![BASE Banner]({BANNER_URL})\n\n"));
+    out.push_str("<h1 align=\"center\">PRISM top architecture</h1>\n\n");
+    out.push_str("<p align=\"center\"><b>Global-best miner architecture on Base PRISM — benchmarks vs GPT-2 Large</b></p>\n\n");
+    out.push_str("</div>\n\n---\n\n");
+    out.push_str("## Benchmarks vs GPT-2 Large\n\n");
+    out.push_str("Prism-protocol **public** eval pack. Accuracy: **↑ higher better**. BPB: **↓ lower better**. ");
+    out.push_str(&format!(
+        "Reference: [{GPT2_LABEL}]({GPT2_SOURCE}) (eval-only; not a miner train).\n\n"
+    ));
+    out.push_str("| Metric | This model | GPT-2 Large | Δ | vs GPT-2 Large |\n");
+    out.push_str("|---|---:|---:|---:|:---|\n");
+    out.push_str(&bench_row_lower("Val BPB (G1)", Some(req.bpb), GPT2_BPB, 4));
+    for (name, ours, theirs) in [
+        ("HellaSwag", benches.hellaswag, GPT2_HELLASWAG),
+        ("ARC-Easy", benches.arc_easy, GPT2_ARC_EASY),
+        ("ARC-Challenge", benches.arc_challenge, GPT2_ARC_CHALLENGE),
+        ("PIQA", benches.piqa, GPT2_PIQA),
+        ("WinoGrande", benches.winogrande, GPT2_WINOGRANDE),
+        ("BoolQ", benches.boolq, GPT2_BOOLQ),
+        ("LAMBADA", benches.lambada, GPT2_LAMBADA),
+        ("OpenBookQA", benches.openbookqa, GPT2_OPENBOOKQA),
+    ] {
+        out.push_str(&bench_row_higher(name, ours, theirs, 3));
+    }
+    out.push_str("\n### Compute notes\n\n");
+    out.push_str("| | This model | GPT-2 Large |\n|---|---|---|\n");
+    out.push_str(&format!("| Parameters | {params_cell} | {gpt2_params} |\n"));
+    out.push_str(&format!("| Size vs reference | {params_vs} | 1× |\n"));
+    out.push_str(&format!(
+        "| Train tokens | {tokens_cell} | _(eval-only reference)_ |\n"
+    ));
+    out.push_str(&format!(
+        "| Wall clock | {wall_cell} | _(eval-only reference)_ |\n"
+    ));
+    out.push_str(&format!(
+        "| Sustained train throughput | {tflops_cell} | n/a (no Prism train) |\n"
+    ));
+    out.push_str(&format!(
+        "| GPU (harness) | `{gpu}` | 1×RTX 5090 (eval) |\n"
+    ));
+    out.push_str(
+        "\nThroughput ≈ `6 × N × D / wall` TFLOPS (dense transformer train FLOPs rule of thumb).\n\n",
+    );
+    out.push_str("## Model card\n\n");
+    out.push_str("| field | value |\n|---|---|\n");
+    out.push_str(&format!("| arch_id | `{arch}` |\n"));
+    out.push_str(&format!("| bpb | `{:.6}` |\n", req.bpb));
+    out.push_str(&format!("| submission | `{}` |\n", req.submission_id));
+    out.push_str(&format!("| owner_hotkey | `{hotkey}…` |\n"));
+    out.push_str(&format!("| hub repo | `{DEFAULT_REPO}` |\n\n"));
+    out.push_str("## Load (trust_remote_code)\n\n");
+    out.push_str("```python\n");
+    out.push_str("from transformers import AutoModel, AutoConfig\n");
+    out.push_str(&format!(
+        "cfg = AutoConfig.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)\n"
+    ));
+    out.push_str(&format!(
+        "model = AutoModel.from_pretrained(\"{DEFAULT_REPO}\", trust_remote_code=True)\n"
+    ));
+    out.push_str("```\n\n");
+    out.push_str(ckpt_note);
+    out.push_str("\n\nCompanion GitHub publish (when configured) lives under `BaseIntelligence/prism` `top-model/`.\n");
+    out
+}
+
+#[derive(Default)]
+struct G2Benches {
+    hellaswag: Option<f64>,
+    arc_easy: Option<f64>,
+    arc_challenge: Option<f64>,
+    piqa: Option<f64>,
+    winogrande: Option<f64>,
+    boolq: Option<f64>,
+    lambada: Option<f64>,
+    openbookqa: Option<f64>,
+}
+
+fn extract_g2(metrics: Option<&serde_json::Value>) -> G2Benches {
+    G2Benches {
+        hellaswag: g2_acc(metrics, &["org.g2.hellaswag_acc", "g2.hellaswag.acc_norm"]),
+        arc_easy: g2_acc(metrics, &["org.g2.arc_easy_acc", "g2.arc_easy.acc_norm"]),
+        arc_challenge: g2_acc(
+            metrics,
+            &["org.g2.arc_challenge_acc", "g2.arc_challenge.acc_norm"],
+        ),
+        piqa: g2_acc(metrics, &["org.g2.piqa_acc", "g2.piqa.acc_norm"]),
+        winogrande: g2_acc(
+            metrics,
+            &["org.g2.winogrande_acc", "g2.winogrande.acc_norm"],
+        ),
+        boolq: g2_acc(metrics, &["org.g2.boolq_acc", "g2.boolq.acc_norm"]),
+        lambada: g2_acc(metrics, &["org.g2.lambada_acc", "g2.lambada.acc_norm"]),
+        openbookqa: g2_acc(
+            metrics,
+            &[
+                "org.g2.obqa_acc",
+                "g2.openbookqa.acc_norm",
+                "org.g2.openbookqa_acc",
+            ],
+        ),
+    }
+}
+
+fn g2_acc(metrics: Option<&serde_json::Value>, keys: &[&str]) -> Option<f64> {
+    let m = metrics?;
+    for k in keys {
+        if let Some(v) = lookup_num(m, k) {
+            return Some(v);
+        }
+        // battery.groups.g2.metrics.<key>
+        if let Some(v) = m
+            .pointer(&format!("/battery/groups/g2/metrics/{k}"))
+            .and_then(json_num)
+        {
+            return Some(v);
+        }
+        if let Some(v) = m
+            .pointer(&format!("/battery/metrics/{k}/value"))
+            .and_then(json_num)
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn lookup_num(m: &serde_json::Value, key: &str) -> Option<f64> {
+    m.get(key)
+        .and_then(|v| json_num(v).or_else(|| v.get("value").and_then(json_num)))
+        .or_else(|| {
+            m.pointer(&format!("/battery/metrics/{key}/value"))
+                .and_then(json_num)
+        })
+}
+
+fn json_num(v: &serde_json::Value) -> Option<f64> {
+    v.as_f64()
+        .or_else(|| v.as_i64().map(|i| i as f64))
+        .or_else(|| v.as_u64().map(|u| u as f64))
+}
+
+fn metric_f64(metrics: Option<&serde_json::Value>, keys: &[&str]) -> Option<f64> {
+    let m = metrics?;
+    for k in keys {
+        if let Some(v) = if k.contains('.') {
+            m.pointer(&format!("/{}", k.replace('.', "/")))
+                .and_then(json_num)
+        } else {
+            lookup_num(m, k)
+        } {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn metric_u64(metrics: Option<&serde_json::Value>, keys: &[&str]) -> Option<u64> {
+    metric_f64(metrics, keys).map(|f| f as u64)
+}
+
+fn metric_str(metrics: Option<&serde_json::Value>, keys: &[&str]) -> Option<String> {
+    let m = metrics?;
+    for k in keys {
+        if let Some(s) = m.get(*k).and_then(|v| v.as_str()) {
+            return Some(s.to_owned());
+        }
+    }
+    None
+}
+
+fn train_tokens(metrics: Option<&serde_json::Value>) -> Option<u64> {
+    metric_u64(metrics, &["train_metrics.tokens"])
+        .or_else(|| metric_u64(metrics, &["tokens_seen"]).filter(|&t| t > 10_000))
+}
+
+fn bench_row_higher(name: &str, ours: Option<f64>, base: f64, digits: usize) -> String {
+    match ours {
+        Some(v) => {
+            let delta = v - base;
+            let (arrow, verdict) = if (delta).abs() < 1e-9 {
+                ("=", "tie")
+            } else if delta > 0.0 {
+                ("↑", "✓ better")
+            } else {
+                ("↓", "worse")
+            };
+            format!(
+                "| {name} | {v:.digits$} | {base:.digits$} | {arrow} {delta:+.digits$} | {verdict} |\n"
+            )
+        }
+        None => format!("| {name} | — | {base:.digits$} | — | _(missing)_ |\n"),
+    }
+}
+
+fn bench_row_lower(name: &str, ours: Option<f64>, base: f64, digits: usize) -> String {
+    match ours {
+        Some(v) => {
+            let delta = v - base;
+            let (arrow, verdict) = if (delta).abs() < 1e-9 {
+                ("=", "tie")
+            } else if delta < 0.0 {
+                ("↓", "✓ better")
+            } else {
+                ("↑", "worse")
+            };
+            format!(
+                "| {name} | {v:.digits$} | {base:.digits$} | {arrow} {delta:+.digits$} | {verdict} |\n"
+            )
+        }
+        None => format!("| {name} | — | {base:.digits$} | — | _(missing)_ |\n"),
+    }
 }
 
 const CONFIGURATION_PRISM_PY: &str = r#"
@@ -633,20 +878,40 @@ fn is_publishable_source(path: &str) -> bool {
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
+    use crate::publish::require_topmodel_weights;
+    use std::sync::Mutex;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn req() -> TopModelRequest {
         TopModelRequest {
             submission_id: "subm-hf".into(),
             arch_id: Some("arch_hf".into()),
             owner_hotkey: "cd".repeat(32),
-            bpb: 1.1,
+            bpb: 3.9,
             architecture_py: "def build_model(ctx):\n    return None\n".into(),
             training_py: "def train(model, ctx):\n    return {}\n".into(),
             metrics_json: Some(serde_json::json!({
-                "n_params": 1,
-                "battery": {"g1": {"status": "ok"}},
+                "n_params": 112_000_000_u64,
+                "tokens_seen": 1000,
+                "train_metrics": {"tokens": 2_000_000_000_u64, "wall_seconds": 10_000.0},
+                "wall_clock_seconds": 10_000.0,
+                "gpu_type": "GPU 0: NVIDIA GeForce RTX 5090",
+                "battery": {
+                    "metrics": {
+                        "org.g2.hellaswag_acc": {"value": 0.40},
+                        "org.g2.arc_easy_acc": {"value": 0.30},
+                        "org.g2.arc_challenge_acc": {"value": 0.25},
+                        "org.g2.piqa_acc": {"value": 0.70},
+                        "org.g2.winogrande_acc": {"value": 0.50},
+                        "org.g2.boolq_acc": {"value": 0.60},
+                        "org.g2.lambada_acc": {"value": 0.90},
+                        "org.g2.obqa_acc": {"value": 0.28},
+                    },
+                    "groups": {"g2": {"status": "ok"}},
+                },
                 "flow": "v3",
                 "eval_tier": "public",
             })),
@@ -660,6 +925,8 @@ mod tests {
 
     #[tokio::test]
     async fn commits_custom_arch_pack() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "0");
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/api/repos/create"))
@@ -690,6 +957,56 @@ mod tests {
         assert!(keys.contains(&"config.json"));
         assert!(keys.contains(&"modeling_prism.py"));
         assert!(keys.contains(&"sources/nemo_automodel/components/models/toy/layers.py"));
+    }
+
+    #[test]
+    fn require_weights_defaults_closed() {
+        // Serialize env mutation across this crate's HF tests.
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("PRISM_TOPMODEL_REQUIRE_WEIGHTS").ok();
+        std::env::remove_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS");
+        assert!(require_topmodel_weights());
+        std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "0");
+        assert!(!require_topmodel_weights());
+        std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "1");
+        assert!(require_topmodel_weights());
+        match prev {
+            Some(v) => std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", v),
+            None => std::env::remove_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS"),
+        }
+    }
+
+    #[tokio::test]
+    async fn refuses_without_checkpoint_when_weights_required() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "1");
+        let server = MockServer::start().await;
+        let p = HfTopModelPublisher::with_config(
+            "hf_tok_test",
+            server.uri(),
+            "BaseIntelligence/top-prism-architecture",
+            "main",
+        )
+        .unwrap();
+        let err = p.publish(&req()).await.unwrap_err();
+        assert!(
+            matches!(err, PublishError::Transport(ref s) if s.contains("checkpoint missing")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn readme_benchmarks_first_vs_gpt2_large() {
+        let md = hub_readme(&req(), "arch_hf", true);
+        assert!(md.contains("Benchmarks vs GPT-2 Large"), "{md}");
+        assert!(md.contains(BANNER_URL), "{md}");
+        assert!(md.contains("HellaSwag"), "{md}");
+        assert!(md.contains("✓ better") || md.contains("worse"), "{md}");
+        assert!(md.contains("TFLOPS"), "{md}");
+        assert!(md.contains("LAMBADA"), "{md}");
+        assert!(md.contains("OpenBookQA"), "{md}");
+        assert!(!md.contains("no GPT-2 Large ref"), "{md}");
+        assert!(!md.contains("GPT-2 Small"), "{md}");
     }
 
     #[test]

--- a/crates/prism-registry/src/hooks.rs
+++ b/crates/prism-registry/src/hooks.rs
@@ -84,8 +84,8 @@ pub async fn post_score_hooks(
     }
 
     // (3) Top-model publish on a new global best — GitHub (optional) + HF
-    // (optional). GitHub weights require secure receive (RECEIPT.json);
-    // HF publishes sources regardless so the champion card stays current.
+    // (optional). Both require a verified secure-receive receipt when
+    // `PRISM_TOPMODEL_REQUIRE_WEIGHTS=1` (default); source-only is opt-in.
     // Recipe 2.0 / AutoModel only — legacy 1.x never becomes the published
     // top-model champion (historical FE rows stay in Postgres).
     if !row.weight_eligible() {

--- a/crates/prism-registry/src/lib.rs
+++ b/crates/prism-registry/src/lib.rs
@@ -28,5 +28,7 @@ mod weights;
 pub use competition::{apply_wta, competition_scores, OWNER_ARCH_CREDIT_ENABLED};
 pub use hf::HfTopModelPublisher;
 pub use hooks::post_score_hooks;
-pub use publish::{TopModelPublisher, TopModelRequest, TOPMODEL_REPO_PATH};
+pub use publish::{
+    require_topmodel_weights, TopModelPublisher, TopModelRequest, TOPMODEL_REPO_PATH,
+};
 pub use weights::{CheckpointMeta, TOPMODEL_RELEASE_TAG};

--- a/crates/prism-registry/src/publish.rs
+++ b/crates/prism-registry/src/publish.rs
@@ -9,6 +9,20 @@
 //! publisher is `None` and the orchestrator skips publishing entirely
 //! (graceful no-op).
 
+/// Whether top-model publish must include a parked checkpoint.
+///
+/// Default **true** (`PRISM_TOPMODEL_REQUIRE_WEIGHTS` unset/`1`). Set to
+/// `0`/`false`/`no` for source-only publish (legacy / tests).
+#[must_use]
+pub fn require_topmodel_weights() -> bool {
+    !matches!(
+        std::env::var("PRISM_TOPMODEL_REQUIRE_WEIGHTS")
+            .unwrap_or_else(|_| "1".into())
+            .trim(),
+        "0" | "false" | "FALSE" | "no" | "NO"
+    )
+}
+
 /// Repo directory that always mirrors the current global top model.
 pub const TOPMODEL_REPO_PATH: &str = "top-model";
 
@@ -136,12 +150,7 @@ impl TopModelPublisher {
     /// `0`/`false` to allow source-only publish (legacy / tests).
     pub async fn publish(&self, req: &TopModelRequest) -> Result<String, PublishError> {
         let arch = req.arch_id.as_deref().unwrap_or("arch-unregistered");
-        let require_weights = !matches!(
-            std::env::var("PRISM_TOPMODEL_REQUIRE_WEIGHTS")
-                .unwrap_or_else(|_| "1".into())
-                .trim(),
-            "0" | "false" | "FALSE" | "no" | "NO"
-        );
+        let require_weights = require_topmodel_weights();
         let mut weight_note = String::new();
         if let Some(path) = &req.checkpoint_path {
             let meta = self.publish_checkpoint(path, arch, req.bpb).await?;

--- a/crates/prism-registry/src/publish.rs
+++ b/crates/prism-registry/src/publish.rs
@@ -265,9 +265,21 @@ fn readme_block(req: &TopModelRequest, weight_note: &str) -> String {
     )
 }
 
+/// Serialize unit tests that mutate `PRISM_TOPMODEL_REQUIRE_WEIGHTS`.
+#[cfg(test)]
+pub(crate) static TOPMODEL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+pub(crate) fn topmodel_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::PoisonError;
+    TOPMODEL_ENV_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::await_holding_lock)]
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -291,6 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn publishes_all_files_and_returns_commit_sha() {
+        let _lock = topmodel_env_lock();
         std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "0");
         let server = MockServer::start().await;
         for f in [
@@ -325,6 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn api_error_is_typed() {
+        let _lock = topmodel_env_lock();
         std::env::set_var("PRISM_TOPMODEL_REQUIRE_WEIGHTS", "0");
         let server = MockServer::start().await;
         Mock::given(method("GET"))

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -515,11 +515,7 @@ async fn fetch_prism_details(st: &SiteState, ids: &[String]) -> HashMap<String, 
             Some((id, PrismDetailFanout { detail, zone_a }))
         }
     });
-    join_all(futs)
-        .await
-        .into_iter()
-        .flatten()
-        .collect()
+    join_all(futs).await.into_iter().flatten().collect()
 }
 
 /// When detail metrics omit public G2 benches, pull Zone-A rows from the eval store.

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -494,11 +494,8 @@ async fn fetch_prism_details(st: &SiteState, ids: &[String]) -> HashMap<String, 
         let st = st.clone();
         let id = id.clone();
         async move {
-            let Some(mut detail) =
-                upstream::get_json_opt(&st, PRISM, &format!("/v1/submissions/{id}")).await
-            else {
-                return None;
-            };
+            let mut detail =
+                upstream::get_json_opt(&st, PRISM, &format!("/v1/submissions/{id}")).await?;
             // Optional /diff for pin_id when detail alone lacks era signals.
             if pin_id_from_payload(&detail).is_none() {
                 if let Some(diff) =

--- a/crates/site-api/src/prism_enrich.rs
+++ b/crates/site-api/src/prism_enrich.rs
@@ -35,6 +35,10 @@ pub const GPT2_PIQA: f64 = 0.69;
 pub const GPT2_WINOGRANDE: f64 = 0.545;
 /// BoolQ `org.g2.boolq_acc`.
 pub const GPT2_BOOLQ: f64 = 0.64;
+/// LAMBADA `org.g2.lambada_acc` (Prism public pack on 1×RTX 5090).
+pub const GPT2_LAMBADA: f64 = 0.985;
+/// OpenBookQA `org.g2.obqa_acc` (Prism public pack on 1×RTX 5090).
+pub const GPT2_OPENBOOKQA: f64 = 0.335;
 
 /// Frozen public GPT-2 baseline(s) for `GET …/references`.
 #[must_use]
@@ -51,6 +55,8 @@ pub fn prism_reference_baselines() -> Vec<PrismReferenceBaseline> {
             piqa: Some(GPT2_PIQA),
             winogrande: Some(GPT2_WINOGRANDE),
             boolq: Some(GPT2_BOOLQ),
+            lambada: Some(GPT2_LAMBADA),
+            openbookqa: Some(GPT2_OPENBOOKQA),
         },
         source_url: GPT2_SOURCE_URL.into(),
         disclaimer: GPT2_DISCLAIMER.into(),
@@ -175,6 +181,23 @@ pub fn map_benchmarks(metrics: Option<&Value>) -> PrismBenchmarks {
         boolq: metric_f64(
             metrics,
             &["org.g2.boolq_acc", "g2.boolq.acc_norm", "g2.boolq.acc"],
+        ),
+        lambada: metric_f64(
+            metrics,
+            &[
+                "org.g2.lambada_acc",
+                "g2.lambada.acc_norm",
+                "g2.lambada.acc",
+            ],
+        ),
+        openbookqa: metric_f64(
+            metrics,
+            &[
+                "org.g2.obqa_acc",
+                "org.g2.openbookqa_acc",
+                "g2.openbookqa.acc_norm",
+                "g2.openbookqa.acc",
+            ],
         ),
     }
 }
@@ -501,6 +524,8 @@ mod tests {
         assert!((refs[0].bpb.unwrap() - GPT2_BPB).abs() < 1e-9);
         assert!((refs[0].params_m - 774.0).abs() < f64::EPSILON);
         assert!((refs[0].benchmarks.hellaswag.unwrap() - GPT2_HELLASWAG).abs() < f64::EPSILON);
+        assert!((refs[0].benchmarks.lambada.unwrap() - GPT2_LAMBADA).abs() < f64::EPSILON);
+        assert!((refs[0].benchmarks.openbookqa.unwrap() - GPT2_OPENBOOKQA).abs() < f64::EPSILON);
         assert!(refs[0].disclaimer.contains("Prism-protocol"));
         assert!(refs[0].source_url.contains("gpt2-large"));
     }

--- a/crates/site-types/src/types.rs
+++ b/crates/site-types/src/types.rs
@@ -176,6 +176,12 @@ pub struct PrismBenchmarks {
     /// BoolQ accuracy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub boolq: Option<f64>,
+    /// LAMBADA accuracy (`org.g2.lambada_acc`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lambada: Option<f64>,
+    /// OpenBookQA accuracy (`org.g2.obqa_acc`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openbookqa: Option<f64>,
 }
 
 impl PrismBenchmarks {
@@ -188,6 +194,8 @@ impl PrismBenchmarks {
             && self.piqa.is_none()
             && self.winogrande.is_none()
             && self.boolq.is_none()
+            && self.lambada.is_none()
+            && self.openbookqa.is_none()
     }
 
     /// Merge non-empty fields from `other` into `self` (fill gaps only).
@@ -209,6 +217,12 @@ impl PrismBenchmarks {
         }
         if self.boolq.is_none() {
             self.boolq = other.boolq;
+        }
+        if self.lambada.is_none() {
+            self.lambada = other.lambada;
+        }
+        if self.openbookqa.is_none() {
+            self.openbookqa = other.openbookqa;
         }
     }
 }

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -260,7 +260,12 @@ a mutable Release tag `prism-top-model`. The same trigger also commits a
 (`PRISM_TOPMODEL_HF_TOKEN_FILE`, default repo
 `BaseIntelligence/top-prism-architecture`): seam sources, AutoModel novelty
 under `sources/`, `config.json` + `trust_remote_code` wrappers, and
-`checkpoint.pt` (LFS when large). The publication is journaled
+`checkpoint.pt` (LFS when large; Hub LFS PUT uses a bare HTTP client so
+pre-signed storage auth is not dual-Authorization). HF publish is
+**fail-closed** on missing receipt when `PRISM_TOPMODEL_REQUIRE_WEIGHTS=1`
+(same as GitHub). The Hub README leads with public G2 benches vs
+**GPT-2 Large** (↑/↓ / ✓ better|worse) plus compute/TFLOPS notes and the
+Base banner. The publication is journaled
 (`prism_topmodel_publication`). GitHub token:
 `PRISM_TOPMODEL_GITHUB_TOKEN_FILE` (`deploy/secrets/github/token`);
 absent/empty → publish no-op. With `PRISM_TOPMODEL_REQUIRE_WEIGHTS=1`


### PR DESCRIPTION
## Summary
- HuggingFace top-model auto-publish now **requires** a master-parked `checkpoint.pt` (same fail-closed policy as GitHub), fixes Hub LFS PUT dual-Authorization, and generates a benchmarks-first model card vs **GPT-2 Large** (↑/↓ / ✓ better|worse + TFLOPS notes + Base banner).
- Fill **LAMBADA** / **OpenBookQA** GPT-2 Large refs from the prior **Prism-protocol Lium 1×5090** eval (`0.985` / `0.335`) into `prism_enrich` references, `PrismBenchmarks`, and the Hub README template (prefer Prism over literature LAMBADA ≈60.12% which uses a different protocol).
- Live Hub card + org Space updated; champion weights (`checkpoint.pt`, ~454MB LFS) published for `c93346119…`.

## Test plan
- [x] `cargo test -p prism-registry -p site-api --lib`
- [x] Live README shows LAMBADA/OpenBookQA Δ vs GPT-2 Large
- [x] `checkpoint.pt` present on `BaseIntelligence/top-prism-architecture`
- [ ] CI fmt/clippy/loc-cap/spec-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added LAMBADA and OpenBookQA benchmark results to model evaluation data.
  - Expanded model cards with benchmark comparisons, training metrics, compute estimates, banner metadata, and loading instructions.
  - Added support for displaying the new benchmark metrics.

- **Bug Fixes**
  - Improved large-file model uploads using pre-signed storage links.
  - Verification remains authenticated while preventing duplicate authorization headers.
  - Checkpoint availability is now required by default, with an opt-out option.

- **Documentation**
  - Clarified checkpoint requirements, upload behavior, publication safeguards, and expanded model-card content.

- **Testing**
  - Added coverage for checkpoint policies, benchmark reporting, environment settings, and request metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->