### PR TITLE
fix(db): backtick llm_infra and ast_infra in clippy docs

### DIFF
--- a/crates/db/src/prism_store.rs
+++ b/crates/db/src/prism_store.rs
@@ -274,7 +274,7 @@ pub async fn update_prism_submission(
 /// Completed measurements are retained for post-run review retries; rows
 /// without metrics drop stale pod/exec fields and re-provision cleanly.
 /// When `bump_retry`, increments `retry_count` and clears screens
-/// (manual / llm_infra / ast_infra). When false (Lium 429 / `no_capacity`),
+/// (manual / `llm_infra` / `ast_infra`). When false (Lium 429 / `no_capacity`),
 /// keeps attempts **and** similarity/review so sold-out rent ticks do not
 /// re-bill LLM screens.
 ///


### PR DESCRIPTION
## Summary
- Clippy `doc_markdown` fails on `main` after #185 (`llm_infra` / `ast_infra` in `prism_store.rs`).
- Required so site-api PRs #177–#179 can go green and merge.

## Test plan
- [x] CI fmt/clippy on this PR