### PR TITLE
fix(design-challenge): drop crate_name so loc-cap is under 1500

### DIFF
--- a/crates/design-challenge/src/lib.rs
+++ b/crates/design-challenge/src/lib.rs
@@ -47,18 +47,12 @@ pub use host_sim::{
 };
 pub use orchestrator::{ErrorClass, Orchestrator, OrchestratorConfig};
 
-#[must_use]
-pub fn crate_name() -> &'static str {
-    "design-challenge"
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn identity() {
-        assert_eq!(crate_name(), "design-challenge");
         assert_eq!(CHALLENGE_ID, "design");
         assert_eq!(SCORING_VERSION, 3);
     }


### PR DESCRIPTION
## Summary
- `crates/design-challenge` is 1501 LOC (cap 1500); `cargo test -p xtask` fails closed.
- Remove unused `crate_name` helper (only referenced from its own unit test).

## Test plan
- [ ] CI loc-cap / cargo test