### PR TITLE
fix(validator): verify sealed weights from chain.joinbase.ai

### DIFF
--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -20,11 +20,11 @@ services:
       # for 60s and tries the next in order.
       BASE_CHAIN_ENDPOINTS: "wss://bittensor-finney.api.onfinality.io/public-ws,wss://entrypoint-finney.opentensor.ai:443"
       BASE_COORDINATION_INTERVAL_SECS: "10"
-      # Prod master gateway over VPC. Pin here — never rely on the
-      # role-validator.yml default (that IP is the *staging* master; pointing
-      # prod at it makes the validator verify testnet-541 bundles against
-      # mainnet and every tick fails `BlockHashMismatch`).
-      BASE_GATEWAY_ENDPOINT: "http://10.116.0.3:8080"
+      # Public sealed-weights API (same gateway as Caddy). Validators verify
+      # `GET /v1/weights/latest` + `GET /v1/bundle/{epoch}` here — not the
+      # VPC bind. Do not fall back to role-validator.yml (that default is
+      # the staging master VPC IP / netuid 541).
+      BASE_GATEWAY_ENDPOINT: "https://chain.joinbase.ai"
       BT_WALLETS_PATH: /run/base/wallets
       BASE_VALIDATOR_WALLET: base-validator
     volumes:

--- a/deploy/compose/role-validator.yml
+++ b/deploy/compose/role-validator.yml
@@ -1,12 +1,13 @@
 # Validator role — NO gateway, NO owner hotkey, NO challenge execution.
-# Points at the master gateway over the DO VPC private IP.
-# Used with: docker compose -f docker-compose.yml -f deploy/compose/role-validator.yml
+# Points at the master gateway (staging VPC default; env-prod.yml pins
+# https://chain.joinbase.ai). Used with:
+# docker compose -f docker-compose.yml -f deploy/compose/role-validator.yml
 services:
   validator:
     environment:
-      # Default is the STAGING master VPC IP; env-prod.yml pins the prod master
-      # (http://10.116.0.3:8080). Never carry this pin in a shell var or an
-      # uncommitted .env — a bare `docker compose up` silently drops it.
+      # Default is the STAGING master VPC IP. env-prod.yml pins the public
+      # prod API. Never carry a prod pin in a shell var or an uncommitted
+      # .env — a bare `docker compose up` silently drops it.
       BASE_GATEWAY_ENDPOINT: ${BASE_GATEWAY_ENDPOINT:-http://10.116.0.2:8080}
       BASE_COORDINATION_INTERVAL_SECS: "3"
     volumes:

--- a/deploy/scripts/prod-burn-seal.sh
+++ b/deploy/scripts/prod-burn-seal.sh
@@ -13,11 +13,10 @@
 # challenge mini-secrets stay at $BASE_CHALLENGE_SK_FILE / $BASE_DESIGN_SK_FILE
 # (mode 0400).
 #
-# D24 (exact-E): with both challenges at >0 bps (currently 5000/5000), sealing
-# requires a complete leaf set from EVERY >0-bps challenge at the seal epoch.
-# The design pass therefore emits NoScore leaves first; its own seal attempt
-# 409s until the prism pass lands (tolerated), and the prism pass then seals
-# the complete set. All-NoScore still aggregates to the uid-0 burn vector.
+# D24 (exact-E): only challenges with emission_share_bps > 0 must have a
+# complete leaf set. Extra leaves for a 0-bps challenge (design today) are
+# IncompleteParticipantSet. Trust root is prism = 10000 / design = 0, so this
+# script emits prism NoScore only. All-NoScore still aggregates to uid-0 burn.
 set -euo pipefail
 
 BASE_HOME="${BASE_HOME:-/opt/base}"
@@ -44,37 +43,14 @@ if ! flock -n 9; then
 fi
 
 {
-  echo "$(date -Is) seal start gateway=${GATEWAY} netuid=${NETUID}"
-  # Design NoScore leaves (D24 participant). A 409 "incomplete participant
-  # set" on its seal attempt is expected until the prism pass seals.
-  dout="$("${BIN}" --gateway "${GATEWAY}" --burn --netuid "${NETUID}" \
-    --chain-endpoint "${CHAIN}" --challenge-id design --challenge-sk "${DESIGN_SK}" 2>&1 || true)"
-  # grep under `set -euo pipefail`: no-match must not kill the script before
-  # the explicit failure path below can log the design output.
-  echo "${dout}" | grep -E 'submitted|seal ok|latest OK|incomplete' | tail -2 || true
-  if ! echo "${dout}" | grep -qE 'submitted|seal ok'; then
-    echo "$(date -Is) design leaves FAILED (no submission)"
-    echo "${dout}" | tail -5
-    exit 1
-  fi
-  # D24 completeness is per-epoch: the prism pass must emit at the SAME epoch
-  # the design pass used (each run otherwise self-derives a fresh tip and the
-  # sets never intersect). Parse the design epoch and pin both epoch + block_b.
-  depoch="$(printf '%s\n' "${dout}" | sed -n 's/.*epoch=\([0-9][0-9]*\).*/\1/p' | head -1)"
-  if [[ -z "${depoch}" ]]; then
-    echo "$(date -Is) could not parse design epoch from weights-smoke output"
-    exit 1
-  fi
-  echo "pinning prism pass to design epoch=${depoch}"
-  # Prism pass: seals the now-complete D24 set at the pinned epoch.
+  echo "$(date -Is) seal start gateway=${GATEWAY} netuid=${NETUID} challenge=prism"
   if out="$("${BIN}" --gateway "${GATEWAY}" --burn --netuid "${NETUID}" \
-      --chain-endpoint "${CHAIN}" --challenge-sk "${SK}" \
-      --epoch "${depoch}" --block-b "${depoch}" 2>&1)"; then
+      --chain-endpoint "${CHAIN}" --challenge-id prism --challenge-sk "${SK}" 2>&1)"; then
     echo "${out}" | grep -E 'seal ok|latest OK' || echo "${out}" | tail -3
     echo "$(date -Is) seal ok"
   else
     rc=$?
-    echo "${out}" | tail -5
+    echo "${out}" | tail -8
     echo "$(date -Is) seal FAILED rc=${rc}"
     exit "${rc}"
   fi


### PR DESCRIPTION
## Summary
- Prod validator fetches `GET /v1/weights/latest` and `GET /v1/bundle/{epoch}` from `https://chain.joinbase.ai` (same public API miners/clients use).
- Burn-seal is prism-only so 0-bps design leaves no longer 409 D24.

## Test plan
- [x] Recreated prod validator with `BASE_GATEWAY_ENDPOINT=https://chain.joinbase.ai`
- [x] `validator_match` on public seal epoch 8885161 / merkle `b413f777…`