### PR TITLE
fix(prism): do not re-run LLM screens on Lium no_capacity

### DIFF
--- a/crates/db/src/prism_store.rs
+++ b/crates/db/src/prism_store.rs
@@ -270,11 +270,13 @@ pub async fn update_prism_submission(
     Ok(row)
 }
 
-/// Reset a row for retry: clears review/score fields and re-queues.
+/// Reset a row for retry: clears score fields and re-queues.
 /// Completed measurements are retained for post-run review retries; rows
 /// without metrics drop stale pod/exec fields and re-provision cleanly.
-/// When `bump_retry`, increments `retry_count` (manual/auto infra). When
-/// false, keeps attempts (Lium 429 autonomous requeue — do not burn budget).
+/// When `bump_retry`, increments `retry_count` and clears screens
+/// (manual / llm_infra / ast_infra). When false (Lium 429 / `no_capacity`),
+/// keeps attempts **and** similarity/review so sold-out rent ticks do not
+/// re-bill LLM screens.
 ///
 /// # Errors
 /// SQL error / 0 rows for id.
@@ -290,7 +292,8 @@ pub async fn reset_prism_submission_for_retry(
             pod_provider = CASE WHEN metrics_json IS NULL THEN NULL ELSE pod_provider END, \
             receipt_json = CASE WHEN metrics_json IS NULL THEN NULL ELSE receipt_json END, \
             bpb = CASE WHEN metrics_json IS NULL THEN NULL ELSE bpb END, \
-            review_json = NULL, similarity_json = NULL, \
+            review_json = CASE WHEN $2 THEN NULL ELSE review_json END, \
+            similarity_json = CASE WHEN $2 THEN NULL ELSE similarity_json END, \
             kind = NULL, score = NULL, absence_reason = NULL, emitted_epoch = NULL, \
             error_detail = NULL, \
             retry_count = CASE WHEN $2 THEN retry_count + 1 ELSE retry_count END, \

--- a/crates/prism-challenge/src/orchestrator.rs
+++ b/crates/prism-challenge/src/orchestrator.rs
@@ -667,10 +667,11 @@ impl<C: ChainClient + Send> Orchestrator<C> {
         id: &str,
         row: &SubmissionState,
     ) -> Option<(SimilarityVerdict, prism_review::ReviewVerdict)> {
-        if mid_pod_resume(row) {
-            if let (Some(s), Some(r)) = (row.similarity.clone(), row.review.clone()) {
-                return Some((s, r));
-            }
+        // Keep pre-pod screens across 429 / no_capacity requeues. Re-running
+        // similarity + LLM review + pre-pod agentic every rent tick burns
+        // tokens while waiting for a B200.
+        if let (Some(s), Some(r)) = (row.similarity.clone(), row.review.clone()) {
+            return Some((s, r));
         }
         let (s, r, _) = self.pre_pod_screens(id, row).await?;
         if !mid_pod_resume(row) {

--- a/crates/prism-challenge/tests/e2e_orchestrate_sim.rs
+++ b/crates/prism-challenge/tests/e2e_orchestrate_sim.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -20,7 +21,9 @@ use prism_lium::{
     CostGuardrailError, EvalJobBackend, Instance, InstanceSpec, LiumError, Offer, RemoteExecResult,
     SimLiumBackend,
 };
-use prism_review::SimReviewer;
+use prism_review::{
+    ReviewBackend, ReviewError, ReviewVerdict, SimReviewer, SimilarityVerdict, SourceSnippet,
+};
 use std::sync::Mutex;
 
 fn fake_chain() -> FakeChain {
@@ -403,10 +406,56 @@ fn row_from_example(id: &str, req: &prism_challenge::SubmissionRequest) -> Submi
     }
 }
 
+struct CountingReviewer {
+    inner: SimReviewer,
+    reviews: AtomicUsize,
+    sims: AtomicUsize,
+}
+
+impl CountingReviewer {
+    fn new() -> Self {
+        Self {
+            inner: SimReviewer::new(),
+            reviews: AtomicUsize::new(0),
+            sims: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl ReviewBackend for CountingReviewer {
+    async fn review(
+        &self,
+        architecture_py: &str,
+        training_py: &str,
+    ) -> Result<ReviewVerdict, ReviewError> {
+        self.reviews.fetch_add(1, Ordering::SeqCst);
+        self.inner.review(architecture_py, training_py).await
+    }
+
+    async fn similarity(
+        &self,
+        architecture_py: &str,
+        corpus: &[SourceSnippet],
+    ) -> Result<SimilarityVerdict, ReviewError> {
+        self.sims.fetch_add(1, Ordering::SeqCst);
+        self.inner.similarity(architecture_py, corpus).await
+    }
+}
+
 fn orch_with_backend(
     store: &Arc<MemoryPrismStore>,
     chain: &Arc<LockedFake>,
     backend: Arc<dyn EvalJobBackend>,
+) -> Orchestrator<LockedFake> {
+    orch_with_backend_review(store, chain, backend, Arc::new(SimReviewer::new()))
+}
+
+fn orch_with_backend_review(
+    store: &Arc<MemoryPrismStore>,
+    chain: &Arc<LockedFake>,
+    backend: Arc<dyn EvalJobBackend>,
+    reviewer: Arc<dyn ReviewBackend>,
 ) -> Orchestrator<LockedFake> {
     let gateway = Arc::new(
         GatewayClient::new(GatewayClientConfig {
@@ -426,7 +475,7 @@ fn orch_with_backend(
         },
         Arc::clone(store) as Arc<dyn PrismStore>,
         backend,
-        Arc::new(SimReviewer::new()),
+        reviewer,
         Arc::new(SimAgent::new()),
         &gateway,
         Arc::clone(chain),
@@ -438,10 +487,12 @@ fn orch_with_backend(
 async fn no_capacity_requeues_with_b200_note() {
     let store = Arc::new(MemoryPrismStore::new());
     let chain = Arc::new(LockedFake(Mutex::new(fake_chain())));
-    let orch = orch_with_backend(
+    let reviewer = Arc::new(CountingReviewer::new());
+    let orch = orch_with_backend_review(
         &store,
         &chain,
         Arc::new(ProvisionFail("capacity")) as Arc<dyn EvalJobBackend>,
+        Arc::clone(&reviewer) as Arc<dyn ReviewBackend>,
     );
     let req = example_valid_request();
     let id = submission_id(&req);
@@ -475,6 +526,18 @@ async fn no_capacity_requeues_with_b200_note() {
     assert!(orch.cycle_once().await.unwrap());
     let row = store.get(&id).await.unwrap().expect("row");
     assert_eq!(row.status, Stage::Queued, "next tick still queued");
+    assert!(row.review.is_some(), "sold-out must keep llm_review");
+    assert!(row.similarity.is_some(), "sold-out must keep similarity");
+    assert_eq!(
+        reviewer.reviews.load(Ordering::SeqCst),
+        1,
+        "llm_review must not re-run on every no_capacity tick"
+    );
+    assert_eq!(
+        reviewer.sims.load(Ordering::SeqCst),
+        1,
+        "similarity must not re-run on every no_capacity tick"
+    );
 }
 
 #[tokio::test]

--- a/crates/prism-store/src/store.rs
+++ b/crates/prism-store/src/store.rs
@@ -35,12 +35,13 @@ pub trait PrismStore: Send + Sync + std::fmt::Debug {
         event: Option<&StageEvent>,
     ) -> Result<SubmissionState, StoreError>;
 
-    /// Retry reset: clears review/score fields and re-queues. A completed
+    /// Retry reset: clears score fields and re-queues. A completed
     /// measurement (metrics plus its pod/receipt/bpb fields) is retained so a
     /// post-run infra retry resumes without another GPU run; an incomplete
     /// measure attempt is cleared so provisioning starts cleanly.
-    /// `bump_retry` increments `retry_count` (manual/auto infra). Pass
-    /// `false` for Lium 429 / `no_capacity` requeue (do not burn attempt budget).
+    /// `bump_retry` increments `retry_count` and clears similarity/review
+    /// (manual / llm_infra / ast_infra). Pass `false` for Lium 429 /
+    /// `no_capacity` so pre-pod screens stay and are not re-billed.
     async fn reset_for_retry(
         &self,
         id: &str,
@@ -310,8 +311,10 @@ impl PrismStore for MemoryPrismStore {
             row.metrics_json = None;
             row.bpb = None;
         }
-        row.review = None;
-        row.similarity = None;
+        if bump_retry {
+            row.review = None;
+            row.similarity = None;
+        }
         row.final_score = None;
         row.error_detail = None;
         if bump_retry {
@@ -761,6 +764,43 @@ mod tests {
         assert_eq!(retried.retry_count, 1);
         assert_eq!(s.telemetry("a").await.unwrap().len(), 2);
         assert!(s.get("a").await.unwrap().unwrap().metrics_json.is_some());
+    }
+
+    #[tokio::test]
+    async fn no_capacity_reset_keeps_pre_pod_screens() {
+        use prism_review::{ReviewVerdict, SimilarityKind, SimilarityVerdict};
+        let s = MemoryPrismStore::new();
+        let mut r = row("a", "11");
+        r.metrics_json = None;
+        s.insert_queued(&r).await.unwrap();
+        s.apply(
+            "a",
+            &StatePatch {
+                review: Some(ReviewVerdict {
+                    quality_score: 10,
+                    issues: vec![],
+                    prompt_version: "t",
+                }),
+                similarity: Some(SimilarityVerdict {
+                    kind: SimilarityKind::Original,
+                    score: 0.1,
+                    closest: None,
+                    evidence: vec![],
+                    prompt_version: "t",
+                }),
+                ..StatePatch::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        let kept = s.reset_for_retry("a", false).await.unwrap();
+        assert!(kept.review.is_some());
+        assert!(kept.similarity.is_some());
+        let wiped = s.reset_for_retry("a", true).await.unwrap();
+        assert!(wiped.review.is_none());
+        assert!(wiped.similarity.is_none());
+        assert_eq!(wiped.retry_count, 1);
     }
 
     #[tokio::test]

--- a/docs/PRISM.md
+++ b/docs/PRISM.md
@@ -132,7 +132,9 @@ failed 429 rows from the last **6 hours**. **No matching 1× B200 offer**
 (`no_capacity` / sold out) is the same class: the row stays **`queued`**
 (not `failed` / Score(0)), events and `error_detail` carry
 `B200s are currently out of capacity on Lium; this job is queued until an offer appears.`,
-and the next `claim_next` tick retries rent on the miner BYOK key. Template
+and the next `claim_next` tick retries **rent only** on the miner BYOK key
+(similarity / LLM review / pre-pod agentic stay on the row — they are not
+re-run every sold-out tick). Template
 permission / auth / bad ZIP stay fails (Lium already retries a rentable
 template once). After an infra `blocked`, the
 miner may **`/retry` or re-POST the same bytes** for `ChallengeInternal`


### PR DESCRIPTION
## Summary
- `no_capacity` / 429 requeues were wiping `similarity` + `llm_review` and re-running screens (plus pre-pod agentic / `scoring`) every ~15s while waiting for a B200.
- Keep those verdicts when the retry does not burn attempt budget; next claim retries rent only.

## Test plan
- [x] `no_capacity_reset_keeps_pre_pod_screens`
- [x] `no_capacity_requeues_with_b200_note` asserts 1 review + 1 similarity across two cycles