### PR TITLE
fix(prism): rank top-model / board by G2 lattice score

### DIFF
--- a/bins/prism-challenge/src/main.rs
+++ b/bins/prism-challenge/src/main.rs
@@ -289,7 +289,7 @@ async fn cmd_republish_topmodel(id: String) -> Result<(), String> {
         .await
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("unknown submission {id}"))?;
-    let score = match &row.final_score {
+    let lattice_score = match &row.final_score {
         Some(FinalScore::Score(v)) if *v > 0 => *v,
         _ => return Err(format!("submission {id} has no positive lattice score")),
     };
@@ -300,7 +300,7 @@ async fn cmd_republish_topmodel(id: String) -> Result<(), String> {
     }
     let gh = build_topmodel();
     println!(
-        "republish-topmodel id={id} score={score} bpb={:?} arch={:?} github={}",
+        "republish-topmodel id={id} score={lattice_score} bpb={:?} arch={:?} github={}",
         row.bpb,
         row.arch_id,
         gh.is_some()

--- a/bins/prism-challenge/src/main.rs
+++ b/bins/prism-challenge/src/main.rs
@@ -305,7 +305,7 @@ async fn cmd_republish_topmodel(id: String) -> Result<(), String> {
         row.arch_id,
         gh.is_some()
     );
-    prism_registry::force_publish_topmodel(&store, gh.as_deref(), &row).await;
+    prism_registry::post_score_hooks(&store, gh.as_deref(), &row, true).await;
     if let Ok(Some(pub_row)) = store.last_publication().await {
         println!(
             "publication submission_id={} repo={} commit={:?}",

--- a/bins/prism-challenge/src/main.rs
+++ b/bins/prism-challenge/src/main.rs
@@ -131,6 +131,13 @@ enum Cmd {
         #[arg(long, default_value_t = 500)]
         limit: u32,
     },
+    /// Force-publish one submission to GitHub/HF top-model (operator republish).
+    /// Requires DB + `PRISM_TOPMODEL_*` token files + parked checkpoint when
+    /// weights are required.
+    RepublishTopmodel {
+        /// Submission id (64 hex).
+        id: String,
+    },
 }
 
 fn main() -> ExitCode {
@@ -162,6 +169,13 @@ fn run(cli: Cli) -> Result<(), String> {
                 .build()
                 .map_err(|e| e.to_string())?;
             return rt.block_on(cmd_rescore_g2(*dry_run, id.clone(), *limit));
+        }
+        Some(Cmd::RepublishTopmodel { id }) => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| e.to_string())?;
+            return rt.block_on(cmd_republish_topmodel(id.clone()));
         }
         _ => {}
     }
@@ -262,6 +276,44 @@ async fn cmd_rescore_g2(dry_run: bool, id: Option<String>, limit: u32) -> Result
         updated += 1;
     }
     println!("rescore-g2 done updated={updated} skipped={skipped} dry_run={dry_run}");
+    Ok(())
+}
+
+async fn cmd_republish_topmodel(id: String) -> Result<(), String> {
+    let url = std::env::var("BASE_DATABASE_URL")
+        .map_err(|_| "BASE_DATABASE_URL required for republish-topmodel".to_string())?;
+    let pool = db::connect(&url).await.map_err(|e| e.to_string())?;
+    let store: Arc<dyn PrismStore> = Arc::new(DbPrismStore::new(pool));
+    let row = store
+        .get(&id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("unknown submission {id}"))?;
+    let score = match &row.final_score {
+        Some(FinalScore::Score(v)) if *v > 0 => *v,
+        _ => return Err(format!("submission {id} has no positive lattice score")),
+    };
+    if !row.weight_eligible() {
+        return Err(format!(
+            "submission {id} is not weight-eligible (AutoModel 2.0)"
+        ));
+    }
+    let gh = build_topmodel();
+    println!(
+        "republish-topmodel id={id} score={score} bpb={:?} arch={:?} github={}",
+        row.bpb,
+        row.arch_id,
+        gh.is_some()
+    );
+    prism_registry::force_publish_topmodel(&store, gh.as_deref(), &row).await;
+    if let Ok(Some(pub_row)) = store.last_publication().await {
+        println!(
+            "publication submission_id={} repo={} commit={:?}",
+            pub_row.submission_id, pub_row.repo_path, pub_row.commit_sha
+        );
+    } else {
+        println!("publication: no journal row (publish may have failed; check logs)");
+    }
     Ok(())
 }
 

--- a/crates/prism-challenge/src/orchestrator.rs
+++ b/crates/prism-challenge/src/orchestrator.rs
@@ -481,7 +481,8 @@ impl<C: ChainClient + Send> Orchestrator<C> {
             .map_err(|e| e.to_string())?;
 
         if let Ok(Some(scored)) = self.store.get(&id).await {
-            prism_registry::post_score_hooks(&self.store, self.topmodel.as_deref(), &scored).await;
+            prism_registry::post_score_hooks(&self.store, self.topmodel.as_deref(), &scored, false)
+                .await;
         }
         self.logs.clear(&id);
         Ok(())
@@ -988,12 +989,8 @@ impl<C: ChainClient + Send> Orchestrator<C> {
             .await
             .map_err(|e| e.to_string())?;
         if let Some(s) = &summary {
-            info!(
-                epoch = s.epoch,
-                leaves = s.leaves,
-                batch = s.batch,
-                "epoch leaf set emitted"
-            );
+            #[rustfmt::skip]
+            info!(epoch = s.epoch, leaves = s.leaves, batch = s.batch, "epoch leaf set emitted");
         }
         Ok(summary)
     }

--- a/crates/prism-challenge/tests/arch_competition.rs
+++ b/crates/prism-challenge/tests/arch_competition.rs
@@ -349,7 +349,7 @@ async fn topmodel_hooks_graceful_without_publisher() {
     r.metrics_json = Some(serde_json::json!({"n_params": 12_000_000}));
     store.insert_queued(&r).await.unwrap();
 
-    prism_registry::post_score_hooks(&store, None, &r).await;
+    prism_registry::post_score_hooks(&store, None, &r, false).await;
 
     // Arch published even without a GitHub publisher; nothing journaled.
     assert!(store

--- a/crates/prism-registry/src/hf.rs
+++ b/crates/prism-registry/src/hf.rs
@@ -1,7 +1,8 @@
 //! HuggingFace Hub top-model publisher.
 //!
-//! When a submission becomes the new global-best bpb, the master publishes a
-//! **reloadable** Hub model card to `PRISM_TOPMODEL_HF_REPO` (default
+//! When a submission becomes the new global-best **lattice score** (G2 board
+//! ranking — never min-bpb alone), the master publishes a **reloadable** Hub
+//! model card to `PRISM_TOPMODEL_HF_REPO` (default
 //! `BaseIntelligence/top-prism-architecture`):
 //!
 //! - custom architecture / AutoModel novelty sources (`architecture.py`,

--- a/crates/prism-registry/src/hooks.rs
+++ b/crates/prism-registry/src/hooks.rs
@@ -8,10 +8,12 @@
 //!    their arch. Idempotent on digest (simultaneous duplicates share the
 //!    first registration).
 //! 2. **Arch best bpb** — lower-wins update feeding owner credit + the
-//!    public leaderboard (any trainer's result counts).
-//! 3. **Top-model publish** — when the row's bpb is a new global best
-//!    (≤ best scored bpb ever AND < last published bpb), publish to GitHub
-//!    and journal the publication. No-op without a configured publisher.
+//!    public leaderboard (any trainer's result counts; audit / secondary).
+//! 3. **Top-model publish** — when the row's **lattice score** is a new
+//!    global best (≥ best scored score ever AND > last published score),
+//!    publish to GitHub/HF and journal. Matches live board ranking
+//!    (G2 benchmark lattice under `scoring_version` 4). Never min-bpb alone.
+//!    No-op without a configured publisher.
 
 use std::sync::Arc;
 
@@ -24,16 +26,35 @@ use tracing::{info, warn};
 use crate::publish::{TopModelPublisher, TopModelRequest, TOPMODEL_REPO_PATH};
 
 /// Run registry + top-model bookkeeping for one finalized row.
-#[allow(clippy::too_many_lines)]
 pub async fn post_score_hooks(
     store: &Arc<dyn PrismStore>,
     publisher: Option<&TopModelPublisher>,
     row: &SubmissionState,
 ) {
-    let (Some(bpb), Some(FinalScore::Score(v))) = (row.bpb, &row.final_score) else {
+    post_score_hooks_inner(store, publisher, row, false).await;
+}
+
+/// Operator force-publish (republish CLI): same path as the auto trigger but
+/// skips the global-best / beats-published guards.
+pub async fn force_publish_topmodel(
+    store: &Arc<dyn PrismStore>,
+    publisher: Option<&TopModelPublisher>,
+    row: &SubmissionState,
+) {
+    post_score_hooks_inner(store, publisher, row, true).await;
+}
+
+#[allow(clippy::too_many_lines)]
+async fn post_score_hooks_inner(
+    store: &Arc<dyn PrismStore>,
+    publisher: Option<&TopModelPublisher>,
+    row: &SubmissionState,
+    force: bool,
+) {
+    let (Some(bpb), Some(FinalScore::Score(lattice))) = (row.bpb, &row.final_score) else {
         return;
     };
-    if *v == 0 {
+    if *lattice == 0 {
         return; // cheat / copy-gate zero never publishes nor sets arch best
     }
 
@@ -83,9 +104,9 @@ pub async fn post_score_hooks(
         }
     }
 
-    // (3) Top-model publish on a new global best — GitHub (optional) + HF
-    // (optional). Both require a verified secure-receive receipt when
-    // `PRISM_TOPMODEL_REQUIRE_WEIGHTS=1` (default); source-only is opt-in.
+    // (3) Top-model publish on a new global-best **lattice score** — GitHub
+    // (optional) + HF (optional). Both require a verified secure-receive
+    // receipt when `PRISM_TOPMODEL_REQUIRE_WEIGHTS=1` (default).
     // Recipe 2.0 / AutoModel only — legacy 1.x never becomes the published
     // top-model champion (historical FE rows stay in Postgres).
     if !row.weight_eligible() {
@@ -95,12 +116,20 @@ pub async fn post_score_hooks(
         );
         return;
     }
-    let last = store.last_publication_bpb().await.unwrap_or(None);
-    let global = store.best_scored_bpb().await.unwrap_or(None);
-    let is_global_best = global.is_some_and(|g| bpb <= g);
-    let beats_published = last.is_none_or(|l| bpb < l);
-    if !(is_global_best && beats_published) {
-        return;
+    if force {
+        info!(
+            submission_id = %row.id,
+            score = lattice,
+            "top-model: force republish (operator)"
+        );
+    } else {
+        let last = store.last_publication_score().await.unwrap_or(None);
+        let global = store.best_scored_score().await.unwrap_or(None);
+        let is_global_best = global.is_some_and(|g| *lattice >= g);
+        let beats_published = last.is_none_or(|l| *lattice > l);
+        if !(is_global_best && beats_published) {
+            return;
+        }
     }
     let ckpt = match prism_artifacts::verify_parked(&row.id) {
         Ok(receipt) => {
@@ -139,7 +168,13 @@ pub async fn post_score_hooks(
     if let Some(publisher) = publisher {
         match publisher.publish(&req).await {
             Ok(sha) => {
-                info!(submission_id = %row.id, bpb, commit = %sha, "top model published to GitHub");
+                info!(
+                    submission_id = %row.id,
+                    score = lattice,
+                    bpb,
+                    commit = %sha,
+                    "top model published to GitHub"
+                );
                 let rec = TopModelPublication {
                     submission_id: row.id.clone(),
                     arch_id: arch_id.clone(),

--- a/crates/prism-registry/src/hooks.rs
+++ b/crates/prism-registry/src/hooks.rs
@@ -26,26 +26,11 @@ use tracing::{info, warn};
 use crate::publish::{TopModelPublisher, TopModelRequest, TOPMODEL_REPO_PATH};
 
 /// Run registry + top-model bookkeeping for one finalized row.
-pub async fn post_score_hooks(
-    store: &Arc<dyn PrismStore>,
-    publisher: Option<&TopModelPublisher>,
-    row: &SubmissionState,
-) {
-    post_score_hooks_inner(store, publisher, row, false).await;
-}
-
-/// Operator force-publish (republish CLI): same path as the auto trigger but
-/// skips the global-best / beats-published guards.
-pub async fn force_publish_topmodel(
-    store: &Arc<dyn PrismStore>,
-    publisher: Option<&TopModelPublisher>,
-    row: &SubmissionState,
-) {
-    post_score_hooks_inner(store, publisher, row, true).await;
-}
-
+///
+/// When `force` is true (operator republish CLI), skip the global-best /
+/// beats-published guards and publish anyway.
 #[allow(clippy::too_many_lines)]
-async fn post_score_hooks_inner(
+pub async fn post_score_hooks(
     store: &Arc<dyn PrismStore>,
     publisher: Option<&TopModelPublisher>,
     row: &SubmissionState,
@@ -117,17 +102,11 @@ async fn post_score_hooks_inner(
         return;
     }
     if force {
-        info!(
-            submission_id = %row.id,
-            score = lattice,
-            "top-model: force republish (operator)"
-        );
+        info!(submission_id = %row.id, score = lattice, "top-model: force republish");
     } else {
         let last = store.last_publication_score().await.unwrap_or(None);
         let global = store.best_scored_score().await.unwrap_or(None);
-        let is_global_best = global.is_some_and(|g| *lattice >= g);
-        let beats_published = last.is_none_or(|l| *lattice > l);
-        if !(is_global_best && beats_published) {
+        if !(global.is_some_and(|g| *lattice >= g) && last.is_none_or(|l| *lattice > l)) {
             return;
         }
     }
@@ -168,13 +147,7 @@ async fn post_score_hooks_inner(
     if let Some(publisher) = publisher {
         match publisher.publish(&req).await {
             Ok(sha) => {
-                info!(
-                    submission_id = %row.id,
-                    score = lattice,
-                    bpb,
-                    commit = %sha,
-                    "top model published to GitHub"
-                );
+                info!(submission_id = %row.id, score = lattice, bpb, commit = %sha, "top model published");
                 let rec = TopModelPublication {
                     submission_id: row.id.clone(),
                     arch_id: arch_id.clone(),

--- a/crates/prism-registry/src/lib.rs
+++ b/crates/prism-registry/src/lib.rs
@@ -5,8 +5,9 @@
 //! - [`competition_scores`] — per-epoch emission math for the architecture
 //!   competition (SCORE_MAX lattice preserved; exact rule documented in
 //!   `docs/PRISM.md` § Architecture competition).
-//! - [`TopModelPublisher`] — publishes each new global-best bpb model to the
-//!   public `BaseIntelligence/prism` GitHub repo under `top-model/`, via a
+//! - [`TopModelPublisher`] — publishes each new global-best **lattice score**
+//!   model (G2 benches under `scoring_version` 4 — never min-bpb alone) to
+//!   the public `BaseIntelligence/prism` GitHub repo under `top-model/`, via a
 //!   token read from a deploy secret file (`PRISM_TOPMODEL_GITHUB_TOKEN_FILE`;
 //!   graceful no-op when absent).
 //! - [`HfTopModelPublisher`] — same trigger, commits a reloadable custom-arch
@@ -27,7 +28,7 @@ mod weights;
 
 pub use competition::{apply_wta, competition_scores, OWNER_ARCH_CREDIT_ENABLED};
 pub use hf::HfTopModelPublisher;
-pub use hooks::post_score_hooks;
+pub use hooks::{force_publish_topmodel, post_score_hooks};
 pub use publish::{
     require_topmodel_weights, TopModelPublisher, TopModelRequest, TOPMODEL_REPO_PATH,
 };

--- a/crates/prism-registry/src/lib.rs
+++ b/crates/prism-registry/src/lib.rs
@@ -28,7 +28,7 @@ mod weights;
 
 pub use competition::{apply_wta, competition_scores, OWNER_ARCH_CREDIT_ENABLED};
 pub use hf::HfTopModelPublisher;
-pub use hooks::{force_publish_topmodel, post_score_hooks};
+pub use hooks::post_score_hooks;
 pub use publish::{
     require_topmodel_weights, TopModelPublisher, TopModelRequest, TOPMODEL_REPO_PATH,
 };

--- a/crates/prism-registry/src/publish.rs
+++ b/crates/prism-registry/src/publish.rs
@@ -1,7 +1,7 @@
-//! Top-model GitHub publisher: each new global-best bpb model is published
-//! to the public `BaseIntelligence/prism` repo under `top-model/`
-//! (architecture.py + training.py + METRICS.json + README.md block) via the
-//! GitHub contents API.
+//! Top-model GitHub publisher: each new global-best **lattice score** model
+//! (G2 benchmark board ranking) is published to the public
+//! `BaseIntelligence/prism` repo under `top-model/` (architecture.py +
+//! training.py + METRICS.json + README.md block) via the GitHub contents API.
 //!
 //! Token discipline: the GitHub token is read from a deploy secret **file**
 //! (`PRISM_TOPMODEL_GITHUB_TOKEN_FILE`, e.g. `deploy/secrets/github/token`),
@@ -51,7 +51,7 @@ pub struct TopModelRequest {
     pub arch_id: Option<String>,
     /// Miner hotkey that set the best.
     pub owner_hotkey: String,
-    /// Global-best bpb.
+    /// Measured bpb (audit / README; champion selection uses lattice score).
     pub bpb: f64,
     /// architecture.py (registry source for training-only entries).
     pub architecture_py: String,
@@ -240,8 +240,9 @@ fn readme_block(req: &TopModelRequest, weight_note: &str) -> String {
     };
     format!(
         "# PRISM top model\n\n\
-         Published by the Base master on every new global-best bpb. This\n\
-         directory always mirrors the current champion; history lives in git.\n\n\
+         Published by the Base master on every new global-best G2 lattice\n\
+         score (live board ranking). This directory always mirrors the\n\
+         current champion; history lives in git.\n\n\
          | field | value |\n|---|---|\n\
          | arch_id | `{}` |\n\
          | owner_hotkey | `{}…` |\n\

--- a/crates/prism-store/src/arch.rs
+++ b/crates/prism-store/src/arch.rs
@@ -197,6 +197,19 @@ pub(crate) async fn last_publication_bpb(pool: &PgPool) -> Result<Option<f64>, S
     Ok(last_publication(pool).await?.map(|p| p.bpb))
 }
 
+pub(crate) async fn last_publication_score(pool: &PgPool) -> Result<Option<u64>, StoreError> {
+    let row: Option<(Option<i64>,)> = sqlx::query_as(
+        "SELECT s.score FROM prism_topmodel_publication p \
+         JOIN prism_submission s ON s.id = p.submission_id \
+         WHERE s.kind = 'score' AND s.score > 0 \
+         ORDER BY p.published_at DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(backend)?;
+    Ok(row.and_then(|(s,)| s.map(i64::cast_unsigned)))
+}
+
 pub(crate) async fn last_publication(
     pool: &PgPool,
 ) -> Result<Option<TopModelPublication>, StoreError> {
@@ -231,4 +244,17 @@ pub(crate) async fn best_scored_bpb(pool: &PgPool) -> Result<Option<f64>, StoreE
     .await
     .map_err(backend)?;
     Ok(row.0)
+}
+
+pub(crate) async fn best_scored_score(pool: &PgPool) -> Result<Option<u64>, StoreError> {
+    let row: (Option<i64>,) = sqlx::query_as(&format!(
+        "SELECT MAX(score) FROM prism_submission \
+         WHERE kind = 'score' AND score > 0 \
+           AND {}",
+        crate::emit::WEIGHT_ELIGIBLE_SQL
+    ))
+    .fetch_one(pool)
+    .await
+    .map_err(backend)?;
+    Ok(row.0.map(i64::cast_unsigned))
 }

--- a/crates/prism-store/src/dbprism.rs
+++ b/crates/prism-store/src/dbprism.rs
@@ -426,12 +426,20 @@ impl PrismStore for DbPrismStore {
         arch::last_publication_bpb(&self.pool).await
     }
 
+    async fn last_publication_score(&self) -> Result<Option<u64>, StoreError> {
+        arch::last_publication_score(&self.pool).await
+    }
+
     async fn last_publication(&self) -> Result<Option<TopModelPublication>, StoreError> {
         arch::last_publication(&self.pool).await
     }
 
     async fn best_scored_bpb(&self) -> Result<Option<f64>, StoreError> {
         arch::best_scored_bpb(&self.pool).await
+    }
+
+    async fn best_scored_score(&self) -> Result<Option<u64>, StoreError> {
+        arch::best_scored_score(&self.pool).await
     }
 
     async fn list_stuck(&self, grace_secs: u64) -> Result<Vec<SubmissionState>, StoreError> {

--- a/crates/prism-store/src/store.rs
+++ b/crates/prism-store/src/store.rs
@@ -118,16 +118,24 @@ pub trait PrismStore: Send + Sync + std::fmt::Debug {
     /// Journal one top-model publication.
     async fn record_publication(&self, p: &TopModelPublication) -> Result<(), StoreError>;
 
-    /// bpb of the most recent publication (idempotency guard; `None` = never
-    /// published).
+    /// bpb of the most recent publication (audit; prefer [`Self::last_publication_score`]).
     async fn last_publication_bpb(&self) -> Result<Option<f64>, StoreError>;
+
+    /// Lattice score of the submission behind the most recent publication
+    /// (idempotency guard for G2 / score ranking; `None` = never published or
+    /// the published row has no positive score).
+    async fn last_publication_score(&self) -> Result<Option<u64>, StoreError>;
 
     /// Most recent top-model publication row (`None` = never published).
     async fn last_publication(&self) -> Result<Option<TopModelPublication>, StoreError>;
 
-    /// Best (lowest) bpb across all scored submissions ever (global top-model
-    /// trigger baseline).
+    /// Best (lowest) bpb across weight-eligible scored submissions (audit /
+    /// legacy). Top-model publish uses [`Self::best_scored_score`].
     async fn best_scored_bpb(&self) -> Result<Option<f64>, StoreError>;
+
+    /// Best (highest) lattice score across weight-eligible scored submissions
+    /// (global top-model / HF champion trigger — matches live board ranking).
+    async fn best_scored_score(&self) -> Result<Option<u64>, StoreError>;
 
     /// Non-terminal rows beyond grace — for the stuck sweep.
     async fn list_stuck(&self, grace_secs: u64) -> Result<Vec<SubmissionState>, StoreError>;
@@ -596,6 +604,24 @@ impl PrismStore for MemoryPrismStore {
             .map(|p| p.bpb))
     }
 
+    async fn last_publication_score(&self) -> Result<Option<u64>, StoreError> {
+        let last = self.last_publication().await?;
+        let Some(p) = last else {
+            return Ok(None);
+        };
+        let rows = self
+            .rows
+            .lock()
+            .map_err(|_| StoreError::Backend("poison".into()))?;
+        Ok(rows
+            .iter()
+            .find(|r| r.id == p.submission_id)
+            .and_then(|r| match r.final_score {
+                Some(FinalScore::Score(v)) if v > 0 => Some(v),
+                _ => None,
+            }))
+    }
+
     async fn last_publication(&self) -> Result<Option<TopModelPublication>, StoreError> {
         Ok(self
             .publications
@@ -615,6 +641,20 @@ impl PrismStore for MemoryPrismStore {
             .filter(|r| matches!(r.final_score, Some(FinalScore::Score(v)) if v > 0))
             .filter_map(|r| r.bpb)
             .min_by(f64::total_cmp))
+    }
+
+    async fn best_scored_score(&self) -> Result<Option<u64>, StoreError> {
+        Ok(self
+            .rows
+            .lock()
+            .map_err(|_| StoreError::Backend("poison".into()))?
+            .iter()
+            .filter(|r| r.weight_eligible())
+            .filter_map(|r| match r.final_score {
+                Some(FinalScore::Score(v)) if v > 0 => Some(v),
+                _ => None,
+            })
+            .max())
     }
 
     async fn list_stuck(&self, grace_secs: u64) -> Result<Vec<SubmissionState>, StoreError> {

--- a/crates/prism-store/src/store.rs
+++ b/crates/prism-store/src/store.rs
@@ -182,6 +182,10 @@ fn now_ms() -> u64 {
         .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
+fn lock<T>(m: &Mutex<T>) -> Result<std::sync::MutexGuard<'_, T>, StoreError> {
+    m.lock().map_err(|_| StoreError::Backend("poison".into()))
+}
+
 /// Extract the miner-reported loss series from a `RemoteExecResult` JSON blob
 /// (`telemetry.loss_series`). Empty when absent or malformed — the harness
 /// controls the shape, so a parse miss means a pre-telemetry recipe.
@@ -196,10 +200,7 @@ pub(crate) fn telemetry_from_metrics(metrics_json: &serde_json::Value) -> Vec<Te
 #[async_trait]
 impl PrismStore for MemoryPrismStore {
     async fn insert_queued(&self, row: &SubmissionState) -> Result<(), StoreError> {
-        let mut rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut rows = lock(&self.rows)?;
         // Match Postgres unique(id): reject duplicates so a second POST cannot
         // enqueue another billable Lium claim for the same submission_id.
         if rows.iter().any(|r| r.id == row.id) {
@@ -210,20 +211,11 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn get(&self, id: &str) -> Result<Option<SubmissionState>, StoreError> {
-        Ok(self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .iter()
-            .find(|r| r.id == id)
-            .cloned())
+        Ok(lock(&self.rows)?.iter().find(|r| r.id == id).cloned())
     }
 
     async fn claim_next(&self) -> Result<Option<SubmissionState>, StoreError> {
-        let mut rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut rows = lock(&self.rows)?;
         let pos = rows.iter().position(|r| r.status == Stage::Queued);
         let Some(i) = pos else { return Ok(None) };
         let mut row = rows.remove(i).ok_or(StoreError::Backend("pop".into()))?;
@@ -238,10 +230,7 @@ impl PrismStore for MemoryPrismStore {
         update: &StatePatch,
         event: Option<&StageEvent>,
     ) -> Result<SubmissionState, StoreError> {
-        let mut rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut rows = lock(&self.rows)?;
         let row = rows
             .iter_mut()
             .find(|r| r.id == id)
@@ -286,17 +275,11 @@ impl PrismStore for MemoryPrismStore {
         if let Some(m) = &update.metrics_json {
             let series = telemetry_from_metrics(m);
             if !series.is_empty() {
-                self.telemetry
-                    .lock()
-                    .map_err(|_| StoreError::Backend("poison".into()))?
-                    .insert(id.to_owned(), series);
+                lock(&self.telemetry)?.insert(id.to_owned(), series);
             }
         }
         if let Some(e) = event {
-            self.events
-                .lock()
-                .map_err(|_| StoreError::Backend("poison".into()))?
-                .push((id.to_owned(), e.clone()));
+            lock(&self.events)?.push((id.to_owned(), e.clone()));
         }
         Ok(out)
     }
@@ -306,10 +289,7 @@ impl PrismStore for MemoryPrismStore {
         id: &str,
         bump_retry: bool,
     ) -> Result<SubmissionState, StoreError> {
-        let mut rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut rows = lock(&self.rows)?;
         let row = rows
             .iter_mut()
             .find(|r| r.id == id)
@@ -337,15 +317,9 @@ impl PrismStore for MemoryPrismStore {
         let out = row.clone();
         drop(rows);
         // A re-scored row must re-enter the emission outbox.
-        self.emitted
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .remove(id);
+        lock(&self.emitted)?.remove(id);
         if !retained_measurement {
-            self.telemetry
-                .lock()
-                .map_err(|_| StoreError::Backend("poison".into()))?
-                .remove(id);
+            lock(&self.telemetry)?.remove(id);
         }
         Ok(out)
     }
@@ -358,10 +332,7 @@ impl PrismStore for MemoryPrismStore {
     ) -> Result<Vec<SubmissionState>, StoreError> {
         let st = status.and_then(Stage::parse);
         let miner_norm = miner.map(|m| m.trim().to_ascii_lowercase());
-        let mut v: Vec<_> = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
+        let mut v: Vec<_> = lock(&self.rows)?
             .iter()
             .filter(|r| st.is_none() || Some(r.status) == st)
             .filter(|r| {
@@ -377,10 +348,7 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn list_champions(&self, limit: u32) -> Result<Vec<SubmissionState>, StoreError> {
-        let mut v: Vec<_> = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
+        let mut v: Vec<_> = lock(&self.rows)?
             .iter()
             .filter(|r| matches!(r.final_score, Some(FinalScore::Score(s)) if s > 0))
             .cloned()
@@ -391,10 +359,7 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn events(&self, id: &str) -> Result<Vec<StageEvent>, StoreError> {
-        Ok(self
-            .events
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
+        Ok(lock(&self.events)?
             .iter()
             .filter(|(k, _)| k == id)
             .map(|(_, e)| e.clone())
@@ -402,13 +367,7 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn telemetry(&self, id: &str) -> Result<Vec<TelemetryPoint>, StoreError> {
-        Ok(self
-            .telemetry
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .get(id)
-            .cloned()
-            .unwrap_or_default())
+        Ok(lock(&self.telemetry)?.get(id).cloned().unwrap_or_default())
     }
 
     async fn assign_emit_batch(
@@ -416,14 +375,8 @@ impl PrismStore for MemoryPrismStore {
         netuid: u16,
         epoch: u64,
     ) -> Result<Vec<EpochScoreRow>, StoreError> {
-        let rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
-        let mut emitted = self
-            .emitted
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let rows = lock(&self.rows)?;
+        let mut emitted = lock(&self.emitted)?;
         let mut out = Vec::new();
         for r in rows.iter() {
             if r.netuid == netuid && r.final_score.is_some() && !emitted.contains_key(&r.id) {
@@ -440,14 +393,8 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn emit_batch(&self, netuid: u16, epoch: u64) -> Result<Vec<EpochScoreRow>, StoreError> {
-        let rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
-        let emitted = self
-            .emitted
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let rows = lock(&self.rows)?;
+        let emitted = lock(&self.emitted)?;
         Ok(rows
             .iter()
             .filter(|r| {
@@ -463,10 +410,7 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn active_score_rows(&self, netuid: u16) -> Result<Vec<EpochScoreRow>, StoreError> {
-        let rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let rows = lock(&self.rows)?;
         Ok(rows
             .iter()
             .filter(|r| r.netuid == netuid && r.weight_eligible())
@@ -483,19 +427,11 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn emit_cursor(&self, netuid: u16) -> Result<Option<u64>, StoreError> {
-        Ok(self
-            .cursors
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .get(&netuid)
-            .copied())
+        Ok(lock(&self.cursors)?.get(&netuid).copied())
     }
 
     async fn set_emit_cursor(&self, netuid: u16, epoch: u64) -> Result<(), StoreError> {
-        let mut cursors = self
-            .cursors
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut cursors = lock(&self.cursors)?;
         let e = cursors.entry(netuid).or_insert(0);
         *e = (*e).max(epoch);
         Ok(())
@@ -507,14 +443,8 @@ impl PrismStore for MemoryPrismStore {
             Some(c) => c.saturating_add(1),
             None => 0,
         };
-        let rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
-        let emitted = self
-            .emitted
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let rows = lock(&self.rows)?;
+        let emitted = lock(&self.emitted)?;
         Ok(rows
             .iter()
             .filter(|r| r.netuid == netuid)
@@ -529,10 +459,7 @@ impl PrismStore for MemoryPrismStore {
         &self,
         rec: &ArchitectureRecord,
     ) -> Result<PublishArchOutcome, StoreError> {
-        let mut archs = self
-            .archs
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut archs = lock(&self.archs)?;
         if let Some(existing) = archs.values().find(|a| a.arch_digest == rec.arch_digest) {
             return Ok(PublishArchOutcome::Duplicate(existing.arch_id.clone()));
         }
@@ -541,32 +468,18 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn get_arch(&self, arch_id: &str) -> Result<Option<ArchitectureRecord>, StoreError> {
-        Ok(self
-            .archs
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .get(arch_id)
-            .cloned())
+        Ok(lock(&self.archs)?.get(arch_id).cloned())
     }
 
     async fn list_archs(&self, limit: u32) -> Result<Vec<ArchitectureRecord>, StoreError> {
-        let mut v: Vec<_> = self
-            .archs
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .values()
-            .cloned()
-            .collect();
+        let mut v: Vec<_> = lock(&self.archs)?.values().cloned().collect();
         v.sort_by_key(|r| std::cmp::Reverse(r.created_at_ms));
         v.truncate(limit as usize);
         Ok(v)
     }
 
     async fn note_arch_best_bpb(&self, arch_id: &str, bpb: f64) -> Result<bool, StoreError> {
-        let mut archs = self
-            .archs
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut archs = lock(&self.archs)?;
         let Some(rec) = archs.get_mut(arch_id) else {
             return Ok(false);
         };
@@ -578,30 +491,19 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn arch_owners(&self) -> Result<Vec<(String, String)>, StoreError> {
-        Ok(self
-            .archs
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
+        Ok(lock(&self.archs)?
             .values()
             .map(|a| (a.arch_id.clone(), a.owner_hotkey.clone()))
             .collect())
     }
 
     async fn record_publication(&self, p: &TopModelPublication) -> Result<(), StoreError> {
-        self.publications
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .push(p.clone());
+        lock(&self.publications)?.push(p.clone());
         Ok(())
     }
 
     async fn last_publication_bpb(&self) -> Result<Option<f64>, StoreError> {
-        Ok(self
-            .publications
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .last()
-            .map(|p| p.bpb))
+        Ok(lock(&self.publications)?.last().map(|p| p.bpb))
     }
 
     async fn last_publication_score(&self) -> Result<Option<u64>, StoreError> {
@@ -609,10 +511,7 @@ impl PrismStore for MemoryPrismStore {
         let Some(p) = last else {
             return Ok(None);
         };
-        let rows = self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let rows = lock(&self.rows)?;
         Ok(rows
             .iter()
             .find(|r| r.id == p.submission_id)
@@ -623,19 +522,11 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn last_publication(&self) -> Result<Option<TopModelPublication>, StoreError> {
-        Ok(self
-            .publications
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
-            .last()
-            .cloned())
+        Ok(lock(&self.publications)?.last().cloned())
     }
 
     async fn best_scored_bpb(&self) -> Result<Option<f64>, StoreError> {
-        Ok(self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
+        Ok(lock(&self.rows)?
             .iter()
             .filter(|r| r.weight_eligible())
             .filter(|r| matches!(r.final_score, Some(FinalScore::Score(v)) if v > 0))
@@ -644,10 +535,7 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn best_scored_score(&self) -> Result<Option<u64>, StoreError> {
-        Ok(self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
+        Ok(lock(&self.rows)?
             .iter()
             .filter(|r| r.weight_eligible())
             .filter_map(|r| match r.final_score {
@@ -659,10 +547,7 @@ impl PrismStore for MemoryPrismStore {
 
     async fn list_stuck(&self, grace_secs: u64) -> Result<Vec<SubmissionState>, StoreError> {
         let cutoff = now_ms().saturating_sub(grace_secs.saturating_mul(1000));
-        Ok(self
-            .rows
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?
+        Ok(lock(&self.rows)?
             .iter()
             .filter(|r| !r.status.is_terminal() && r.updated_at_ms < cutoff)
             .cloned()
@@ -670,10 +555,7 @@ impl PrismStore for MemoryPrismStore {
     }
 
     async fn precheck_quota_get(&self, identity: &str, day: &str) -> Result<u32, StoreError> {
-        let map = self
-            .precheck_quota
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let map = lock(&self.precheck_quota)?;
         Ok(map
             .get(&(identity.to_owned(), day.to_owned()))
             .copied()
@@ -686,10 +568,7 @@ impl PrismStore for MemoryPrismStore {
         day: &str,
         limit: u32,
     ) -> Result<Option<u32>, StoreError> {
-        let mut map = self
-            .precheck_quota
-            .lock()
-            .map_err(|_| StoreError::Backend("poison".into()))?;
+        let mut map = lock(&self.precheck_quota)?;
         let key = (identity.to_owned(), day.to_owned());
         let used = map.get(&key).copied().unwrap_or(0);
         if used >= limit {

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -1261,7 +1261,8 @@ mod tests {
         let (s, v) = call(app.clone(), "/v1/site/arenas/prism/leaderboard").await;
         assert_eq!(s, StatusCode::OK, "{v}");
         assert_eq!(v["metric"], "score");
-        assert_eq!(v["items"][0]["elo"], 1.25);
+        // Lattice score in `elo`; measured bpb stays secondary.
+        assert_eq!(v["items"][0]["elo"], 900.0);
         assert_eq!(v["items"][0]["bpb"], 1.25);
         assert_eq!(v["items"][0]["paramsM"], 12.0);
 

--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -477,7 +477,7 @@ async fn prism_leaderboard_json(
         "total": page_out.total,
         "pageCount": page_out.page_count,
         "epoch": epoch,
-        "metric": "bpb",
+        "metric": "score",
         "updatedAt": now_iso(),
     })
 }
@@ -1260,7 +1260,7 @@ mod tests {
 
         let (s, v) = call(app.clone(), "/v1/site/arenas/prism/leaderboard").await;
         assert_eq!(s, StatusCode::OK, "{v}");
-        assert_eq!(v["metric"], "bpb");
+        assert_eq!(v["metric"], "score");
         assert_eq!(v["items"][0]["elo"], 1.25);
         assert_eq!(v["items"][0]["bpb"], 1.25);
         assert_eq!(v["items"][0]["paramsM"], 12.0);

--- a/crates/site-data/src/map.rs
+++ b/crates/site-data/src/map.rs
@@ -644,16 +644,18 @@ pub fn is_prism_champion_submission(row: &Value) -> bool {
         .unwrap_or(false)
 }
 
-/// Prism BPB leaderboard from **champion** terminal submissions (Score>0).
+/// Prism champion leaderboard from terminal submissions (`Score>0`).
 ///
-/// Non-top submissions are hidden from the public board. `elo` carries the BPB
-/// value so the existing leaderboard row contract can surface rankings without
-/// inventing Elo/duels; `bpb` / `paramsM` mirror the measured values explicitly
-/// for telemetry-aware clients. `submissionId` is the best-BPB champion row so
-/// clients can open the detail modal; era / benches are filled by detail fan-out.
+/// Ranks by **lattice score** descending (G2 equal-weight mean under
+/// `scoring_version` 4) — never min-bpb alone. Per hotkey, the highest-scoring
+/// champion row wins. `elo` carries the lattice score so the existing row
+/// contract can surface rankings; `bpb` / `paramsM` remain measured secondary
+/// fields. `submissionId` opens the detail modal; era / benches fill via
+/// detail fan-out.
 #[must_use]
 pub fn prism_bpb_leaderboard(subs: &[Value], epoch: u64) -> Vec<LeaderboardRow> {
-    let mut best: HashMap<String, (f64, Option<u64>, String)> = HashMap::new();
+    // (score, bpb, n_params, submission_id) — higher score wins per hotkey.
+    let mut best: HashMap<String, (u64, Option<f64>, Option<u64>, String)> = HashMap::new();
     let mut counts: HashMap<String, u32> = HashMap::new();
     for row in subs {
         if row.get("status").and_then(Value::as_str) != Some("terminated") {
@@ -662,9 +664,17 @@ pub fn prism_bpb_leaderboard(subs: &[Value], epoch: u64) -> Vec<LeaderboardRow> 
         if !is_prism_champion_submission(row) {
             continue;
         }
-        let Some(bpb) = row.get("bpb").and_then(Value::as_f64) else {
+        let Some(score) = row
+            .get("score")
+            .and_then(|s| s.get("value"))
+            .and_then(Value::as_u64)
+        else {
             continue;
         };
+        if score == 0 {
+            continue;
+        }
+        let bpb = row.get("bpb").and_then(Value::as_f64);
         let n_params = row.get("n_params").and_then(Value::as_u64);
         let id = row
             .get("id")
@@ -678,36 +688,38 @@ pub fn prism_bpb_leaderboard(subs: &[Value], epoch: u64) -> Vec<LeaderboardRow> 
             .to_owned();
         *counts.entry(hk.clone()).or_insert(0) += 1;
         best.entry(hk)
-            .and_modify(|(b, p, sid)| {
-                if bpb < *b {
+            .and_modify(|(s, b, p, sid)| {
+                if score > *s {
+                    *s = score;
                     *b = bpb;
                     *p = n_params;
                     sid.clone_from(&id);
                 }
             })
-            .or_insert((bpb, n_params, id));
+            .or_insert((score, bpb, n_params, id));
     }
-    let mut rows: Vec<(f64, String, u32, Option<u64>, String)> = best
+    let mut rows: Vec<_> = best
         .into_iter()
-        .map(|(hk, (bpb, n_params, sid))| {
+        .map(|(hk, (score, bpb, n_params, sid))| {
             let n = counts.get(&hk).copied().unwrap_or(1);
-            (bpb, hk, n, n_params, sid)
+            (score, bpb, hk, n, n_params, sid)
         })
         .collect();
-    rows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    // Higher lattice score first; ties break by lexicographically smaller id.
+    rows.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.5.cmp(&b.5)));
     rows.into_iter()
         .enumerate()
         .map(
-            |(i, (bpb, hk, submissions, n_params, sid))| LeaderboardRow {
+            |(i, (score, bpb, hk, submissions, n_params, sid))| LeaderboardRow {
                 rank: u32::try_from(i + 1).unwrap_or(u32::MAX),
                 agent: agent_from_hotkey(&hk, epoch),
-                elo: bpb,
+                elo: score as f64,
                 wins: 0,
                 losses: 0,
                 win_rate: 0.0,
                 submissions,
                 delta7d: 0.0,
-                bpb: Some(bpb),
+                bpb,
                 params_m: n_params.map(|p| p as f64 / 1e6),
                 weight: None,
                 tao_per_day: None,
@@ -1460,8 +1472,10 @@ mod tests {
         ];
         let rows = prism_bpb_leaderboard(&subs, 3);
         assert_eq!(rows.len(), 2);
-        assert!((rows[0].bpb.unwrap() - 1.0).abs() < f64::EPSILON);
+        // Higher lattice score first (bb=200), not lower bpb.
         assert_eq!(rows[0].submission_id.as_deref(), Some("b"));
+        assert!((rows[0].elo - 200.0).abs() < f64::EPSILON);
+        assert!((rows[0].bpb.unwrap() - 1.0).abs() < f64::EPSILON);
         assert!(rows[0].params_m.is_none());
         assert!((rows[1].params_m.unwrap() - 12.0).abs() < f64::EPSILON);
         assert_eq!(rows[1].submission_id.as_deref(), Some("a"));
@@ -1563,19 +1577,22 @@ mod tests {
     }
 
     #[test]
-    fn prism_bpb_leaderboard_ranks_lower_first() {
+    fn prism_score_leaderboard_ranks_higher_first() {
         let subs = vec![
             json!({"id":"a","status":"terminated","bpb":2.0,"miner_hotkey":"aa","score":{"kind":"score","value":10}}),
             json!({"id":"b","status":"terminated","bpb":1.0,"miner_hotkey":"bb","score":{"kind":"score","value":20}}),
             json!({"id":"c","status":"queued","bpb":0.1,"miner_hotkey":"cc","score":{"kind":"score","value":30}}),
+            // Same hotkey as aa — higher score should win the slot.
             json!({"id":"d","status":"terminated","bpb":0.5,"miner_hotkey":"aa","score":{"kind":"score","value":40}}),
         ];
         let rows = prism_bpb_leaderboard(&subs, 3);
         assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].submission_id.as_deref(), Some("d"));
+        assert!((rows[0].elo - 40.0).abs() < f64::EPSILON);
+        assert_eq!(rows[1].submission_id.as_deref(), Some("b"));
+        assert!((rows[1].elo - 20.0).abs() < f64::EPSILON);
         assert_eq!(rows[0].rank, 1);
-        assert!((rows[0].elo - 0.5).abs() < f64::EPSILON);
         assert_eq!(rows[0].submissions, 2);
-        assert!((rows[1].elo - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -222,8 +222,9 @@ lands in, not the leaf format or the math).** Per emitted epoch set:
   the epoch projects all-zero (burn / hold) — never emit Prism share to 1.x.
 
 **Top-model publish + secure receive.** The master tracks the global best
-bpb across **weight-eligible** (recipe 2.0 / AutoModel) scored submissions.
-After a successful Lium eval it
+**lattice score** (G2 equal-weight accuracies under `scoring_version` 4 —
+never min-bpb alone) across **weight-eligible** (recipe 2.0 / AutoModel)
+scored submissions. After a successful Lium eval it
 **pulls** `checkpoint.pt` from the pod over SSH (master-initiated; the pod
 never pushes) and stages it through the secure receive hook into
 `$PRISM_ARTIFACT_DIR/<submission_id>/` **before** terminate. Staging
@@ -251,7 +252,8 @@ check is tighter when measured params are known. Oversized payloads are
 refused **before** writing.
 
 Top-model publish calls `verify_parked` and refuses weights without a
-valid receipt. On a new global best (≤ best ever and < last published), it
+valid receipt. On a new global-best lattice score (≥ best ever and >
+last published score), it
 publishes `architecture.py` + `training.py` + `METRICS.json` +
 `ARTIFACT.json` + a `README.md` block to the public
 [`BaseIntelligence/prism`](https://github.com/BaseIntelligence/prism) repo

--- a/docs/external-miner/prism.md
+++ b/docs/external-miner/prism.md
@@ -225,8 +225,8 @@ set emitted at the first chain-epoch boundary **after** your run finalizes (a
 long train that crosses epochs is normal — outbox assignment is exactly once).
 Positive scores then keep participating in later epochs' competition sets until
 a better valid score supersedes them (WTA still collapses to one leaf winner).
-The global-best model (sources + `ARTIFACT.json` / checkpoint release) is
-published to
+The global-best model by **G2 lattice score** (sources + `ARTIFACT.json` /
+checkpoint release) is published to
 [`BaseIntelligence/prism`](https://github.com/BaseIntelligence/prism)
 `top-model/` and (when configured) a HuggingFace model repo
 `BaseIntelligence/top-prism-architecture` (custom-arch / AutoModel novelty +


### PR DESCRIPTION
## Summary
- Top-model / HF auto-publish now selects the champion by **lattice score** (G2 equal-weight accuracies under `scoring_version` 4), never min-bpb alone — matching live board ranking.
- Public Prism site leaderboard ranks by the same lattice score (desc) instead of lowest BPB.
- Adds `prism-challenge republish-topmodel <id>` for operator force-republish (live board #1 `c9334611…` → `BaseIntelligence/top-prism-architecture` with weights).

## Test plan
- [x] Unit tests / clippy for prism-registry, prism-store, site-data, site-api
- [ ] CI green
- [ ] Force-republish `c9334611…` on prod → Hub shows that submission + `checkpoint.pt`
- [ ] After promote (resume-first): auto-publish only on a higher lattice score

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an administrative command to republish an eligible top model.
  * Added support for manually publishing a validated model when automatic thresholds are bypassed.

* **Changes**
  * Top-model selection and publication now use G2 lattice score as the primary metric.
  * Leaderboards prioritize lattice score while retaining BPB and parameter details.
  * Publication records now include the lattice score.

* **Documentation**
  * Updated publication and leaderboard guidance to reflect score-based champion selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->