### PR TITLE
chore(deploy): promote prod gateway+prism pins for GPT-2 refs (#158)

### DIFF
--- a/deploy/pins/prod.json
+++ b/deploy/pins/prod.json
@@ -1,8 +1,8 @@
 {
-  "commit_sha": "5d44ea63dffbfd98c78c90541c3c3258696d0cff",
+  "commit_sha": "e74458664f6db474b29509512cb0eaafcd29cee0",
   "env": "prod",
   "previous": {
-    "commit_sha": "900d66945f706f02c9048fb00e88fa12cf0f463e",
+    "commit_sha": "e74458664f6db474b29509512cb0eaafcd29cee0",
     "services": {
       "design-challenge": {
         "digest": "sha256:a0c145924c05efdce699e26218d867efbce309fe625fb7d88f6b2820c51a2c27",
@@ -10,13 +10,13 @@
         "repository": "ghcr.io/baseintelligence/base/design-challenge"
       },
       "gateway": {
-        "digest": "sha256:0c8c4d91d71c3a1d97c2fbd206437b837d579d46eca58afadb6a92fcf2e9d3b8",
-        "image": "ghcr.io/baseintelligence/base/gateway@sha256:0c8c4d91d71c3a1d97c2fbd206437b837d579d46eca58afadb6a92fcf2e9d3b8",
+        "digest": "sha256:f7c8551a998f31fe46da052e50e3ce714c0a802518a16eaa7c602a8743c0ed18",
+        "image": "ghcr.io/baseintelligence/base/gateway@sha256:f7c8551a998f31fe46da052e50e3ce714c0a802518a16eaa7c602a8743c0ed18",
         "repository": "ghcr.io/baseintelligence/base/gateway"
       },
       "prism-challenge": {
-        "digest": "sha256:64b898d03011a472ea4e3e9898ca30277d908938b7575d1d5459602e6f9bca52",
-        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:64b898d03011a472ea4e3e9898ca30277d908938b7575d1d5459602e6f9bca52",
+        "digest": "sha256:3fb469f990cacfdefe79173378b74499a3cafd733a4e6e482521df98fb88cf22",
+        "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:3fb469f990cacfdefe79173378b74499a3cafd733a4e6e482521df98fb88cf22",
         "repository": "ghcr.io/baseintelligence/base/prism-challenge"
       },
       "updater": {
@@ -30,7 +30,7 @@
         "repository": "ghcr.io/baseintelligence/base/validator"
       }
     },
-    "updated_at": "2026-08-14T17:12:53Z"
+    "updated_at": "2026-08-15T06:43:53Z"
   },
   "services": {
     "design-challenge": {
@@ -39,13 +39,13 @@
       "repository": "ghcr.io/baseintelligence/base/design-challenge"
     },
     "gateway": {
-      "digest": "sha256:0c8c4d91d71c3a1d97c2fbd206437b837d579d46eca58afadb6a92fcf2e9d3b8",
-      "image": "ghcr.io/baseintelligence/base/gateway@sha256:0c8c4d91d71c3a1d97c2fbd206437b837d579d46eca58afadb6a92fcf2e9d3b8",
+      "digest": "sha256:f7c8551a998f31fe46da052e50e3ce714c0a802518a16eaa7c602a8743c0ed18",
+      "image": "ghcr.io/baseintelligence/base/gateway@sha256:f7c8551a998f31fe46da052e50e3ce714c0a802518a16eaa7c602a8743c0ed18",
       "repository": "ghcr.io/baseintelligence/base/gateway"
     },
     "prism-challenge": {
-      "digest": "sha256:3fb469f990cacfdefe79173378b74499a3cafd733a4e6e482521df98fb88cf22",
-      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:3fb469f990cacfdefe79173378b74499a3cafd733a4e6e482521df98fb88cf22",
+      "digest": "sha256:4fe35bb96162474f07f93115fc21d64c5eb92af92d151b96b1ed0281481644eb",
+      "image": "ghcr.io/baseintelligence/base/prism-challenge@sha256:4fe35bb96162474f07f93115fc21d64c5eb92af92d151b96b1ed0281481644eb",
       "repository": "ghcr.io/baseintelligence/base/prism-challenge"
     },
     "updater": {
@@ -59,5 +59,5 @@
       "repository": "ghcr.io/baseintelligence/base/validator"
     }
   },
-  "updated_at": "2026-08-15T02:45:51Z"
+  "updated_at": "2026-08-15T06:43:53Z"
 }


### PR DESCRIPTION
## Summary
- Promote prod `gateway` + `prism-challenge` digests from merge `#158` (`e744586`) so site-api GPT-2 Large LAMBADA/OpenBookQA refs and HF parked-weights publisher ship.
- Digests: gateway `sha256:f7c8551a…`, prism-challenge `sha256:4fe35bb9…`

## Test plan
- [ ] remote-deploy / surgical recreate gateway+prism on prod master (resume-first)
- [ ] `GET https://chain.joinbase.ai/v1/site/arenas/prism/references` includes lambada/openbookqa