### PR TITLE
fix(prism): backtick no_capacity in clippy docs

### DIFF
--- a/bins/prism-challenge/src/main.rs
+++ b/bins/prism-challenge/src/main.rs
@@ -782,7 +782,7 @@ fn spawn_orchestrator(
     spawn_rate_limit_recovery(store, gating);
 }
 
-/// Re-queue failed Lium 429 (6h window) and no_capacity / B200 sold-out rows.
+/// Re-queue failed Lium 429 (6h window) and `no_capacity` / B200 sold-out rows.
 async fn recover_rate_limited(
     store: &Arc<dyn PrismStore>,
     gating: Option<&Arc<dyn GatingStore>>,


### PR DESCRIPTION
## Summary
- `clippy::doc_markdown` fails CI on `main` (`no_capacity` in a doc comment).
- Needed so #180 can get a green CI SHA and ship to prod.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (local)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified recovery guidance by identifying `no_capacity` as a Lium failure condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->