### PR TITLE
fix(deploy): chmod real-seal script instead of install onto itself

### DIFF
--- a/deploy/scripts/remote-deploy.sh
+++ b/deploy/scripts/remote-deploy.sh
@@ -589,7 +589,7 @@ PY
   # Prism WTA is the live seal path. Burn-seal posts NoScore at a block-scale
   # epoch and hid the 2.1 winner until a real chain-epoch seal existed.
   if [[ -f /opt/base/deploy/scripts/prod-real-seal.sh ]]; then
-    install -m 0755 /opt/base/deploy/scripts/prod-real-seal.sh /opt/base/deploy/scripts/prod-real-seal.sh
+    chmod 0755 /opt/base/deploy/scripts/prod-real-seal.sh
     install -m 0644 /opt/base/deploy/systemd/base-real-seal.service /etc/systemd/system/base-real-seal.service
     install -m 0644 /opt/base/deploy/systemd/base-real-seal.timer /etc/systemd/system/base-real-seal.timer
     systemctl disable --now base-burn-seal.timer >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- Staging master deploy failed after healthy gateway/backend smoke: `install` src==dest on `prod-real-seal.sh`.
- Use `chmod 0755` so CI can go green and prod can be tagged.

## Test plan
- [ ] Staging master deploy in CI