### PR TITLE
fix(site-api): rustfmt leaderboard pin-only assertion

### DIFF
--- a/crates/site-api/src/handlers.rs
+++ b/crates/site-api/src/handlers.rs
@@ -1598,7 +1598,10 @@ mod tests {
         let (s, v) = call(app, "/v1/site/arenas/prism/leaderboard").await;
         assert_eq!(s, StatusCode::OK, "{v}");
         assert_eq!(v["waitingForFirst"], true, "{v}");
-        assert_eq!(v["total"], 0, "pin-only 2.0 must not rank under live 2.1: {v}");
+        assert_eq!(
+            v["total"], 0,
+            "pin-only 2.0 must not rank under live 2.1: {v}"
+        );
         assert_eq!(v["competitionId"], "prism-v2.1");
         assert_eq!(v["scoringGeneration"], 21);
     }


### PR DESCRIPTION
## Summary
- `cargo fmt --check` failed on main after #179 (`handlers.rs` leaderboard assertion).
- Required so CI can go green and prod can promote.

## Test plan
- [x] `cargo fmt --all -- --check`