### PR TITLE
fix(deploy): pin prod Prism to public Lium template v9

### DIFF
--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -59,6 +59,8 @@ services:
       # G1–G8 battery (two-phase train/eval). Default harness is v3; pin here
       # so pods never silently fall back to BPB-only even on older images.
       PRISM_FLOW: "v3"
+      # Public v9 boots B200/5090; avoids private DO template create without cred.
+      PRISM_POD_TEMPLATE_ID: "f2f5e84c-3b09-4090-be83-1913eabd009e"
       # Full public pack (not tiny caps). Host path staged by
       # deploy/scripts/prism-overnight-battery.sh / build_private_pack.
       PRISM_EVAL_ASSETS_DIR: "/var/lib/prism/eval-assets"


### PR DESCRIPTION
## Summary
- Persist `PRISM_POD_TEMPLATE_ID=f2f5e84c-…` (public `prism-recipe-v9`) in prod compose so the next digest deploy does not wipe the live hotfix.

## Test plan
- [x] Already set on prod master; prism-challenge healthy
- [ ] Next `remote-deploy.sh --env prod --role master --build-from registry` keeps the pin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration to use the designated public pod template.
  * Avoids requiring private template creation credentials during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->