### PR TITLE
fix(prism): rent-permission fallback + public CUDA 13 pin

### DIFF
--- a/crates/prism-lium-harness/src/lib.rs
+++ b/crates/prism-lium-harness/src/lib.rs
@@ -30,10 +30,15 @@ pub const RECIPES_TEMPLATE_NAME: &str = "prism-recipe-v10-digest-fe1197b26e30-ta
 /// must ship under a new name or pods would keep the old template).
 pub const RECIPES_TEMPLATE_NAME_V10: &str = "prism-recipe-v10";
 /// Public Lium templates that already boot B200/5090 (daturaai/pytorch).
-/// Used when the private DO pin cannot be created (no docker credential).
-pub const PUBLIC_TEMPLATE_FALLBACK_NAMES: &[&str] = &["prism-recipe-v10", "prism-recipe-v9"];
-/// Known-good public template id prefix (`prism-recipe-v9` / daturaai).
-pub const PUBLIC_TEMPLATE_FALLBACK_ID_PREFIXES: &[&str] = &["f2f5e84c"];
+/// Private `prism-recipe-v9` (`f2f5e84c…`) is **not** rentable by miner BYOK.
+pub const PUBLIC_TEMPLATE_FALLBACK_NAMES: &[&str] = &[
+    "prism-recipe-v9-public",
+    "prism-recipe-v10",
+    "prism-recipe-v9",
+    "Pytorch (Cuda + DinD)",
+];
+/// Official / account-owned **public** ids (CUDA 13 DIND, then CUDA 12.8).
+pub const PUBLIC_TEMPLATE_FALLBACK_ID_PREFIXES: &[&str] = &["345273fa", "5982b998", "e03e4d64"];
 /// Lium replaces `USER_PUBLIC_KEY` before launching this command. The image
 /// deliberately uses `CMD` so this bootstrap can install the rental key,
 /// signal readiness, and keep sshd as the container's foreground process.
@@ -185,16 +190,34 @@ pub fn reuse_public_template_if_uncreatable(
     }
 }
 
-/// First allowlisted public template already present on the Lium account.
+/// `false` only when Lium marks the template private (other accounts 400).
+#[must_use]
+pub fn template_is_rentable(tmpl: &serde_json::Value) -> bool {
+    tmpl.get("is_private") != Some(&serde_json::Value::Bool(true))
+        && tmpl
+            .get("id")
+            .and_then(|x| x.as_str())
+            .is_some_and(|id| !id.is_empty())
+}
+
+/// Rent 400: this API key cannot use the pinned template (typical miner BYOK).
+#[must_use]
+pub fn is_template_rent_forbidden(err: &str) -> bool {
+    let err = err.to_ascii_lowercase();
+    err.contains("permission to rent this template")
+        || (err.contains("permission") && err.contains("rent") && err.contains("template"))
+}
+
+/// First allowlisted **non-private** template already present on Lium.
 #[must_use]
 pub fn public_template_fallback_id(templates: &[serde_json::Value]) -> Option<(String, String)> {
     let named = |want: &str| {
         templates.iter().find_map(|tmpl| {
+            if !template_is_rentable(tmpl) {
+                return None;
+            }
             let name = tmpl.get("name").and_then(|x| x.as_str())?;
-            let id = tmpl
-                .get("id")
-                .and_then(|x| x.as_str())
-                .filter(|s| !s.is_empty())?;
+            let id = tmpl.get("id").and_then(|x| x.as_str())?;
             (name == want).then(|| (want.to_owned(), id.to_owned()))
         })
     };
@@ -203,16 +226,40 @@ pub fn public_template_fallback_id(templates: &[serde_json::Value]) -> Option<(S
         .find_map(|name| named(name))
         .or_else(|| {
             templates.iter().find_map(|tmpl| {
-                let id = tmpl
-                    .get("id")
-                    .and_then(|x| x.as_str())
-                    .filter(|s| !s.is_empty())?;
+                if !template_is_rentable(tmpl) {
+                    return None;
+                }
+                let id = tmpl.get("id").and_then(|x| x.as_str())?;
                 PUBLIC_TEMPLATE_FALLBACK_ID_PREFIXES
                     .iter()
                     .any(|prefix| id.starts_with(prefix))
                     .then(|| (id.to_owned(), id.to_owned()))
             })
         })
+}
+
+/// Rentable template after a permission 400 (`skip` = the id that just failed).
+#[must_use]
+pub fn rentable_fallback_template_id(
+    templates: &[serde_json::Value],
+    skip: Option<&str>,
+) -> Option<String> {
+    if let Some((_, id)) = public_template_fallback_id(templates) {
+        if skip != Some(id.as_str()) {
+            return Some(id);
+        }
+    }
+    templates.iter().find_map(|tmpl| {
+        if !template_is_rentable(tmpl) {
+            return None;
+        }
+        let id = tmpl.get("id").and_then(|x| x.as_str())?;
+        if skip == Some(id) {
+            return None;
+        }
+        (tmpl.get("docker_image").and_then(|x| x.as_str()) == Some("daturaai/pytorch"))
+            .then(|| id.to_owned())
+    })
 }
 
 fn template_name_for_image(image: &str) -> String {
@@ -411,9 +458,9 @@ pub fn random_seed_hex() -> Result<String, LiumError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        credential_scoped_template_name, is_digest_image_ref, lium_template_create_body,
-        private_registry_needs_credential, public_template_fallback_id, template_name_for_image,
-        RECIPES_TEMPLATE_STARTUP,
+        credential_scoped_template_name, is_digest_image_ref, is_template_rent_forbidden,
+        lium_template_create_body, private_registry_needs_credential, public_template_fallback_id,
+        rentable_fallback_template_id, template_name_for_image, RECIPES_TEMPLATE_STARTUP,
     };
 
     #[test]
@@ -463,12 +510,25 @@ mod tests {
         ));
         let listed = serde_json::json!([
             {"name": "prism-recipe-v10-digest-fe1197b26e30-tagged", "id": ""},
-            {"name": "prism-recipe-v9", "id": "f2f5e84c-public-v9"}
+            {"name": "prism-recipe-v9", "id": "f2f5e84c-owned-private", "is_private": true},
+            {"name": "Pytorch (Cuda + DinD)", "id": "345273fa-official", "is_private": false,
+             "docker_image": "daturaai/pytorch"}
         ]);
         assert_eq!(
             public_template_fallback_id(listed.as_array().unwrap()),
-            Some(("prism-recipe-v9".into(), "f2f5e84c-public-v9".into()))
+            Some(("Pytorch (Cuda + DinD)".into(), "345273fa-official".into()))
         );
+        assert_eq!(
+            rentable_fallback_template_id(
+                listed.as_array().unwrap(),
+                Some("f2f5e84c-owned-private")
+            ),
+            Some("345273fa-official".into())
+        );
+        assert!(is_template_rent_forbidden(
+            "POST /executors/x/rent -> 400 Bad Request: permission to rent this template"
+        ));
+        assert!(!is_template_rent_forbidden("POST /executors/x/rent -> 429"));
         let err = lium_template_create_body(
             "private",
             "registry.digitalocean.com/basecrawl/prism-pod@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/crates/prism-lium-types/src/json.rs
+++ b/crates/prism-lium-types/src/json.rs
@@ -1,0 +1,82 @@
+//! Lium JSON field helpers (kept here for the `prism-lium` LOC cap).
+
+use serde_json::Value;
+
+use crate::{Instance, Offer};
+
+/// First string value found at any of `keys` (top-level object lookups).
+#[must_use]
+pub fn get_str<'a>(v: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|k| v.get(k).and_then(|x| x.as_str()))
+}
+
+/// First array found at any of `keys` (bare arrays pass through at call sites).
+#[must_use]
+pub fn get_array(v: &Value, keys: &[&str]) -> Vec<Value> {
+    keys.iter()
+        .find_map(|k| v.get(k).and_then(|x| x.as_array()))
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Parse one `/executors` row.
+#[must_use]
+pub fn parse_one_offer(item: &Value) -> Option<Offer> {
+    let id = get_str(item, &["id", "executor_id"])?.to_owned();
+    let gpu_type = get_str(item, &["gpu_type", "gpu_name", "machine_name"])
+        .or_else(|| item.pointer("/machine/gpu_type").and_then(|x| x.as_str()))
+        .unwrap_or("UNKNOWN")
+        .to_owned();
+    let raw_count = item
+        .get("gpu_count")
+        .and_then(|x| x.as_u64())
+        .or_else(|| item.get("available_gpu_count").and_then(|x| x.as_u64()))
+        .or_else(|| item.get("gpus").and_then(|x| x.as_u64()))
+        .unwrap_or(1) as u32;
+    let gpu_count = crate::effective_gpu_count(raw_count, &gpu_type);
+    let price = item
+        .get("price_per_hour")
+        .or_else(|| item.get("price_per_gpu"))
+        .or_else(|| item.get("price"))
+        .or_else(|| item.pointer("/price/per_gpu_hour"))
+        .and_then(|x| x.as_f64())
+        .or_else(|| {
+            get_str(item, &["price_per_hour", "price_per_gpu"]).and_then(|s| s.parse().ok())
+        })
+        .unwrap_or(f64::MAX);
+    Some(Offer {
+        id,
+        gpu_type,
+        gpu_count,
+        price_per_hour: price,
+        provider: "lium".into(),
+    })
+}
+
+/// Parse a `/pods/{id}` object.
+#[must_use]
+pub fn parse_instance(v: &Value, fallback_id: &str) -> Instance {
+    Instance {
+        id: get_str(v, &["id", "pod_id"])
+            .unwrap_or(fallback_id)
+            .to_owned(),
+        status: get_str(v, &["status", "state"])
+            .unwrap_or("UNKNOWN")
+            .to_owned(),
+        provider: "lium".into(),
+        gpu_type: get_str(v, &["gpu_type"])
+            .or_else(|| v.pointer("/executor/gpu_type").and_then(|x| x.as_str()))
+            .map(str::to_owned),
+        ssh_connect_cmd: get_str(v, &["ssh_connect_cmd"]).map(str::to_owned),
+    }
+}
+
+/// Pod id from a rent response.
+#[must_use]
+pub fn extract_pod_id(v: &Value) -> Option<String> {
+    v.get("id")
+        .or_else(|| v.get("pod_id"))
+        .or_else(|| v.pointer("/pod/id"))
+        .and_then(|x| x.as_str())
+        .map(str::to_owned)
+}

--- a/crates/prism-lium-types/src/lib.rs
+++ b/crates/prism-lium-types/src/lib.rs
@@ -14,12 +14,15 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
 #![allow(clippy::doc_markdown)]
+#![allow(clippy::redundant_closure_for_method_calls)]
 
 mod error;
+mod json;
 mod receipt;
 mod types;
 
 pub use error::{CostGuardrailError, LiumError};
+pub use json::{extract_pod_id, get_array, get_str, parse_instance, parse_one_offer};
 pub use receipt::{EvalReceipt, NoScoreGate};
 pub use types::{
     effective_gpu_count, gpu_count_from_label, parse_pod_gpu_count, parse_pod_gpu_name,

--- a/crates/prism-lium/src/client.rs
+++ b/crates/prism-lium/src/client.rs
@@ -16,14 +16,14 @@ use crate::ssh::{
 use crate::{EvalJobBackend, HARNESS_LOG_RETAIN_BYTES, LIUM_API_BASE_URL, MIN_LIFETIME_HOURS};
 use prism_lium_harness::{
     classify_log, detach_launch_cmd, eval_assets_dir, harness_env_pairs, harness_upload_tar,
-    listed_template_id, lium_template_create_body, parse_harness_probe, parse_metrics_output,
-    random_seed_hex, resolved_pod_image, HarnessProgress, EVAL_ASSETS_POD_DIR, HARNESS_ABSENT,
-    HARNESS_BOOTSTRAP, HARNESS_EXTRACT_CMD, HARNESS_HARVEST_CMD, HARNESS_PROBE_CMD,
-    RECIPES_TEMPLATE_STARTUP, TRAIN_DONE_MARKER,
+    is_template_rent_forbidden, listed_template_id, lium_template_create_body, parse_harness_probe,
+    parse_metrics_output, random_seed_hex, rentable_fallback_template_id, resolved_pod_image,
+    HarnessProgress, EVAL_ASSETS_POD_DIR, HARNESS_ABSENT, HARNESS_BOOTSTRAP, HARNESS_EXTRACT_CMD,
+    HARNESS_HARVEST_CMD, HARNESS_PROBE_CMD, RECIPES_TEMPLATE_STARTUP, TRAIN_DONE_MARKER,
 };
 use prism_lium_types::{
-    CostGuardrailError, GpuPreference, Instance, InstanceSpec, LiumError, LiumSshConfig, Offer,
-    RemoteExecResult,
+    extract_pod_id, get_array, get_str, parse_instance, parse_one_offer, CostGuardrailError,
+    GpuPreference, Instance, InstanceSpec, LiumError, LiumSshConfig, Offer, RemoteExecResult,
 };
 
 const RUNNING_STATUSES: &[&str] = &["RUNNING", "RUNNING_SSH", "READY"];
@@ -288,7 +288,6 @@ impl LiumClient {
                 return Ok(id.clone());
             }
         }
-        // Explicit public id (v9 f2f5e84c) skips private-template create.
         if let Ok(id) = std::env::var("PRISM_POD_TEMPLATE_ID") {
             let id = id.trim();
             if !id.is_empty() {
@@ -312,6 +311,18 @@ impl LiumClient {
             docker_credential_id.as_deref(),
         )
         .await
+    }
+
+    async fn fallback_rentable_template(&self, forbidden: &str) -> Option<String> {
+        let v = self
+            .request(reqwest::Method::GET, "/templates", None)
+            .await
+            .ok()?;
+        let t = v
+            .as_array()
+            .cloned()
+            .unwrap_or_else(|| get_array(&v, &["templates"]));
+        rentable_fallback_template_id(&t, Some(forbidden))
     }
 
     /// Account balance (USD) when available.
@@ -698,70 +709,6 @@ impl LiumClient {
     }
 }
 
-/// First string value found at any of `keys` (top-level object lookups).
-fn get_str<'a>(v: &'a Value, keys: &[&str]) -> Option<&'a str> {
-    keys.iter().find_map(|k| v.get(k).and_then(|x| x.as_str()))
-}
-
-/// First array found at any of `keys` (bare arrays pass through at call sites).
-fn get_array(v: &Value, keys: &[&str]) -> Vec<Value> {
-    keys.iter()
-        .find_map(|k| v.get(k).and_then(|x| x.as_array()))
-        .cloned()
-        .unwrap_or_default()
-}
-
-fn parse_one_offer(item: &Value) -> Option<Offer> {
-    let id = get_str(item, &["id", "executor_id"])?.to_owned();
-    // Live API uses machine_name + price_per_gpu (not gpu_type / price_per_hour).
-    let gpu_type = get_str(item, &["gpu_type", "gpu_name", "machine_name"])
-        .or_else(|| item.pointer("/machine/gpu_type").and_then(|x| x.as_str()))
-        .unwrap_or("UNKNOWN")
-        .to_owned();
-    let raw_count = item
-        .get("gpu_count")
-        .and_then(|x| x.as_u64())
-        .or_else(|| item.get("available_gpu_count").and_then(|x| x.as_u64()))
-        .or_else(|| item.get("gpus").and_then(|x| x.as_u64()))
-        .unwrap_or(1) as u32;
-    // Prefer the higher of the numeric field and any `8x` / `x8` label so a
-    // lying `gpu_count: 1` on a multi-GPU host cannot pass the single-GPU filter.
-    let gpu_count = prism_lium_types::effective_gpu_count(raw_count, &gpu_type);
-    let price = item
-        .get("price_per_hour")
-        .or_else(|| item.get("price_per_gpu"))
-        .or_else(|| item.get("price"))
-        .or_else(|| item.pointer("/price/per_gpu_hour"))
-        .and_then(|x| x.as_f64())
-        .or_else(|| {
-            get_str(item, &["price_per_hour", "price_per_gpu"]).and_then(|s| s.parse().ok())
-        })
-        .unwrap_or(f64::MAX);
-    Some(Offer {
-        id,
-        gpu_type,
-        gpu_count,
-        price_per_hour: price,
-        provider: "lium".into(),
-    })
-}
-
-fn parse_instance(v: &Value, fallback_id: &str) -> Instance {
-    Instance {
-        id: get_str(v, &["id", "pod_id"])
-            .unwrap_or(fallback_id)
-            .to_owned(),
-        status: get_str(v, &["status", "state"])
-            .unwrap_or("UNKNOWN")
-            .to_owned(),
-        provider: "lium".into(),
-        gpu_type: get_str(v, &["gpu_type"])
-            .or_else(|| v.pointer("/executor/gpu_type").and_then(|x| x.as_str()))
-            .map(str::to_owned),
-        ssh_connect_cmd: get_str(v, &["ssh_connect_cmd"]).map(str::to_owned),
-    }
-}
-
 fn sanitize_err(msg: &str, key: &str) -> String {
     if key.is_empty() {
         msg.to_owned()
@@ -776,14 +723,6 @@ fn truncate(s: &str, n: usize) -> String {
     } else {
         format!("{}…", &s[..n])
     }
-}
-
-fn extract_pod_id(v: &Value) -> Option<String> {
-    v.get("id")
-        .or_else(|| v.get("pod_id"))
-        .or_else(|| v.pointer("/pod/id"))
-        .and_then(|x| x.as_str())
-        .map(str::to_owned)
 }
 
 #[async_trait]
@@ -840,10 +779,11 @@ impl EvalJobBackend for LiumClient {
         }
 
         let lifetime = spec.max_lifetime_hours.ceil() as u64;
-        let template_id = self.resolve_template_id(spec).await?;
+        let mut template_id = self.resolve_template_id(spec).await?;
+        let mut swapped_forbidden_template = false;
 
         let mut last_err = String::from("no offer tried");
-        for selected in &candidates {
+        'offers: for selected in &candidates {
             if selected.price_per_hour > spec.max_price_per_hour {
                 continue;
             }
@@ -860,70 +800,85 @@ impl EvalJobBackend for LiumClient {
                     "abort: refusing {rent_gpu_count}× 5090 rent (no 8×5090 fallback)"
                 )));
             }
-            info!(
-                offer_id = %selected.id,
-                gpu = %selected.gpu_type,
-                gpu_count = effective,
-                rent_gpu_count,
-                price = selected.price_per_hour,
-                %template_id,
-                "lium rent"
-            );
-            let body = serde_json::json!({
-                "pod_name": spec.name,
-                "user_public_key": spec.ssh_public_keys,
-                "termination_hours": lifetime.max(1),
-                "gpu_count": rent_gpu_count,
-                "template_id": template_id,
-            });
-            // Fire rent immediately — BYOK keys must not share a process-wide
-            // queue with each other or with an operator fallback key.
-            let rented = self
-                .request(
-                    reqwest::Method::POST,
-                    &format!("/executors/{}/rent", selected.id),
-                    Some(&body),
-                )
-                .await;
-            match rented {
-                Ok(v) => {
-                    let id = match extract_pod_id(&v) {
-                        Some(id) => Some(id),
-                        None => self.find_pod_id_by_name(&spec.name).await,
-                    };
-                    let Some(id) = id else {
-                        last_err = "could not determine provisioned pod id from rent".into();
+            loop {
+                info!(
+                    offer_id = %selected.id,
+                    gpu = %selected.gpu_type,
+                    gpu_count = effective,
+                    rent_gpu_count,
+                    price = selected.price_per_hour,
+                    %template_id,
+                    "lium rent"
+                );
+                let body = serde_json::json!({
+                    "pod_name": spec.name,
+                    "user_public_key": spec.ssh_public_keys,
+                    "termination_hours": lifetime.max(1),
+                    "gpu_count": rent_gpu_count,
+                    "template_id": template_id,
+                });
+                // Fire rent immediately — BYOK keys must not share a process-wide
+                // queue with each other or with an operator fallback key.
+                let rented = self
+                    .request(
+                        reqwest::Method::POST,
+                        &format!("/executors/{}/rent", selected.id),
+                        Some(&body),
+                    )
+                    .await;
+                match rented {
+                    Ok(v) => {
+                        let id = match extract_pod_id(&v) {
+                            Some(id) => Some(id),
+                            None => self.find_pod_id_by_name(&spec.name).await,
+                        };
+                        let Some(id) = id else {
+                            last_err = "could not determine provisioned pod id from rent".into();
+                            self.reclaim_pods_named(&spec.name).await;
+                            continue 'offers;
+                        };
+                        match self.wait_until_running(&id).await {
+                            Ok(inst) => {
+                                let labeled = inst.gpu_type.as_deref().unwrap_or("");
+                                if !labeled.is_empty() && !pref.matches_pin(labeled) {
+                                    warn!(pod_id = %id, gpu = %labeled, "non-pin GPU after rent");
+                                    let _ = self.terminate(&id).await;
+                                    last_err = format!("non-pin GPU after rent: {labeled}");
+                                    continue 'offers;
+                                }
+                                return Ok(inst);
+                            }
+                            Err(e) => {
+                                last_err = format!("offer {} wait_running: {e}", selected.id);
+                                self.cleanup_after_rent(&id).await;
+                                self.reclaim_pods_named(&spec.name).await;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        last_err = e.to_string();
+                        // 429/transport can still leave a PENDING pod under our name.
                         self.reclaim_pods_named(&spec.name).await;
-                        continue;
-                    };
-                    match self.wait_until_running(&id).await {
-                        Ok(inst) => {
-                            let labeled = inst.gpu_type.as_deref().unwrap_or("");
-                            if !labeled.is_empty() && !pref.matches_pin(labeled) {
-                                warn!(pod_id = %id, gpu = %labeled, "non-pin GPU after rent");
-                                let _ = self.terminate(&id).await;
-                                last_err = format!("non-pin GPU after rent: {labeled}");
+                        // A rent 429 consumed one call on *this* API key's budget.
+                        // Return after orphan cleanup — do not walk more offers.
+                        if lium_rent_pool::is_rate_limited(&last_err) {
+                            return Err(LiumError::Api(last_err));
+                        }
+                        if !swapped_forbidden_template && is_template_rent_forbidden(&last_err) {
+                            if let Some(alt) = self.fallback_rentable_template(&template_id).await {
+                                warn!(
+                                    from = %template_id,
+                                    to = %alt,
+                                    "lium template not rentable; retrying"
+                                );
+                                template_id = alt;
+                                swapped_forbidden_template = true;
                                 continue;
                             }
-                            return Ok(inst);
-                        }
-                        Err(e) => {
-                            last_err = format!("offer {} wait_running: {e}", selected.id);
-                            self.cleanup_after_rent(&id).await;
-                            self.reclaim_pods_named(&spec.name).await;
                         }
                     }
                 }
-                Err(e) => {
-                    last_err = e.to_string();
-                    // 429/transport can still leave a PENDING pod under our name.
-                    self.reclaim_pods_named(&spec.name).await;
-                    // A rent 429 consumed one call on *this* API key's budget.
-                    // Return after orphan cleanup — do not walk more offers.
-                    if lium_rent_pool::is_rate_limited(&last_err) {
-                        return Err(LiumError::Api(last_err));
-                    }
-                }
+                break;
             }
         }
         self.reclaim_pods_named(&spec.name).await;
@@ -1255,6 +1210,50 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(id, "f2f5e84c-public-v9");
+    }
+
+    #[tokio::test]
+    async fn provision_retries_on_template_rent_forbidden() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/templates"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"name": "prism-recipe-v9", "id": "f2f5e84c-3b09-4090-be83-1913eabd009e", "is_private": true},
+                {"name": "Pytorch (Cuda + DinD)", "id": "345273fa-4818-46f7-a8fa-32f0e331713c",
+                 "is_private": false, "docker_image": "daturaai/pytorch"}
+            ])))
+            .mount(&server)
+            .await;
+        mount_common(
+            &server,
+            serde_json::json!([{
+                "id": "pin-b200",
+                "gpu_type": "NVIDIA B200",
+                "gpu_count": 1,
+                "price_per_hour": 5.5
+            }]),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path("/executors/pin-b200/rent"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "success": false,
+                "message": "You don't have permission to rent this template."
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        mount_rent_path(&server, "pin-b200", "pod-public").await;
+        Mock::given(method("GET"))
+            .and(path("/pods"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+        let c = LiumClient::with_base_url("test-key", server.uri()).unwrap();
+        let mut spec = provision_spec();
+        spec.template_id = Some("f2f5e84c-3b09-4090-be83-1913eabd009e".into());
+        let inst = c.provision(&spec).await.unwrap();
+        assert_eq!(inst.id, "pod-public");
     }
 
     #[tokio::test]

--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -60,7 +60,9 @@ services:
       # so pods never silently fall back to BPB-only even on older images.
       PRISM_FLOW: "v3"
       # Public v9 boots B200/5090; avoids private DO template create without cred.
-      PRISM_POD_TEMPLATE_ID: "f2f5e84c-3b09-4090-be83-1913eabd009e"
+      # Official public daturaai/pytorch CUDA 13 DIND (miner BYOK can rent).
+      # Do not pin private prism-recipe-v9 f2f5e84c — rent 400s for other accounts.
+      PRISM_POD_TEMPLATE_ID: "345273fa-4818-46f7-a8fa-32f0e331713c"
       # Full public pack (not tiny caps). Host path staged by
       # deploy/scripts/prism-overnight-battery.sh / build_private_pack.
       PRISM_EVAL_ASSETS_DIR: "/var/lib/prism/eval-assets"

--- a/deploy/env/prism-challenge.env.example
+++ b/deploy/env/prism-challenge.env.example
@@ -41,8 +41,8 @@ BASE_NETUID=541
 # PRISM_TOPMODEL_HF_TOKEN_FILE=/run/base/huggingface/token
 # PRISM_TOPMODEL_HF_REPO=BaseIntelligence/top-prism-architecture
 
-# Optional existing public Lium template (v9 boots B200/5090). If unset,
-# provision falls back to public prism-recipe-v9/v10 when present.
-# PRISM_POD_TEMPLATE_ID=f2f5e84c-...
+# Optional existing **public** Lium template. Private v9 (f2f5e84c) 400s for
+# miner BYOK. Official CUDA 13 DIND: 345273fa-4818-46f7-a8fa-32f0e331713c
+# PRISM_POD_TEMPLATE_ID=345273fa-4818-46f7-a8fa-32f0e331713c
 # Required only to *create* a new private DO/GHCR template:
 # PRISM_POD_DOCKER_CREDENTIAL_ID=<lium-docker-credential-id>

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -641,7 +641,7 @@ into the pod where applicable):
 | `PRISM_POD_IMAGE_REF` | optional staged pod image, required form `repository@sha256:<64 lowercase hex>` |
 | `PRISM_POD_IMAGE_TAG` | Lium pull locator (default `v10-cuda13-te`); never accepted without the separate digest pin |
 | `PRISM_POD_DOCKER_CREDENTIAL_ID` | non-secret Lium reference required only when **creating** a new private DigitalOcean registry template. Unset is fine when `PRISM_POD_TEMPLATE_ID` is set or public `prism-recipe-v9`/`v10` already exists on Lium |
-| `PRISM_POD_TEMPLATE_ID` | optional existing Lium template id (public v9 `f2f5e84c…` is the known-good B200/5090 boot path) |
+| `PRISM_POD_TEMPLATE_ID` | optional **public** Lium template id. Prod pin is official `daturaai/pytorch` CUDA 13 DIND `345273fa…`. Private v9 `f2f5e84c…` 400s for miner BYOK; provision retries a rentable public template |
 
 **Anchor set v1 battery keys** (emitted by the harness on every real run;
 inert under v0 since unknown `org.*` keys are ignored):

--- a/docs/runbooks/prism-enable-lium-and-emission.md
+++ b/docs/runbooks/prism-enable-lium-and-emission.md
@@ -91,8 +91,9 @@ PRISM_POD_DOCKER_CREDENTIAL_ID=<lium-docker-credential-id>
 The credential ID is a non-secret reference; the registry username/password
 remain stored in Lium. It is needed **only** to create a new private provider
 template (digest- and credential-scoped). If it is unset, provision reuses
-`PRISM_POD_TEMPLATE_ID` or an existing public `prism-recipe-v9` / `v10`
-template instead of failing every miner submit. To pin private images later,
+`PRISM_POD_TEMPLATE_ID` (prod: official public `345273fa…` CUDA 13 DIND) or
+another **non-private** `prism-recipe-v9-public` / official Pytorch template
+instead of failing every miner submit. Private `f2f5e84c` 400s for BYOK. To pin private images later,
 create the Lium docker credential, set `PRISM_POD_DOCKER_CREDENTIAL_ID` to
 that id, and restart `prism-challenge`. Lium needs the tag as a pull locator,
 but records and checks the digest separately; malformed or missing digest


### PR DESCRIPTION
## Summary
- Miner BYOK Lium keys 400 on private `prism-recipe-v9` (`f2f5e84c…`) with "You don't have permission to rent this template."
- On that 400, provision retries the same offer with an account-rentable **public** template (official `daturaai/pytorch` CUDA 13 DIND `345273fa…`).
- Prod compose pin updated off private v9. Private templates are no longer treated as public just because the name matches.

## Test plan
- [x] `provision_retries_on_template_rent_forbidden` (wiremock 400 → fallback rent 200)
- [x] harness skips `is_private: true` v9 and picks official public pytorch
- [x] loc-cap / clippy on touched crates
- [x] live rent of executor `38a0b321` with `345273fa` returned 200; pod terminated immediately
- [x] prod master env applied: `PRISM_POD_TEMPLATE_ID=345273fa-…`, `/health` 200, no evil-gateway