### PR TITLE
fix(weights): seal prism 2.1 WTA winner instead of burn

### DIFF
--- a/crates/bundle/src/seal.rs
+++ b/crates/bundle/src/seal.rs
@@ -55,6 +55,17 @@ pub fn build_sealed_bundle<C: ChainClient + ?Sized>(
 
     let emission_shares = trust.challenges.emission_shares();
     validate_shares_sum(&emission_shares)?;
+    // 0-bps challenges are outside E_c (BUNDLE_SPEC §7.3). Strip leftover
+    // leaves (design at 0 bps still historically emitted) so they cannot
+    // 409 D24 as extras while the paid challenge set is complete.
+    let paid: BTreeSet<Vec<u8>> = trust
+        .challenges
+        .challenges
+        .iter()
+        .filter(|c| c.emission_share_bps > 0)
+        .map(|c| c.id.clone())
+        .collect();
+    leaves.retain(|leaf| paid.contains(&leaf.challenge_id));
     assert_participant_completeness(&trust.challenges, &rows, &leaves)?;
 
     sort_leaves(&mut leaves);
@@ -123,7 +134,16 @@ fn assert_participant_completeness(
             }
         }
     }
+    let zero_bps: BTreeSet<Vec<u8>> = challenges
+        .challenges
+        .iter()
+        .filter(|c| c.emission_share_bps == 0)
+        .map(|c| c.id.clone())
+        .collect();
     for key in &leaf_index {
+        if zero_bps.contains(&key.0) {
+            continue;
+        }
         if !expected_keys.contains(key) {
             return Err(BundleError::IncompleteParticipantSet);
         }

--- a/crates/bundle/src/tests.rs
+++ b/crates/bundle/src/tests.rs
@@ -338,6 +338,69 @@ fn d24_missing_participant_rejected() {
 }
 
 #[test]
+fn d24_zero_bps_extra_leaves_stripped_at_seal() {
+    let prism_sk = sk(1);
+    let design_sk = sk(3);
+    let gsk = sk(2);
+    let prism_id = b"prism";
+    let design_id = b"design";
+    let trust = LocalTrustRoot {
+        challenges: ChallengesBody {
+            challenges: vec![
+                ChallengeEntry {
+                    id: design_id.to_vec(),
+                    public_key: pk_of(&design_sk),
+                    emission_share_bps: 0,
+                    policy: ParticipantPolicy::AllMetagraphHotkeys,
+                },
+                ChallengeEntry {
+                    id: prism_id.to_vec(),
+                    public_key: pk_of(&prism_sk),
+                    emission_share_bps: 10_000,
+                    policy: ParticipantPolicy::AllMetagraphHotkeys,
+                },
+            ],
+        },
+        measurements_digest: measurements_digest(&MeasurementsBody::default()),
+    };
+    let block_b = 90u64;
+    let chain = chain_with(vec![hk(0xA1)], block_b);
+    let leaves = vec![
+        make_signed_leaf(
+            &prism_sk,
+            prism_id,
+            hk(0xA1),
+            7,
+            ScoreOrAbsence::Score { value: 100 },
+        )
+        .unwrap(),
+        make_signed_leaf(
+            &design_sk,
+            design_id,
+            hk(0xA1),
+            7,
+            ScoreOrAbsence::Score { value: 1 },
+        )
+        .unwrap(),
+    ];
+    let bundle = build_sealed_bundle(
+        &chain,
+        &trust,
+        leaves,
+        &SealParams {
+            epoch: 7,
+            netuid: 1,
+            block_b,
+            gateway_secret: gsk,
+        },
+    )
+    .unwrap();
+    assert_eq!(bundle.body.leaves.len(), 1);
+    assert_eq!(bundle.body.leaves[0].challenge_id, prism_id);
+    assert!(bundle.verify(&chain, &trust).is_ok());
+}
+
+#[test]
 fn d24_noscore_covers_participant() {
     let csk = sk(1);
     let gsk = sk(2);

--- a/crates/design-challenge-task/src/emit.rs
+++ b/crates/design-challenge-task/src/emit.rs
@@ -20,6 +20,21 @@ pub struct DesignEmitPlan {
 /// Max epochs to walk back on catch-up (Finney public RPC prunes ~256 blocks).
 const MAX_CATCHUP_EPOCHS: u64 = 16;
 
+/// When true, design must not POST `/v1/weights/raw`. Trust-root `design`
+/// share is 0 bps today; leftover design leaves 409 D24 as extras.
+#[must_use]
+pub fn design_leaf_emit_enabled() -> bool {
+    match std::env::var("DESIGN_SKIP_LEAF_EMIT") {
+        Ok(v) => {
+            let v = v.trim();
+            !(v.eq_ignore_ascii_case("1")
+                || v.eq_ignore_ascii_case("true")
+                || v.eq_ignore_ascii_case("yes"))
+        }
+        Err(_) => true,
+    }
+}
+
 /// Decide whether/which epoch the design filler should emit.
 ///
 /// - **Cold start** (`last_emitted == 0`): emit the **current** epoch immediately.
@@ -125,6 +140,11 @@ mod tests {
         let p = design_emit_plan(100, 24424, 10, 360, 8_816_047).unwrap();
         assert_eq!(p.epoch, 24424 - 16);
         assert_eq!(p.pin_block, 8_816_047 - 16 * 360);
+    }
+
+    #[test]
+    fn leaf_emit_enabled_by_default() {
+        assert!(design_leaf_emit_enabled());
     }
 
     #[test]

--- a/crates/design-challenge-task/src/lib.rs
+++ b/crates/design-challenge-task/src/lib.rs
@@ -13,7 +13,9 @@
 
 mod emit;
 mod score;
-pub use emit::{design_emit_plan, DesignEmitPlan, DESIGN_EMIT_LATE_BLOCKS};
+pub use emit::{
+    design_emit_plan, design_leaf_emit_enabled, DesignEmitPlan, DESIGN_EMIT_LATE_BLOCKS,
+};
 pub use score::{
     not_attempted, round_win_delta, score_window, to_leaf, window_start, ScorePlan, WindowScorePlan,
 };

--- a/crates/design-challenge/src/lib.rs
+++ b/crates/design-challenge/src/lib.rs
@@ -28,10 +28,10 @@ pub use challenge_common::{
 };
 pub use design_challenge_task::{
     agent_run_timeout_secs, awaiting_admin_unscored_expired, daily_run_quota, design_emit_plan,
-    manual_daily_run_quota, prompts_per_round, reject_awaiting_admin_run, round_id_at, round_secs,
-    round_win_delta, rounds_per_day_effective, scheduled_daily_run_cap, scheduled_runs_per_day,
-    score_window, unscored_epochs_elapsed, window_start, DesignEmitPlan, ScorePlan,
-    WindowScorePlan, CHALLENGE_ID, CHALLENGE_ID_BYTES, DESIGN_EMIT_LATE_BLOCKS,
+    design_leaf_emit_enabled, manual_daily_run_quota, prompts_per_round, reject_awaiting_admin_run,
+    round_id_at, round_secs, round_win_delta, rounds_per_day_effective, scheduled_daily_run_cap,
+    scheduled_runs_per_day, score_window, unscored_epochs_elapsed, window_start, DesignEmitPlan,
+    ScorePlan, WindowScorePlan, CHALLENGE_ID, CHALLENGE_ID_BYTES, DESIGN_EMIT_LATE_BLOCKS,
     MANUAL_DAILY_RUN_QUOTA, PROMPTS_PER_ROUND, ROUNDS_PER_DAY, ROUND_SECS, SCORE_MAX,
     SCORING_VERSION, SCORING_WINDOW_ROUNDS, UNSCORED_EPOCH_LIMIT,
 };

--- a/crates/design-challenge/src/orchestrator.rs
+++ b/crates/design-challenge/src/orchestrator.rs
@@ -17,9 +17,9 @@ use challenge_common::{
 };
 use crypto::KEY_LEN;
 use design_challenge_task::{
-    awaiting_admin_unscored_expired, clip_logs, design_emit_plan, not_attempted, now_ms, now_secs,
-    reject_awaiting_admin_run, round_id_at, round_secs, score_window, to_leaf, window_start,
-    WindowScorePlan, MAX_LOG_CHARS, UNSCORED_EPOCH_LIMIT,
+    awaiting_admin_unscored_expired, clip_logs, design_emit_plan, design_leaf_emit_enabled,
+    not_attempted, now_ms, now_secs, reject_awaiting_admin_run, round_id_at, round_secs,
+    score_window, to_leaf, window_start, WindowScorePlan, MAX_LOG_CHARS, UNSCORED_EPOCH_LIMIT,
 };
 use design_http::{enqueue_active_harnesses_for_round, mark_awaiting_admin, AdminAwardHook};
 use design_prompts::{prompt_set_digest, select_prompts_for_round};
@@ -282,6 +282,9 @@ impl<C: ChainClient + Send + Sync + 'static> Orchestrator<C> {
     {
         let state = chain::gather_schedule_state(self.chain.as_ref(), self.cfg.netuid)
             .map_err(|e| format!("schedule: {e}"))?;
+        if !design_leaf_emit_enabled() {
+            return Ok(false);
+        }
         let Some(plan) = design_emit_plan(
             self.emitted_epoch.load(Ordering::Relaxed),
             state.subnet_epoch_index,
@@ -1057,6 +1060,10 @@ impl<C: ChainClient + Send + Sync + 'static> Orchestrator<C> {
     async fn emit_leaves_at(&self, epoch: u64, pin_block: u64) -> Result<(), String> {
         if epoch == 0 {
             return Err("refuse emit for epoch 0".into());
+        }
+        if !design_leaf_emit_enabled() {
+            info!(epoch, "design leaf emit skipped (DESIGN_SKIP_LEAF_EMIT)");
+            return Ok(());
         }
         let block_hash = self
             .chain

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -88,7 +88,9 @@ Full procedure: [`docs/runbooks/local-testnet-e2e.md`](../docs/runbooks/local-te
 
 **Weights seal smoke (default on `--smoke`):** after healthz, `local-e2e.sh` runs `weights-smoke` — signed prism leaves for the live metagraph → `POST /v1/admin/seal` → assert `GET /v1/weights/latest` is **200** with **`sealed: true`**. Skip with `--no-weights-smoke`. Pre-seal, latest is **200 burn** (`sealed: false`, uid 0 = 100%) — never 404; that is unrelated to a missing gateway owner wallet. Prefer `--burn` on mainnet when sealing without real challenge scores (all `NoScore` → uid 0).
 
-**Interim prod burn seal (until prism auto-emits):** keep a fresh sealed bundle on the master gateway so validators can Match + CRV4 submit. On the prod master this runs as a **systemd timer** (`base-burn-seal.timer`, every 21 min — above the 100-block `WeightsSetRateLimit`, inside the ~256-block Finney state-pruning window) driving [`scripts/prod-burn-seal.sh`](scripts/prod-burn-seal.sh); units live in [`systemd/`](systemd/). Install:
+**Interim prod burn seal (retired while prism auto-emits):** `weights-smoke --burn` posts all-`NoScore` at a **block-scale** epoch. That hid the live Prism 2.1 WTA winner (chain epoch ~24k) because `/v1/weights/latest` had no chain-scale bundle to prefer. Keep the script for emergency burn-only windows; **do not** enable `base-burn-seal.timer` when Prism is emitting scores. `remote-deploy` on master enables real-seal and disables the burn timer.
+
+Historical install (burn-only, no live scores):
 
 ```bash
 install -m 0755 target/release/weights-smoke /opt/base/bin/weights-smoke
@@ -106,7 +108,7 @@ cargo run -q --release -p weights-smoke -- \
 
 A seal older than ~256 blocks can never be verified by the validator (public RPC prunes state) — if `GET /v1/weights/latest` shows `metagraph_block` lagging tip by thousands of blocks, check `systemctl status base-burn-seal.timer` and `/var/log/base-burn-seal.log` on the master.
 
-**Real-epoch sealer (post burn-seal retirement):** `base-real-seal.timer` (every **2 min**) drives [`scripts/prod-real-seal.sh`](scripts/prod-real-seal.sh), which walks **current … current−N** chain epochs (`REAL_SEAL_WALK_BACK`, default 16) with `block_b = LastEpochBlock − k×tempo`. Tip reseal is expected: when design/prism tip-supersede leaves mid-epoch, seal rebuilds and appends `epoch_bundle.revision` so `/v1/weights/latest` tracks live scores; identical merkle/vector is a no-op 200. Walk-back still recovers when tip is incomplete D24 (409 continues). The gateway prefers chain-scale bundles over the reserved smoke range (`>= 8_000_000`) — retire the burn timer (`systemctl disable --now base-burn-seal.timer`) after the first real seal verifies end-to-end. Install:
+**Real-epoch sealer (default on master):** `base-real-seal.timer` (every **2 min**) drives [`scripts/prod-real-seal.sh`](scripts/prod-real-seal.sh), which walks **current … current−N** chain epochs (`REAL_SEAL_WALK_BACK`, default 16) with `block_b = LastEpochBlock − k×tempo`. Tip reseal is expected: when prism tip-supersedes leaves mid-epoch, seal rebuilds and appends `epoch_bundle.revision` so `/v1/weights/latest` tracks the WTA winner; identical merkle/vector is a no-op 200. Seal strips 0-bps challenge leftovers (design today) so they cannot 409 D24. The gateway prefers chain-scale bundles over the reserved smoke range (`>= 8_000_000`). Install / `remote-deploy` does this:
 
 ```bash
 install -m 0755 deploy/scripts/prod-real-seal.sh /opt/base/deploy/scripts/prod-real-seal.sh

--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -91,6 +91,9 @@ services:
     environment:
       # Docker-only on prod. Never set BASE_ALLOW_HOST_SIM / DESIGN_FORCE_SIM here.
       DESIGN_FORCE_SIM: "false"
+      # Trust root is design = 0 bps. Extra design leaves 409 D24 and hide
+      # the prism WTA winner. Gate emit until design share is non-zero.
+      DESIGN_SKIP_LEAF_EMIT: "1"
       BASE_CHAIN_ENDPOINTS: "wss://bittensor-finney.api.onfinality.io/public-ws,wss://entrypoint-finney.opentensor.ai:443"
   design-egress-proxy:
     environment:

--- a/deploy/compose/env-staging.yml
+++ b/deploy/compose/env-staging.yml
@@ -84,6 +84,8 @@ services:
       # Staging uses real Docker via socket-proxy. Host SimSandbox is fail-closed
       # here (never set BASE_ALLOW_HOST_SIM / DESIGN_FORCE_SIM on droplets).
       DESIGN_FORCE_SIM: "false"
+      # Same as prod: staging trust root is design = 0 bps.
+      DESIGN_SKIP_LEAF_EMIT: "1"
       # Compressed lifecycle for the staging e2e: ~15-minute rounds (prod
       # defaults stay 8640s / 1800s when these are unset).
       DESIGN_ROUND_SECS: "900"

--- a/deploy/scripts/remote-deploy.sh
+++ b/deploy/scripts/remote-deploy.sh
@@ -586,6 +586,17 @@ PY
     exit 1
   fi
   echo "challenge proxy health: ok"
+  # Prism WTA is the live seal path. Burn-seal posts NoScore at a block-scale
+  # epoch and hid the 2.1 winner until a real chain-epoch seal existed.
+  if [[ -f /opt/base/deploy/scripts/prod-real-seal.sh ]]; then
+    install -m 0755 /opt/base/deploy/scripts/prod-real-seal.sh /opt/base/deploy/scripts/prod-real-seal.sh
+    install -m 0644 /opt/base/deploy/systemd/base-real-seal.service /etc/systemd/system/base-real-seal.service
+    install -m 0644 /opt/base/deploy/systemd/base-real-seal.timer /etc/systemd/system/base-real-seal.timer
+    systemctl disable --now base-burn-seal.timer >/dev/null 2>&1 || true
+    systemctl daemon-reload
+    systemctl enable --now base-real-seal.timer
+    echo "remote-deploy: real-seal timer enabled (burn-seal retired)"
+  fi
 fi
 EOS
 

--- a/docs/BUNDLE_SPEC.md
+++ b/docs/BUNDLE_SPEC.md
@@ -484,7 +484,8 @@ Reject if:
 | Missing leaf for any `(c,h)` in some `E_c` | Censorship / omission |
 | Bundle's implied set is a **proper subset** of `E_c` | D24 explicit |
 | Extra leaf for unknown challenge id | D18 |
-| Extra leaf for hotkey not in `E_c` | Reject (strict coverage) |
+| Extra leaf for hotkey not in `E_c` (bps > 0) | Reject (strict coverage) |
+| Leaf for a challenge with `bps == 0` | Ignored — not in any `E_c`; seal strips before merkle |
 | Duplicate `(c,h)` | Reject |
 
 Gateway seal MUST fail closed rather than publish an incomplete bundle.


### PR DESCRIPTION
## Summary
- Live bug: Prism 2.1 already had a weight-eligible WTA winner (uid 88 / `5F4QNED7…`) but `/v1/weights/latest` stayed uid-0 burn. Cause: `base-burn-seal` + inactive `base-real-seal`, plus 0-bps design leftovers 409ing D24.
- Seal now strips 0-bps challenge leaves (BUNDLE_SPEC §7.3), design skips leaf emit via `DESIGN_SKIP_LEAF_EMIT`, and master `remote-deploy` enables real-seal / retires burn-seal.

## Test plan
- [x] Prod real-seal epoch 24617 → `hotkey_weights` winner = 1.0, leaderboard `weight: 1.0`
- [x] `d24_zero_bps_extra_leaves_stripped_at_seal`
- [ ] CI green, then tag/deploy-prod for the gateway/design image