### PR TITLE
fix(ci): ignore yanked arrayref required by schnorrkel

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -20,6 +20,7 @@ on:
       - "deploy/scripts/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "deny.toml"
       - ".github/workflows/images.yml"
   workflow_dispatch:
     inputs:

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,8 @@ unmaintained = "workspace"
 ignore = [
     # Transitive via dcap-qvl → dcap-qvl-webpki → rsa; no safe upgrade upstream yet.
     { id = "RUSTSEC-2023-0071", reason = "rsa Marvin Attack is transitive through dcap-qvl 0.6.1 (optional attest-policy/dcap feature); no patched rsa in that graph" },
+    # schnorrkel 0.11.5 requires arrayref ^0.3.7; crates.io yanked 0.3.7–0.3.9.
+    { crate = "arrayref@0.3.9", reason = "all arrayref 0.3.x yanked; schnorrkel 0.11.5 has no other crate" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- `cargo deny` fails on `main` because `arrayref` 0.3.7–0.3.9 are yanked and `schnorrkel 0.11.5` cannot move.
- Ignore `arrayref@0.3.9` and trigger the images pin ladder on `deny.toml` so we can tag prod after #180.

## Test plan
- [ ] CI `cargo-deny` green
- [ ] staging pins `commit_sha` matches this merge
- [ ] tag `v3.3.26` → deploy-prod