### PR TITLE
fix(prism-store): backtick llm_infra and ast_infra in clippy docs

### DIFF
--- a/crates/prism-store/src/store.rs
+++ b/crates/prism-store/src/store.rs
@@ -40,7 +40,7 @@ pub trait PrismStore: Send + Sync + std::fmt::Debug {
     /// post-run infra retry resumes without another GPU run; an incomplete
     /// measure attempt is cleared so provisioning starts cleanly.
     /// `bump_retry` increments `retry_count` and clears similarity/review
-    /// (manual / llm_infra / ast_infra). Pass `false` for Lium 429 /
+    /// (manual / `llm_infra` / `ast_infra`). Pass `false` for Lium 429 /
     /// `no_capacity` so pre-pod screens stay and are not re-billed.
     async fn reset_for_retry(
         &self,


### PR DESCRIPTION
## Summary
- Clippy `doc_markdown` fails on `crates/prism-store/src/store.rs` (`llm_infra` / `ast_infra`).
- Required for green CI on main before prod tag.

## Test plan
- [ ] CI clippy on this PR