### PR TITLE
feat(relearn): fail-closed holdout and anti-overfit gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,7 +4636,10 @@ dependencies = [
 name = "relearn-challenge-task"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4657,6 +4660,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.19",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -4794,6 +4798,7 @@ dependencies = [
  "relearn-challenge-task",
  "relearn-score",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.19",
 ]
@@ -7438,6 +7443,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "regex",
+ "relearn-challenge-task",
  "relearn-t2i-task",
  "reqwest 0.12.28",
  "scale-info",

--- a/bins/relearn-challenge/src/main.rs
+++ b/bins/relearn-challenge/src/main.rs
@@ -2,20 +2,27 @@
 //!
 //! Miner HTTP submit → digest freeze → holdout unseal → sim/Lium eval →
 //! operator-audited promote. Miners pay Lium.
+//!
+//! Holdout records are loaded from an operator file and verified against the
+//! commitment in `config/relearn-pin.toml`. If that file is absent or does not
+//! match, the service still serves `/health` and `/v1/status` but refuses
+//! submissions: scoring a reconstructable seed or the public split would
+//! silently turn the anti-overfit gates off.
 
 #![forbid(unsafe_code)]
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 
 use challenge_keys::load_challenge_secret;
 use clap::Parser;
 use relearn_challenge::{
-    hash_admin_token, relearn_router, AppState, MemoryStore, CHALLENGE_ID, SCORING_VERSION,
+    hash_admin_token, parse_holdout_file, relearn_router, AppState, MemoryStore, RelearnPin,
+    CHALLENGE_ID, SCORING_VERSION,
 };
-use relearn_eval::{base_champion_scores, RelearnPin};
+use relearn_eval::base_champion_scores;
 use tokio::net::TcpListener;
 
 /// Operator Relearn challenge service CLI.
@@ -40,6 +47,9 @@ struct Cli {
     /// Pin file (`config/relearn-pin.toml`).
     #[arg(long, env = "RELEARN_PIN_FILE")]
     pin_file: Option<PathBuf>,
+    /// Operator holdout records (JSON array). Never in git.
+    #[arg(long, env = "RELEARN_HOLDOUT_FILE")]
+    holdout_file: Option<PathBuf>,
 }
 
 fn main() -> ExitCode {
@@ -58,15 +68,24 @@ fn run(cli: &Cli) -> Result<(), String> {
     if let Some(p) = &cli.challenge_sk_file {
         let _sk = load_challenge_secret(p).map_err(|e| format!("challenge sk: {e}"))?;
     }
-    let pin = load_pin(cli.pin_file.as_deref());
+    let pin = load_pin(cli.pin_file.as_deref())?;
     if cli.force_sim {
         tracing::info!("RELEARN_FORCE_SIM=1 — sim eval only");
     }
     let admin_hashes = load_admin_hashes(cli.admin_tokens_file.as_deref());
     let store = MemoryStore::new();
     store
-        .set_base_champion(base_champion_scores())
+        .set_holdout_commitment(&pin.holdout_commitment, pin.holdout_size)
         .map_err(|e| e.to_string())?;
+    match load_holdout(&store, &pin, cli.holdout_file.as_deref()) {
+        Ok(n) => tracing::info!(holdout_items = n, "holdout verified against pin commitment"),
+        Err(e) => tracing::warn!("holdout unavailable ({e}); submissions will 503 until fixed"),
+    }
+    if let Ok(recs) = store.unseal_holdout("boot-baseline") {
+        store
+            .set_base_champion(base_champion_scores(&recs))
+            .map_err(|e| e.to_string())?;
+    }
     let state = AppState {
         store,
         pin,
@@ -79,13 +98,32 @@ fn run(cli: &Cli) -> Result<(), String> {
     rt.block_on(serve(cli.bind, state))
 }
 
-fn load_pin(path: Option<&std::path::Path>) -> RelearnPin {
-    path.and_then(|p| std::fs::read_to_string(p).ok())
-        .map(|s| RelearnPin::from_toml(&s))
-        .unwrap_or_default()
+fn load_pin(path: Option<&Path>) -> Result<RelearnPin, String> {
+    let Some(p) = path else {
+        return Ok(RelearnPin::default());
+    };
+    let body = std::fs::read_to_string(p).map_err(|e| format!("read {}: {e}", p.display()))?;
+    let pin = RelearnPin::from_toml(&body).map_err(|e| e.to_string())?;
+    pin.validate().map_err(|e| e.to_string())?;
+    Ok(pin)
 }
 
-fn load_admin_hashes(path: Option<&std::path::Path>) -> Vec<String> {
+fn load_holdout(
+    store: &MemoryStore,
+    pin: &RelearnPin,
+    path: Option<&Path>,
+) -> Result<usize, String> {
+    let p = path.ok_or("RELEARN_HOLDOUT_FILE not set")?;
+    let body = std::fs::read_to_string(p).map_err(|e| format!("read {}: {e}", p.display()))?;
+    let records = parse_holdout_file(&body)?;
+    let n = records.len();
+    store
+        .load_holdout(records, &[], &pin.public_ids)
+        .map_err(|e| e.to_string())?;
+    Ok(n)
+}
+
+fn load_admin_hashes(path: Option<&Path>) -> Vec<String> {
     let Some(p) = path else {
         return Vec::new();
     };

--- a/config/relearn-pin.toml
+++ b/config/relearn-pin.toml
@@ -1,6 +1,21 @@
 # Cortex pin for the split CortexLM/relearn challenge repo.
 # Deploy = bump eval_image_digest + relearn_git_sha after relearn CI is green.
-# Never put secrets in this file.
+# Never put secrets, teacher endpoints, or holdout items in this file.
+#
+# The holdout split is NOT in this file. Git carries only its commitment; the
+# records live in an operator file (`RELEARN_HOLDOUT_FILE`) and are checked
+# against the commitment at boot. Regenerate with:
+#
+#   cargo run -p xtask -- relearn-holdout --catalog <catalog.json> \
+#     --salt "$RELEARN_HOLDOUT_SALT" --size 120 --exclude <each public id> \
+#     --out /root/.base-secrets/relearn-holdout.json
+#
+# The committed commitment below is the LOCAL salt
+# "cortex-relearn-dev-holdout-v0" over a synthetic catalog so CI and staging
+# can boot. That salt is NOT the T2I/dev salt. Production must rotate to a
+# private salt + private catalog, replace the commitment, and re-sign
+# (config/CEREMONY.md). A documented salt plus a public catalog would let
+# miners reconstruct the scored split.
 
 base_model = "Qwen/Qwen3.8-Flash-Next"
 # HTTP teacher model id. Operator may override with RELEARN_TEACHER_MODEL.
@@ -12,3 +27,14 @@ eval_image = "ghcr.io/cortexlm/relearn-eval"
 eval_image_digest = ""
 relearn_git = "https://github.com/CortexLM/relearn"
 relearn_git_sha = "6e952d1e5edd6e6906ba7fe8442898f334400fb4"
+
+# Public split ids (miners may train on these). Holdout selection must exclude
+# every one of them. The scored holdout records stay off git.
+public_ids = [
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+  31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+]
+holdout_commitment = "84aed1547520f39c325712822a3533dc384d2c0a8f152d8acc686b0b7a921065"
+holdout_size = 120

--- a/crates/relearn-challenge-task/Cargo.toml
+++ b/crates/relearn-challenge-task/Cargo.toml
@@ -9,7 +9,10 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+hex = "0.4"
 serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
+thiserror = "2"
 
 [lints]
 workspace = true

--- a/crates/relearn-challenge-task/src/holdout.rs
+++ b/crates/relearn-challenge-task/src/holdout.rs
@@ -1,0 +1,481 @@
+//! Frozen Relearn holdout records and the pin commitment.
+//!
+//! Git carries only `holdout_commitment` + `holdout_size`. The records live in
+//! an operator file (`RELEARN_HOLDOUT_FILE`) and are checked at boot. A
+//! mismatch is fail-closed: submissions answer 503 rather than scoring a
+//! reconstructable seed or falling back to the public split.
+//!
+//! The previous seed (`sha256(HOLDOUT_DOMAIN ‖ epoch ‖ digest)`) was
+//! regenerable from git. That path is gone.
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::collections::{BTreeSet, HashSet};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::HOLDOUT_DOMAIN;
+
+/// Minimum holdout items. Matches the paired test's evidence floor.
+pub const MIN_HOLDOUT_ITEMS: usize = 100;
+
+/// Largest Jaccard similarity on prompt 3-grams allowed between public and holdout.
+pub const NGRAM_JACCARD_MAX: f64 = 0.80;
+
+/// Task family on a holdout (or public) item.
+///
+/// Vision families exist because the live base is a native VLM. A text-only
+/// record leaves `image_hash` empty and does not take the pixel-shuffle gate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HoldoutTask {
+    /// Language-only item (no image).
+    #[default]
+    Text,
+    /// Free-form captioning.
+    Captioning,
+    /// Visual question answering.
+    Vqa,
+    /// Reading text rendered inside the image.
+    Ocr,
+    /// Spatial relations between objects.
+    Spatial,
+}
+
+impl HoldoutTask {
+    /// Families that carry an image and must take the pixel-shuffle control.
+    pub const VISION: [Self; 4] = [Self::Captioning, Self::Vqa, Self::Ocr, Self::Spatial];
+
+    /// Wire name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Captioning => "captioning",
+            Self::Vqa => "vqa",
+            Self::Ocr => "ocr",
+            Self::Spatial => "spatial",
+        }
+    }
+
+    /// Whether this family is scored with an image.
+    #[must_use]
+    pub const fn is_vision(self) -> bool {
+        !matches!(self, Self::Text)
+    }
+}
+
+/// One frozen eval item. Images stay out of git; only the hash is committed
+/// into the operator file (and then into the pin commitment).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HoldoutItem {
+    /// Stable item id. Never published for the holdout split.
+    pub id: u32,
+    /// Prompt / question text.
+    pub prompt: String,
+    /// Source dataset id (fingerprint only).
+    #[serde(default)]
+    pub dataset_id: String,
+    /// Task family.
+    #[serde(default)]
+    pub task: HoldoutTask,
+    /// SHA-256 hex of the image bytes. Empty for text-only items.
+    #[serde(default)]
+    pub image_hash: String,
+}
+
+impl HoldoutItem {
+    /// Canonical fingerprint used by the contamination gate.
+    #[must_use]
+    pub fn fingerprint(&self) -> String {
+        format!("id:{}", self.id)
+    }
+
+    /// Image fingerprint, when present.
+    #[must_use]
+    pub fn image_fingerprint(&self) -> Option<String> {
+        let h = self.image_hash.trim().to_ascii_lowercase();
+        if h.len() == 64 && h.chars().all(|c| c.is_ascii_hexdigit()) {
+            Some(format!("image:{h}"))
+        } else {
+            None
+        }
+    }
+}
+
+/// Why a holdout set was refused.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum HoldoutError {
+    /// Nothing to score.
+    #[error("holdout set is empty")]
+    Empty,
+    /// Two records claim the same id.
+    #[error("duplicate holdout id {0}")]
+    DuplicateId(u32),
+    /// A record has no prompt body.
+    #[error("holdout id {0} has empty prompt")]
+    EmptyPrompt(u32),
+    /// A vision item is missing a real image hash.
+    #[error("holdout id {0} is a vision task without an image hash")]
+    MissingImageHash(u32),
+    /// The supplied holdout does not match the committed digest.
+    #[error("holdout commitment mismatch (expected {expected}, got {got})")]
+    CommitmentMismatch {
+        /// Digest pinned in git.
+        expected: String,
+        /// Digest of what the operator supplied.
+        got: String,
+    },
+    /// Holdout size disagrees with the pin.
+    #[error("holdout size mismatch (expected {expected}, got {got})")]
+    SizeMismatch {
+        /// Count pinned in git.
+        expected: usize,
+        /// Count the operator supplied.
+        got: usize,
+    },
+    /// A holdout id is also in the published public split.
+    #[error("holdout id {0} is also in the public split")]
+    OverlapsPublic(u32),
+    /// Public and holdout share a near-duplicate prompt or image.
+    #[error("holdout near-duplicate of public item ({0})")]
+    NearDuplicate(String),
+}
+
+/// Commitment over a holdout set.
+///
+/// Domain-separated, id-sorted, and length-prefixed so neither reordering nor
+/// splicing two prompt bodies together can collide.
+#[must_use]
+pub fn holdout_commitment(records: &[HoldoutItem]) -> String {
+    let mut sorted: Vec<&HoldoutItem> = records.iter().collect();
+    sorted.sort_by_key(|r| r.id);
+    let mut h = Sha256::new();
+    h.update(HOLDOUT_DOMAIN);
+    h.update([0xff]);
+    h.update(
+        u64::try_from(sorted.len())
+            .unwrap_or(u64::MAX)
+            .to_le_bytes(),
+    );
+    for r in sorted {
+        h.update(r.id.to_le_bytes());
+        h.update(r.task.as_str().as_bytes());
+        h.update([0xff]);
+        for field in [
+            r.prompt.as_str(),
+            r.dataset_id.as_str(),
+            r.image_hash.trim(),
+        ] {
+            h.update(u64::try_from(field.len()).unwrap_or(u64::MAX).to_le_bytes());
+            h.update(field.as_bytes());
+        }
+    }
+    hex::encode(h.finalize())
+}
+
+fn validate_records(records: &[HoldoutItem]) -> Result<(), HoldoutError> {
+    if records.is_empty() {
+        return Err(HoldoutError::Empty);
+    }
+    let mut seen = BTreeSet::new();
+    for r in records {
+        if r.prompt.trim().is_empty() {
+            return Err(HoldoutError::EmptyPrompt(r.id));
+        }
+        if r.task.is_vision() && r.image_fingerprint().is_none() {
+            return Err(HoldoutError::MissingImageHash(r.id));
+        }
+        if !seen.insert(r.id) {
+            return Err(HoldoutError::DuplicateId(r.id));
+        }
+    }
+    Ok(())
+}
+
+/// Word 3-grams of a prompt, lowercased.
+fn trigrams(text: &str) -> HashSet<String> {
+    let words: Vec<String> = text
+        .split_whitespace()
+        .map(|w| {
+            w.chars()
+                .filter(|c| c.is_alphanumeric())
+                .collect::<String>()
+                .to_ascii_lowercase()
+        })
+        .filter(|w| !w.is_empty())
+        .collect();
+    if words.len() < 3 {
+        return HashSet::new();
+    }
+    words
+        .windows(3)
+        .map(|w| format!("{} {} {}", w[0], w[1], w[2]))
+        .collect()
+}
+
+fn jaccard(a: &HashSet<String>, b: &HashSet<String>) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let inter = a.intersection(b).count() as f64;
+    let union = a.union(b).count() as f64;
+    if union <= 0.0 {
+        0.0
+    } else {
+        inter / union
+    }
+}
+
+/// Public↔holdout near-duplicates (id, image-hash, dataset+id, prompt n-gram).
+#[must_use]
+pub fn near_duplicates(public: &[HoldoutItem], holdout: &[HoldoutItem]) -> Vec<String> {
+    let mut hits = Vec::new();
+    let published_ids: BTreeSet<u32> = public.iter().map(|p| p.id).collect();
+    let published_images: BTreeSet<String> = public
+        .iter()
+        .filter_map(HoldoutItem::image_fingerprint)
+        .collect();
+    let dataset_keys: BTreeSet<(String, u32)> = public
+        .iter()
+        .filter(|p| !p.dataset_id.trim().is_empty())
+        .map(|p| (p.dataset_id.trim().to_owned(), p.id))
+        .collect();
+    let prompt_grams: Vec<(u32, HashSet<String>)> = public
+        .iter()
+        .map(|p| (p.id, trigrams(&p.prompt)))
+        .filter(|(_, g)| g.len() >= 4)
+        .collect();
+
+    for h in holdout {
+        if published_ids.contains(&h.id) {
+            hits.push(format!("id:{}", h.id));
+        }
+        if let Some(img) = h.image_fingerprint() {
+            if published_images.contains(&img) {
+                hits.push(img);
+            }
+        }
+        let ds = h.dataset_id.trim();
+        if !ds.is_empty() && dataset_keys.contains(&(ds.to_owned(), h.id)) {
+            hits.push(format!("dataset:{ds}#{}", h.id));
+        }
+        let hg = trigrams(&h.prompt);
+        if hg.len() >= 4 {
+            for (pid, pg) in &prompt_grams {
+                if jaccard(&hg, pg) > NGRAM_JACCARD_MAX {
+                    hits.push(format!("ngram:{}~{pid}", h.id));
+                }
+            }
+        }
+    }
+    hits.sort();
+    hits.dedup();
+    hits
+}
+
+/// Verify an operator-supplied holdout against the committed digest.
+///
+/// # Errors
+///
+/// Structural problems, size disagreement, public-split overlap, near-duplicates,
+/// or a commitment mismatch. Every one is fail-closed.
+pub fn verify_holdout_items(
+    records: &[HoldoutItem],
+    public: &[HoldoutItem],
+    public_ids: &[u32],
+    expected_commitment: &str,
+    expected_size: usize,
+) -> Result<(), HoldoutError> {
+    validate_records(records)?;
+    if records.len() != expected_size {
+        return Err(HoldoutError::SizeMismatch {
+            expected: expected_size,
+            got: records.len(),
+        });
+    }
+    for r in records {
+        if public_ids.contains(&r.id) {
+            return Err(HoldoutError::OverlapsPublic(r.id));
+        }
+    }
+    if let Some(hit) = near_duplicates(public, records).into_iter().next() {
+        return Err(HoldoutError::NearDuplicate(hit));
+    }
+    let got = holdout_commitment(records);
+    if !got.eq_ignore_ascii_case(expected_commitment.trim()) {
+        return Err(HoldoutError::CommitmentMismatch {
+            expected: expected_commitment.trim().to_ascii_lowercase(),
+            got,
+        });
+    }
+    Ok(())
+}
+
+/// Holdout fingerprints that leaked into a submission's training metadata.
+#[must_use]
+pub fn contamination(
+    train_ids: &BTreeSet<u32>,
+    train_image_hashes: &BTreeSet<String>,
+    train_dataset_ids: &BTreeSet<String>,
+    holdout: &[HoldoutItem],
+) -> Vec<String> {
+    let mut hits = Vec::new();
+    for item in holdout {
+        if train_ids.contains(&item.id) {
+            hits.push(item.fingerprint());
+        }
+        if let Some(img) = item.image_fingerprint() {
+            let raw = img.trim_start_matches("image:");
+            if train_image_hashes
+                .iter()
+                .any(|t| t.trim().eq_ignore_ascii_case(raw))
+            {
+                hits.push(img);
+            }
+        }
+        let ds = item.dataset_id.trim();
+        if !ds.is_empty()
+            && train_dataset_ids
+                .iter()
+                .any(|t| t.trim().eq_ignore_ascii_case(ds))
+            && train_ids.contains(&item.id)
+        {
+            hits.push(format!("dataset:{ds}#{}", item.id));
+        }
+    }
+    hits.sort();
+    hits.dedup();
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: u32, prompt: &str) -> HoldoutItem {
+        HoldoutItem {
+            id,
+            prompt: prompt.into(),
+            dataset_id: "dev".into(),
+            task: HoldoutTask::Text,
+            image_hash: String::new(),
+        }
+    }
+
+    fn vision(id: u32, prompt: &str, hash: &str) -> HoldoutItem {
+        HoldoutItem {
+            id,
+            prompt: prompt.into(),
+            dataset_id: "dev-vis".into(),
+            task: HoldoutTask::Captioning,
+            image_hash: hash.into(),
+        }
+    }
+
+    fn holdout() -> Vec<HoldoutItem> {
+        vec![
+            item(900, "a red cube sits on a wooden table near a lamp"),
+            item(901, "two cats sleep on a sunlit windowsill together"),
+        ]
+    }
+
+    #[test]
+    fn commitment_is_order_independent_and_length_prefixed() {
+        let a = holdout_commitment(&holdout());
+        let mut rev = holdout();
+        rev.reverse();
+        assert_eq!(a, holdout_commitment(&rev));
+        assert_eq!(a.len(), 64);
+        let spliced_ab = holdout_commitment(&[item(1, "ab"), item(2, "c")]);
+        let spliced_bc = holdout_commitment(&[item(1, "a"), item(2, "bc")]);
+        assert_ne!(spliced_ab, spliced_bc);
+    }
+
+    #[test]
+    fn commitment_changes_with_body() {
+        let a = holdout_commitment(&holdout());
+        let mut edited = holdout();
+        edited[0].prompt.push('.');
+        assert_ne!(a, holdout_commitment(&edited));
+    }
+
+    #[test]
+    fn verify_accepts_the_committed_set() {
+        let recs = holdout();
+        let c = holdout_commitment(&recs);
+        verify_holdout_items(&recs, &[], &[1, 2, 3], &c, 2).expect("ok");
+    }
+
+    #[test]
+    fn verify_rejects_public_id_and_near_dupe() {
+        let recs = holdout();
+        let c = holdout_commitment(&recs);
+        assert!(matches!(
+            verify_holdout_items(&recs, &[], &[901], &c, 2),
+            Err(HoldoutError::OverlapsPublic(901))
+        ));
+        let public = vec![item(12, "a red cube sits on a wooden table near a lamp")];
+        assert!(matches!(
+            verify_holdout_items(&recs, &public, &[], &c, 2),
+            Err(HoldoutError::NearDuplicate(_))
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_edited_set_and_size_drift() {
+        let recs = holdout();
+        let c = holdout_commitment(&recs);
+        let mut edited = recs.clone();
+        edited[1].prompt = "three dogs".into();
+        assert!(matches!(
+            verify_holdout_items(&edited, &[], &[], &c, 2),
+            Err(HoldoutError::CommitmentMismatch { .. })
+        ));
+        assert!(matches!(
+            verify_holdout_items(&recs, &[], &[], &c, 3),
+            Err(HoldoutError::SizeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn vision_item_requires_an_image_hash() {
+        let bad = vec![vision(5, "caption this", "")];
+        assert!(matches!(
+            verify_holdout_items(&bad, &[], &[], "00", 1),
+            Err(HoldoutError::MissingImageHash(5))
+        ));
+    }
+
+    #[test]
+    fn contamination_detects_id_and_image_overlap() {
+        let img = "ab".repeat(32);
+        let hold = vec![vision(900, "a scene with a red cube on a table", &img)];
+        let ids: BTreeSet<u32> = [900].into_iter().collect();
+        let hashes: BTreeSet<String> = [img.clone()].into_iter().collect();
+        let no_ids = BTreeSet::new();
+        let no_str = BTreeSet::new();
+        assert!(contamination(&ids, &no_str, &no_str, &hold)
+            .iter()
+            .any(|h| h == "id:900"));
+        assert!(contamination(&no_ids, &hashes, &no_str, &hold)
+            .iter()
+            .any(|h| h.starts_with("image:")));
+        assert!(contamination(&no_ids, &no_str, &no_str, &hold).is_empty());
+    }
+
+    #[test]
+    fn image_hash_overlap_is_a_near_duplicate() {
+        let img = "cd".repeat(32);
+        let public = vec![vision(1, "public caption of a busy street market", &img)];
+        let hold = vec![vision(
+            900,
+            "holdout caption of a quiet harbour at dusk",
+            &img,
+        )];
+        let hits = near_duplicates(&public, &hold);
+        assert!(hits.iter().any(|h| h.starts_with("image:")), "{hits:?}");
+    }
+}

--- a/crates/relearn-challenge-task/src/lib.rs
+++ b/crates/relearn-challenge-task/src/lib.rs
@@ -11,7 +11,14 @@
 //! Master-centralized Lium eval; miners pay Lium.
 
 #![forbid(unsafe_code)]
-#![allow(clippy::doc_markdown)]
+#![allow(clippy::doc_markdown, clippy::module_name_repetitions)]
+
+mod holdout;
+
+pub use holdout::{
+    contamination, holdout_commitment, near_duplicates, verify_holdout_items, HoldoutError,
+    HoldoutItem, HoldoutTask, MIN_HOLDOUT_ITEMS, NGRAM_JACCARD_MAX,
+};
 
 /// Normative challenge id (trust-root / leaf `challenge_id` string).
 pub const CHALLENGE_ID: &str = "relearn";
@@ -59,12 +66,13 @@ pub const RELEARN_GIT_URL: &str = "https://github.com/CortexLM/relearn";
 
 /// Teacher serving mode. v0 default is a teacher-only HTTP API.
 /// Miner weights are never served through the teacher API.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TeacherBackend {
     /// Optional NVFP4 on a digest-pinned Lium pod (`RELEARN_TEACHER_BACKEND=lium`).
     LiumNvfp4,
     /// Teacher-only OpenAI-compatible HTTP API (v0 default).
+    #[default]
     HttpApi,
     /// Deterministic offline judge (CI / `RELEARN_FORCE_SIM`).
     Sim,

--- a/crates/relearn-challenge/src/lib.rs
+++ b/crates/relearn-challenge/src/lib.rs
@@ -15,6 +15,7 @@ use relearn_challenge_task::{CHALLENGE_ID_BYTES, SCORE_MAX};
 use relearn_score::champion_hold_lattice;
 use relearn_store::SubmissionState;
 
+pub use relearn_challenge_task::HoldoutItem;
 pub use relearn_challenge_task::{
     BASE_MODEL_ID, CHALLENGE_ID, CHALLENGE_ID_BYTES as RELEARN_ID_BYTES,
     SCORE_MAX as RELEARN_SCORE_MAX, SCORING_VERSION, TEACHER_MODEL_ID,
@@ -22,6 +23,15 @@ pub use relearn_challenge_task::{
 pub use relearn_eval::{resolve_teacher_backend, RelearnPin};
 pub use relearn_http::{hash_admin_token, relearn_router, AppState};
 pub use relearn_store::MemoryStore;
+
+/// Load frozen holdout records from an operator JSON file body.
+///
+/// # Errors
+///
+/// Returns the serde message when the body is not an item array.
+pub fn parse_holdout_file(body: &str) -> Result<Vec<HoldoutItem>, String> {
+    serde_json::from_str(body).map_err(|e| format!("parse holdout records: {e}"))
+}
 
 /// Build a D24-complete score map: champion (if any) gets a positive lattice;
 /// everyone else is explicit `NoScore` (never silent).
@@ -123,5 +133,13 @@ mod tests {
         let e = BTreeSet::new();
         let leaves = emit_epoch(&sk(), 1, &e, None, 0).expect("empty E");
         assert!(leaves.is_empty());
+    }
+
+    #[test]
+    fn holdout_file_parses_records() {
+        let body = r#"[{"id": 900, "prompt": "a red cube", "dataset_id": "dev", "task": "text"}]"#;
+        let recs = parse_holdout_file(body).expect("parse");
+        assert_eq!(recs.len(), 1);
+        assert!(parse_holdout_file("not json").is_err());
     }
 }

--- a/crates/relearn-eval/Cargo.toml
+++ b/crates/relearn-eval/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
+toml = "0.8"
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/relearn-eval/src/lib.rs
+++ b/crates/relearn-eval/src/lib.rs
@@ -14,23 +14,25 @@
     clippy::significant_drop_tightening
 )]
 
+use std::collections::BTreeMap;
+
 use prism_competition::ExampleSeries;
 use prism_lium::{EvalJobBackend, SimLiumBackend};
 use prism_lium_types::{EvalReceipt, InstanceSpec, NoScoreGate, RemoteExecResult};
 use relearn_challenge_task::{
-    default_teacher_backend, is_configured_teacher_model, TeacherBackend, BASE_MODEL_ID,
-    TEACHER_MODEL_ID, TEACHER_NVFP4_ID,
+    default_teacher_backend, is_configured_teacher_model, HoldoutItem, HoldoutTask, TeacherBackend,
+    BASE_MODEL_ID, MIN_HOLDOUT_ITEMS, TEACHER_MODEL_ID, TEACHER_NVFP4_ID,
 };
-use relearn_score::SliceScores;
-use relearn_store::{unseal_holdout, Holdout};
+use relearn_score::{ShuffleEvidence, SliceScores, MIN_SHUFFLE_DROP};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 /// Pins Cortex stores for the split `CortexLM/relearn` repo + eval image.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct RelearnPin {
-    /// `Qwen/Qwen3.8-Flash-Next`.
+    /// Language / VLM base. Do not recale here; the pin owner owns the id.
     pub base_model: String,
     /// HTTP teacher wire id (`kimi-k3` default; GLM optional override).
     pub teacher_model: String,
@@ -46,6 +48,12 @@ pub struct RelearnPin {
     pub relearn_git: String,
     /// Pinned git SHA of CortexLM/relearn (empty until first push).
     pub relearn_git_sha: String,
+    /// Commitment over the operator holdout file. Required.
+    pub holdout_commitment: String,
+    /// Expected holdout record count.
+    pub holdout_size: usize,
+    /// Published item ids. Miners may train on these.
+    pub public_ids: Vec<u32>,
 }
 
 impl Default for RelearnPin {
@@ -59,44 +67,59 @@ impl Default for RelearnPin {
             eval_image_digest: String::new(),
             relearn_git: relearn_challenge_task::RELEARN_GIT_URL.into(),
             relearn_git_sha: String::new(),
+            holdout_commitment: String::new(),
+            holdout_size: 0,
+            public_ids: Vec::new(),
         }
     }
 }
 
+/// Why a pin was refused.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PinError {
+    /// TOML did not parse.
+    #[error("parse relearn pin: {0}")]
+    Parse(String),
+    /// Holdout commitment is not a 64-hex digest.
+    #[error("holdout_commitment must be 64 hex chars")]
+    BadHoldoutCommitment,
+    /// Holdout split is too thin for a verdict.
+    #[error("holdout_size {got} is below the {min} floor")]
+    TooFewHoldout {
+        /// Count the pin declared.
+        got: usize,
+        /// Required floor.
+        min: usize,
+    },
+}
+
 impl RelearnPin {
-    /// Load from `config/relearn-pin.toml` (best-effort key=value / toml-ish).
-    #[must_use]
-    pub fn from_toml(body: &str) -> Self {
-        let mut pin = Self::default();
-        for raw in body.lines() {
-            let line = raw.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
-            let Some((k, v)) = line.split_once('=') else {
-                continue;
-            };
-            let key = k.trim();
-            let val = v.trim().trim_matches('"').to_owned();
-            match key {
-                "base_model" => pin.base_model = val,
-                "teacher_model" => pin.teacher_model = val,
-                "teacher_nvfp4" => pin.teacher_nvfp4 = val,
-                "eval_image" => pin.eval_image = val,
-                "eval_image_digest" => pin.eval_image_digest = val,
-                "relearn_git" => pin.relearn_git = val,
-                "relearn_git_sha" => pin.relearn_git_sha = val,
-                "teacher_backend" => {
-                    pin.teacher_backend = match val.as_str() {
-                        "lium_nvfp4" => TeacherBackend::LiumNvfp4,
-                        "http_api" => TeacherBackend::HttpApi,
-                        _ => TeacherBackend::Sim,
-                    };
-                }
-                _ => {}
-            }
+    /// Load from `config/relearn-pin.toml`.
+    ///
+    /// # Errors
+    ///
+    /// [`PinError::Parse`] on malformed TOML. Call [`validate`] before boot.
+    pub fn from_toml(body: &str) -> Result<Self, PinError> {
+        toml::from_str(body).map_err(|e| PinError::Parse(e.to_string()))
+    }
+
+    /// Enforce holdout commitment / size. Model ids are not rewritten here.
+    ///
+    /// # Errors
+    ///
+    /// [`PinError::BadHoldoutCommitment`] or [`PinError::TooFewHoldout`].
+    pub fn validate(&self) -> Result<(), PinError> {
+        let commitment = self.holdout_commitment.trim();
+        if commitment.len() != 64 || !commitment.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(PinError::BadHoldoutCommitment);
         }
-        pin
+        if self.holdout_size < MIN_HOLDOUT_ITEMS {
+            return Err(PinError::TooFewHoldout {
+                got: self.holdout_size,
+                min: MIN_HOLDOUT_ITEMS,
+            });
+        }
+        Ok(())
     }
 
     /// True when a live rent is allowed (real digest pin present).
@@ -130,63 +153,93 @@ pub struct EvalOutcome {
     pub scores: SliceScores,
     /// Integrity receipt.
     pub receipt: EvalReceipt,
-    /// Holdout after unseal (seed visible only here).
-    pub holdout: Holdout,
+    /// Holdout item count that was scored (ids stay off the HTTP row).
+    pub holdout_items: usize,
 }
 
-/// Deterministic sim scores from a frozen digest + holdout seed.
+fn unit(parts: &[&str], index: u32) -> f64 {
+    let mut h = Sha256::new();
+    for p in parts {
+        h.update(p.as_bytes());
+        h.update([0xff]);
+    }
+    h.update(index.to_le_bytes());
+    let d = h.finalize();
+    f64::from(d[0]) / 255.0
+}
+
+fn series_ids(prefix: &str, ids: &[u32], digest: &str, salt: &str, bias: f64) -> ExampleSeries {
+    ExampleSeries::from_pairs(ids.iter().map(|id| {
+        let v = unit(&[digest, salt, &id.to_string()], *id);
+        (
+            format!("{prefix}{id}"),
+            (0.45 + 0.4 * v + bias).clamp(0.0, 1.0),
+        )
+    }))
+}
+
+/// Deterministic sim scores from a frozen digest + verified holdout records.
+///
+/// Public and general-canary series are produced from salts that do **not**
+/// include the holdout prompts, so they cannot reconstruct the private split.
 #[must_use]
-pub fn sim_slice_scores(artifact_digest: &str, holdout_seed: &str) -> SliceScores {
-    let holdout = series_from("h", artifact_digest, holdout_seed, 120, 0.15);
-    let public = series_from("p", artifact_digest, holdout_seed, 120, 0.0);
-    let perturbed = series_from(
-        "x",
-        artifact_digest,
-        &format!("{holdout_seed}-p"),
-        120,
-        -0.02,
-    );
-    let canaries = series_from("c", "canary", holdout_seed, 40, 0.45);
+pub fn sim_slice_scores(artifact_digest: &str, holdout: &[HoldoutItem]) -> SliceScores {
+    let hold_ids: Vec<u32> = holdout.iter().map(|r| r.id).collect();
+    let public_ids: Vec<u32> = (1..=40).collect();
+    let mut vision_shuffle = BTreeMap::new();
+    for task in HoldoutTask::VISION {
+        let n = holdout.iter().filter(|r| r.task == task).count();
+        if n == 0 {
+            continue;
+        }
+        let score =
+            (0.55 + 0.2 * unit(&[artifact_digest, task.as_str()], n as u32)).clamp(0.0, 1.0);
+        vision_shuffle.insert(
+            task,
+            ShuffleEvidence {
+                items: u32::try_from(n).unwrap_or(u32::MAX),
+                score,
+                shuffled_score: (score - 2.0 * MIN_SHUFFLE_DROP).max(0.0),
+            },
+        );
+    }
     SliceScores {
-        holdout,
-        public,
-        perturbed,
-        canaries,
+        holdout: series_ids("h", &hold_ids, artifact_digest, "hold", 0.15),
+        public: series_ids("p", &public_ids, artifact_digest, "public", 0.0),
+        perturbed: series_ids("x", &hold_ids, artifact_digest, "pert", -0.02),
+        canaries: series_ids("c", &(0..40).collect::<Vec<_>>(), "canary", "base", 0.45),
+        general_canary: series_ids(
+            "g",
+            &(0..40).collect::<Vec<_>>(),
+            "mmlu-mmmu",
+            "offpath",
+            0.50,
+        ),
         agent_trace: 0.85,
+        vision_shuffle,
+        contaminated_fingerprints: Vec::new(),
     }
 }
 
-/// Fixed base-model champion (Qwen3.8-Flash-Next, no miner adapter).
+/// Baseline champion on the verified holdout (no miner adapter).
 #[must_use]
-pub fn base_champion_scores() -> SliceScores {
-    sim_slice_scores("base-qwen-3.8-flash-next", "base-seed")
+pub fn base_champion_scores(holdout: &[HoldoutItem]) -> SliceScores {
+    sim_slice_scores("base-relearn-champion", holdout)
 }
 
-fn series_from(prefix: &str, digest: &str, seed: &str, n: usize, bias: f64) -> ExampleSeries {
-    let mut h = Sha256::new();
-    h.update(digest.as_bytes());
-    h.update([0xff]);
-    h.update(seed.as_bytes());
-    let root = h.finalize();
-    let pairs = (0..n).map(|i| {
-        let v = f64::from(root[i % 32]) / 255.0;
-        let score = (0.45 + 0.4 * v + bias).clamp(0.0, 1.0);
-        (format!("{prefix}{i}"), score)
-    });
-    ExampleSeries::from_pairs(pairs)
-}
-
-/// Unseal holdout only after `frozen_digest` is recorded, then score.
+/// Score only after the submission digest is frozen and holdout records exist.
 pub fn eval_after_freeze(
-    pending: &Holdout,
     frozen_digest: &str,
     artifact_digest: &str,
+    holdout: &[HoldoutItem],
 ) -> Result<EvalOutcome, EvalError> {
-    let holdout = unseal_holdout(pending, frozen_digest).ok_or(EvalError::HoldoutSealed)?;
-    if !holdout.unsealed {
+    if frozen_digest.trim().is_empty() {
         return Err(EvalError::HoldoutSealed);
     }
-    let scores = sim_slice_scores(artifact_digest, &holdout.seed_hex);
+    if holdout.is_empty() {
+        return Err(EvalError::HoldoutSealed);
+    }
+    let scores = sim_slice_scores(artifact_digest, holdout);
     let metrics = serde_json::to_vec(&serde_json::json!({
         "holdout_n": scores.holdout.len(),
         "agent_trace": scores.agent_trace,
@@ -204,7 +257,7 @@ pub fn eval_after_freeze(
     Ok(EvalOutcome {
         scores,
         receipt,
-        holdout,
+        holdout_items: holdout.len(),
     })
 }
 
@@ -316,16 +369,40 @@ pub async fn sim_rent_roundtrip(digest: &str) -> Result<String, EvalError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use relearn_store::sealed_holdout;
+
+    fn recs(n: u32) -> Vec<HoldoutItem> {
+        (1..=n)
+            .map(|id| {
+                let vision = id % 5;
+                let (task, image_hash) = match vision {
+                    1 => (HoldoutTask::Captioning, format!("{id:064x}")),
+                    2 => (HoldoutTask::Vqa, format!("{:064x}", id + 1000)),
+                    3 => (HoldoutTask::Ocr, format!("{:064x}", id + 2000)),
+                    4 => (HoldoutTask::Spatial, format!("{:064x}", id + 3000)),
+                    _ => (HoldoutTask::Text, String::new()),
+                };
+                HoldoutItem {
+                    id: 800 + id,
+                    prompt: format!("holdout item {id} with enough words for a trigram"),
+                    dataset_id: "dev".into(),
+                    task,
+                    image_hash,
+                }
+            })
+            .collect()
+    }
 
     #[test]
-    fn unseal_happens_only_after_freeze() {
-        let pending = sealed_holdout(1, "digest-a");
-        assert!(eval_after_freeze(&pending, "", "art").is_err());
-        let out = eval_after_freeze(&pending, "digest-a", "art").expect("eval");
-        assert!(out.holdout.unsealed);
+    fn scoring_happens_only_after_freeze_and_unseal() {
+        let hold = recs(120);
+        assert!(eval_after_freeze("", "art", &hold).is_err());
+        assert!(eval_after_freeze("digest-a", "art", &[]).is_err());
+        let out = eval_after_freeze("digest-a", "art", &hold).expect("eval");
         assert_eq!(out.receipt.submission_hash, "digest-a");
+        assert_eq!(out.holdout_items, 120);
         assert!(out.scores.holdout.len() >= 100);
+        assert!(!out.scores.general_canary.is_empty());
+        assert_eq!(out.scores.vision_shuffle.len(), 4);
     }
 
     #[test]
@@ -379,10 +456,32 @@ mod tests {
 base_model = "Qwen/Qwen3.8-Flash-Next"
 teacher_model = "kimi-k3"
 teacher_backend = "http_api"
+holdout_commitment = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+holdout_size = 120
+public_ids = [1, 2, 3]
 "#;
-        let p = RelearnPin::from_toml(body);
+        let p = RelearnPin::from_toml(body).expect("parse");
         assert_eq!(p.base_model, BASE_MODEL_ID);
         assert_eq!(p.teacher_model, TEACHER_MODEL_ID);
         assert_eq!(p.teacher_backend, TeacherBackend::HttpApi);
+        assert_eq!(p.holdout_size, 120);
+        assert_eq!(p.public_ids, vec![1, 2, 3]);
+        p.validate().expect("validates");
+    }
+
+    #[test]
+    fn pin_without_holdout_commitment_fails_validate() {
+        let p = RelearnPin::from_toml("base_model = \"Qwen/Qwen3.8-Flash-Next\"\n").expect("parse");
+        assert!(matches!(p.validate(), Err(PinError::BadHoldoutCommitment)));
+    }
+
+    #[test]
+    fn sim_shuffle_covers_every_vision_family_in_the_holdout() {
+        let scores = sim_slice_scores("art", &recs(120));
+        for task in HoldoutTask::VISION {
+            let ev = scores.vision_shuffle.get(&task).expect("family");
+            assert!(ev.uses_the_image(), "{task:?}");
+        }
+        assert!(SliceScores::mean(&scores.general_canary).unwrap_or(0.0) > 0.9);
     }
 }

--- a/crates/relearn-eval/tests/committed_pin.rs
+++ b/crates/relearn-eval/tests/committed_pin.rs
@@ -1,0 +1,54 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! The committed `config/relearn-pin.toml` must load and carry a real
+//! holdout commitment. Model ids are not rewritten here.
+
+use std::path::{Path, PathBuf};
+
+use relearn_eval::RelearnPin;
+
+fn pin_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../config/relearn-pin.toml")
+        .canonicalize()
+        .expect("pin path")
+}
+
+fn pin() -> RelearnPin {
+    let body = std::fs::read_to_string(pin_path()).expect("read pin");
+    let p = RelearnPin::from_toml(&body).expect("committed pin must parse");
+    p.validate().expect("committed pin must validate");
+    p
+}
+
+#[test]
+fn committed_pin_has_a_holdout_commitment() {
+    let p = pin();
+    assert_eq!(p.holdout_commitment.len(), 64);
+    assert!(p.holdout_size >= relearn_challenge_task::MIN_HOLDOUT_ITEMS);
+    assert!(!p.public_ids.is_empty());
+}
+
+#[test]
+fn pin_carries_no_endpoint_or_secret_or_t2i_salt() {
+    let body = std::fs::read_to_string(pin_path()).expect("read pin");
+    let lower = body.to_ascii_lowercase();
+    for banned in [
+        "api_key",
+        "bearer",
+        "_token",
+        "mnemonic",
+        "https://api.",
+        "modal",
+        "cortex-t2i-dev-holdout-v0",
+    ] {
+        assert!(!lower.contains(banned), "pin mentions {banned:?}");
+    }
+}
+
+#[test]
+fn pin_does_not_embed_holdout_prompts() {
+    let body = std::fs::read_to_string(pin_path()).expect("read pin");
+    assert!(!body.contains("[[holdout"));
+    assert!(!body.contains("holdout_item"));
+}

--- a/crates/relearn-http/src/lib.rs
+++ b/crates/relearn-http/src/lib.rs
@@ -25,12 +25,13 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use std::collections::BTreeSet;
+
 use relearn_challenge_task::{CHALLENGE_ID, SCORE_MAX, SCORING_VERSION};
-use relearn_eval::{base_champion_scores, eval_after_freeze, resolve_teacher_backend, RelearnPin};
-use relearn_score::judge_challenger;
+use relearn_eval::{eval_after_freeze, resolve_teacher_backend, RelearnPin};
+use relearn_score::{contaminated_fingerprints, judge_challenger};
 use relearn_store::{
-    freeze_submission_digest, public_holdout, sealed_holdout, MemoryStore, Submission,
-    SubmissionState,
+    freeze_submission_digest, ArtifactManifest, MemoryStore, Submission, SubmissionState,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -67,6 +68,7 @@ async fn health() -> impl IntoResponse {
 
 async fn status(State(st): State<AppState>) -> impl IntoResponse {
     let champ = st.store.champion_id().ok().flatten();
+    let seal = st.store.holdout_seal().ok();
     Json(serde_json::json!({
         "challenge_id": CHALLENGE_ID,
         "scoring_version": SCORING_VERSION,
@@ -78,6 +80,9 @@ async fn status(State(st): State<AppState>) -> impl IntoResponse {
         "eval_image_digest": st.pin.eval_image_digest,
         "relearn_git": st.pin.relearn_git,
         "relearn_git_sha": st.pin.relearn_git_sha,
+        // Commitment + size + loaded. Never ids, prompts, or image hashes.
+        "holdout": seal,
+        "public_ids": st.pin.public_ids,
         "champion_id": champ,
     }))
 }
@@ -87,6 +92,8 @@ struct SubmitBody {
     miner_hotkey: String,
     artifact_digest: String,
     artifact_uri: Option<String>,
+    #[serde(default)]
+    manifest: ArtifactManifest,
 }
 
 #[derive(Debug, Serialize)]
@@ -132,13 +139,13 @@ async fn submit(
 
     let nonce = nonce_from(&hotkey, &artifact);
     let submission_digest = freeze_submission_digest(&hotkey, &artifact, &nonce);
-    let pending = sealed_holdout(0, &submission_digest);
 
     let row = Submission {
         id: String::new(),
         miner_hotkey: hotkey,
         artifact_digest: artifact.clone(),
         artifact_uri: body.artifact_uri,
+        manifest: body.manifest.clone(),
         nonce,
         submission_digest: submission_digest.clone(),
         state: SubmissionState::Evaluating,
@@ -151,19 +158,40 @@ async fn submit(
         .insert(row)
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "store"))?;
 
-    let eval = eval_after_freeze(&pending, &submission_digest, &artifact)
-        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
-    let _public = public_holdout(&eval.holdout);
-
-    let champ = st
+    let holdout = st
         .store
-        .champion_scores()
-        .ok()
-        .flatten()
-        .unwrap_or_else(base_champion_scores);
-    let verdict = judge_challenger(&champ, &eval.scores);
+        .unseal_holdout(&submission_digest)
+        .map_err(|e| err(StatusCode::SERVICE_UNAVAILABLE, &e.to_string()))?;
+
+    let eval = eval_after_freeze(&submission_digest, &artifact, &holdout)
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+
+    let train_ids: BTreeSet<u32> = body.manifest.train_item_ids.iter().copied().collect();
+    let train_images: BTreeSet<String> = body
+        .manifest
+        .train_image_hashes
+        .iter()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .collect();
+    let train_datasets: BTreeSet<String> = body
+        .manifest
+        .train_dataset_ids
+        .iter()
+        .map(|s| s.trim().to_owned())
+        .collect();
+    let mut scores = eval.scores;
+    scores.contaminated_fingerprints =
+        contaminated_fingerprints(&train_ids, &train_images, &train_datasets, &holdout);
+
+    let champ = st.store.champion_scores().ok().flatten().ok_or_else(|| {
+        err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no champion baseline recorded",
+        )
+    })?;
+    let verdict = judge_challenger(&champ, &scores);
     st.store
-        .record_scores(&row.id, eval.scores.clone())
+        .record_scores(&row.id, scores)
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "store"))?;
     let eligible = verdict.eligible;
     let state = if eligible {
@@ -188,7 +216,7 @@ async fn submit(
             id: row.id,
             submission_digest: row.submission_digest,
             state: row.state,
-            holdout_unsealed: eval.holdout.unsealed,
+            holdout_unsealed: eval.holdout_items > 0,
             eligible,
         }),
     ))
@@ -272,12 +300,62 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use http_body_util::BodyExt;
+    use relearn_challenge_task::{holdout_commitment, HoldoutItem, HoldoutTask};
+    use relearn_eval::base_champion_scores;
     use tower::ServiceExt;
 
     fn digest(label: &str) -> String {
         let mut h = Sha256::new();
         h.update(label.as_bytes());
         hex::encode(h.finalize())
+    }
+
+    fn holdout() -> Vec<HoldoutItem> {
+        (1..=120)
+            .map(|id| {
+                let (task, image_hash) = match id % 5 {
+                    1 => (HoldoutTask::Captioning, format!("{id:064x}")),
+                    2 => (HoldoutTask::Vqa, format!("{:064x}", id + 200)),
+                    3 => (HoldoutTask::Ocr, format!("{:064x}", id + 400)),
+                    4 => (HoldoutTask::Spatial, format!("{:064x}", id + 600)),
+                    _ => (HoldoutTask::Text, String::new()),
+                };
+                HoldoutItem {
+                    id: 800 + id,
+                    prompt: format!("holdout item {id} with enough words for a trigram"),
+                    dataset_id: "dev".into(),
+                    task,
+                    image_hash,
+                }
+            })
+            .collect()
+    }
+
+    fn app_with(token: &str, load: bool) -> Router {
+        let recs = holdout();
+        let pin = RelearnPin {
+            holdout_commitment: holdout_commitment(&recs),
+            holdout_size: recs.len(),
+            public_ids: (1..=40).collect(),
+            ..RelearnPin::default()
+        };
+        let store = MemoryStore::new();
+        store
+            .set_holdout_commitment(&pin.holdout_commitment, pin.holdout_size)
+            .expect("commit");
+        if load {
+            store
+                .load_holdout(recs.clone(), &[], &pin.public_ids)
+                .expect("load");
+            store
+                .set_base_champion(base_champion_scores(&recs))
+                .expect("base");
+        }
+        relearn_router(AppState {
+            store,
+            pin,
+            admin_hashes: Arc::new(vec![hash_admin_token(token)]),
+        })
     }
 
     async fn json_req(
@@ -305,15 +383,7 @@ mod tests {
     #[tokio::test]
     async fn submit_eval_promote_happy_path() {
         let token = "op-test-token";
-        let store = MemoryStore::new();
-        store
-            .set_base_champion(base_champion_scores())
-            .expect("base");
-        let app = relearn_router(AppState {
-            store,
-            pin: RelearnPin::default(),
-            admin_hashes: Arc::new(vec![hash_admin_token(token)]),
-        });
+        let app = app_with(token, true);
 
         let (st, health) =
             json_req(app.clone(), "GET", "/health", serde_json::json!({}), None).await;
@@ -357,11 +427,7 @@ mod tests {
 
     #[tokio::test]
     async fn promote_requires_bearer() {
-        let app = relearn_router(AppState {
-            store: MemoryStore::new(),
-            pin: RelearnPin::default(),
-            admin_hashes: Arc::new(vec![hash_admin_token("x")]),
-        });
+        let app = app_with("x", true);
         let (st, _) = json_req(
             app,
             "POST",
@@ -380,5 +446,59 @@ mod tests {
             "Qwen/Qwen3.8-Flash-Next"
         );
         assert_eq!(relearn_challenge_task::TEACHER_MODEL_ID, "kimi-k3");
+    }
+
+    #[tokio::test]
+    async fn status_publishes_the_seal_not_holdout_items() {
+        let (st, body) = json_req(
+            app_with("op", true),
+            "GET",
+            "/v1/status",
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK);
+        assert_eq!(body["holdout"]["loaded"], true);
+        assert_eq!(body["holdout"]["size"], 120);
+        let dump = body.to_string();
+        assert!(!dump.contains("holdout item"), "{dump}");
+        assert!(!dump.contains("\"id\":801"));
+    }
+
+    #[tokio::test]
+    async fn submit_without_a_loaded_holdout_is_unavailable_not_scored() {
+        let (st, body) = json_req(
+            app_with("op", false),
+            "POST",
+            "/v1/submissions",
+            serde_json::json!({
+                "miner_hotkey": digest("miner-hotkey"),
+                "artifact_digest": digest("x"),
+            }),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+    }
+
+    #[tokio::test]
+    async fn contaminated_training_metadata_cannot_promote() {
+        let hold_id = holdout()[0].id;
+        let (st, created) = json_req(
+            app_with("op", true),
+            "POST",
+            "/v1/submissions",
+            serde_json::json!({
+                "miner_hotkey": digest("miner-hotkey"),
+                "artifact_digest": digest("miner-strong-adapter"),
+                "manifest": { "train_item_ids": [hold_id] },
+            }),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{created}");
+        assert_eq!(created["eligible"], false);
+        assert_eq!(created["state"], "rejected");
     }
 }

--- a/crates/relearn-score/src/lib.rs
+++ b/crates/relearn-score/src/lib.rs
@@ -1,24 +1,32 @@
 //! Displacement scoring for Relearn.
 //!
-//! Score is challenger vs the previous champion on a shared holdout slice.
+//! Score is challenger vs the previous champion on a shared **holdout** slice.
 //! A regression is never crowned. Promotion additionally requires the
-//! operator-audited paired win plus retention / overfit gates.
+//! operator-audited paired win plus retention / overfit / contamination gates.
+//!
+//! The visible lattice is computed from the holdout paired test only. Public
+//! split, general-bench canaries, and pixel-shuffle are gates: they can zero
+//! a run but they never enter the lattice. Miners overfit anything that pays.
 
 #![forbid(unsafe_code)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::doc_markdown,
     clippy::cast_precision_loss,
-    clippy::cast_possible_truncation
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::module_name_repetitions
 )]
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use prism_competition::{
     paired_test, Direction, ExampleSeries, PairedInput, PairedOutcome, PairedRefusal, DEADZONE,
 };
-use relearn_challenge_task::SCORE_MAX;
+use relearn_challenge_task::{contamination, HoldoutItem, HoldoutTask, SCORE_MAX};
 use serde::{Deserialize, Serialize};
 
-/// Maximum allowed public-private accuracy gap (absolute).
+/// Maximum allowed public-minus-holdout gap (absolute).
 pub const MAX_PUBLIC_PRIVATE_GAP: f64 = 0.08;
 
 /// Maximum allowed drop under input perturbation (absolute).
@@ -27,22 +35,80 @@ pub const MAX_PERTURB_DROP: f64 = 0.05;
 /// Minimum canary accuracy (known-answer items the base model already solves).
 pub const MIN_CANARY_ACCURACY: f64 = 0.95;
 
+/// Largest tolerated drop vs the champion on the general-bench canary.
+///
+/// MMLU / MMMU / similar stay **off** the visible score. A regression past
+/// this epsilon is a hard zero, not a reduced lattice.
+pub const CANARY_EPSILON: f64 = 0.02;
+
+/// Minimum score drop required when vision-item pixels are shuffled.
+pub const MIN_SHUFFLE_DROP: f64 = 0.10;
+
 /// Minimum agent-trace score (first-class; 0..1).
 pub const MIN_AGENT_TRACE: f64 = 0.5;
+
+/// Slice id bound into the paired test.
+pub const HOLDOUT_SLICE_ID: &str = "relearn-holdout";
+
+/// Pixel-shuffle evidence for one vision family.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct ShuffleEvidence {
+    /// Items scored in this family.
+    pub items: u32,
+    /// Mean score with the real image (`0..=1`).
+    pub score: f64,
+    /// Mean score with the image pixels shuffled (`0..=1`).
+    pub shuffled_score: f64,
+}
+
+impl ShuffleEvidence {
+    /// How much the score fell when the image was destroyed.
+    #[must_use]
+    pub fn shuffle_drop(&self) -> f64 {
+        self.score - self.shuffled_score
+    }
+
+    /// Whether the model demonstrably used the image.
+    #[must_use]
+    pub fn uses_the_image(&self) -> bool {
+        self.items > 0 && self.shuffle_drop() >= MIN_SHUFFLE_DROP - DEADZONE
+    }
+}
 
 /// Per-example holdout measurements for one submission.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SliceScores {
-    /// Holdout items (scored artifact). Higher is better.
+    /// Holdout items (the only series that may enter the lattice).
     pub holdout: ExampleSeries,
-    /// Public / training-adjacent canary slice (overfit detector).
+    /// Public / training-adjacent split (overfit detector; never lattice).
     pub public: ExampleSeries,
     /// Same holdout items after a pinned perturbation.
     pub perturbed: ExampleSeries,
     /// Known-answer canaries (base-model already-correct items).
     pub canaries: ExampleSeries,
+    /// General benches (MMLU / MMMU / …). Off the visible score path.
+    pub general_canary: ExampleSeries,
     /// Agent-trace quality in `[0, 1]` (first-class; not a side channel).
     pub agent_trace: f64,
+    /// Pixel-shuffle control, one entry per vision family that had images.
+    pub vision_shuffle: BTreeMap<HoldoutTask, ShuffleEvidence>,
+    /// Holdout fingerprints found in the submission's training metadata.
+    pub contaminated_fingerprints: Vec<String>,
+}
+
+impl Default for SliceScores {
+    fn default() -> Self {
+        Self {
+            holdout: ExampleSeries::default(),
+            public: ExampleSeries::default(),
+            perturbed: ExampleSeries::default(),
+            canaries: ExampleSeries::default(),
+            general_canary: ExampleSeries::default(),
+            agent_trace: 0.0,
+            vision_shuffle: BTreeMap::new(),
+            contaminated_fingerprints: Vec::new(),
+        }
+    }
 }
 
 impl SliceScores {
@@ -67,12 +133,28 @@ pub enum GateFail {
     Regression,
     /// Public-private gap too large (memorization / contamination).
     PublicPrivateGap,
+    /// Public split evidence was missing (fail-closed).
+    PublicEvidenceMissing,
     /// Perturbed holdout collapsed (brittle / overfit).
     Perturbation,
-    /// Canaries failed (catastrophic forgetting of base competence).
+    /// Base-competence canaries failed.
     Canaries,
+    /// General-bench canary regressed past [`CANARY_EPSILON`].
+    CanaryRegression {
+        /// Size of the drop in bps.
+        drop_bps: u64,
+    },
+    /// General-bench canary did not run.
+    CanaryEvidenceMissing,
     /// Agent-trace score below floor.
     AgentTrace,
+    /// Eval item ids / image hashes appear in training metadata.
+    Contamination,
+    /// Shuffling the image pixels barely changed the score.
+    IgnoresTheImage {
+        /// Family that ignored the pixels.
+        task: HoldoutTask,
+    },
     /// Paired test refused (slice mismatch / too thin).
     PairedRefusal,
 }
@@ -114,7 +196,21 @@ pub struct PromoteVerdict {
     pub lattice: u64,
 }
 
+/// Eval fingerprints that leaked into a submission's training metadata.
+#[must_use]
+pub fn contaminated_fingerprints(
+    train_ids: &BTreeSet<u32>,
+    train_image_hashes: &BTreeSet<String>,
+    train_dataset_ids: &BTreeSet<String>,
+    holdout: &[HoldoutItem],
+) -> Vec<String> {
+    contamination(train_ids, train_image_hashes, train_dataset_ids, holdout)
+}
+
 /// Judge challenger vs champion. Never returns `eligible` on a regression.
+///
+/// The lattice is holdout-only. General-bench canary, public gap, shuffle, and
+/// contamination can only zero a run.
 #[must_use]
 pub fn judge_challenger(champion: &SliceScores, challenger: &SliceScores) -> PromoteVerdict {
     let mut failed = Vec::new();
@@ -122,7 +218,7 @@ pub fn judge_challenger(champion: &SliceScores, challenger: &SliceScores) -> Pro
     let input = PairedInput {
         metric: "relearn.holdout".into(),
         direction: Direction::HigherBetter,
-        slice_id: "holdout".into(),
+        slice_id: HOLDOUT_SLICE_ID.into(),
         champion: champion.holdout.clone(),
         challenger: challenger.holdout.clone(),
     };
@@ -147,13 +243,17 @@ pub fn judge_challenger(champion: &SliceScores, challenger: &SliceScores) -> Pro
         None => failed.push(GateFail::NoPairedWin),
     }
 
-    if let (Some(pub_m), Some(priv_m)) = (
+    match (
         SliceScores::mean(&challenger.public),
         SliceScores::mean(&challenger.holdout),
     ) {
-        if (pub_m - priv_m).abs() > MAX_PUBLIC_PRIVATE_GAP + DEADZONE {
-            failed.push(GateFail::PublicPrivateGap);
+        (None, _) => failed.push(GateFail::PublicEvidenceMissing),
+        (Some(pub_m), Some(priv_m)) => {
+            if pub_m - priv_m > MAX_PUBLIC_PRIVATE_GAP + DEADZONE {
+                failed.push(GateFail::PublicPrivateGap);
+            }
         }
+        (Some(_), None) => failed.push(GateFail::PairedRefusal),
     }
 
     if let (Some(h), Some(p)) = (
@@ -171,8 +271,36 @@ pub fn judge_challenger(champion: &SliceScores, challenger: &SliceScores) -> Pro
         }
     }
 
+    match (
+        SliceScores::mean(&champion.general_canary),
+        SliceScores::mean(&challenger.general_canary),
+    ) {
+        (None, _) | (_, None) => failed.push(GateFail::CanaryEvidenceMissing),
+        (Some(champ_c), Some(chal_c)) => {
+            let drop = champ_c - chal_c;
+            if drop > CANARY_EPSILON + DEADZONE {
+                failed.push(GateFail::CanaryRegression {
+                    drop_bps: (drop * 10_000.0).round().max(0.0) as u64,
+                });
+            }
+        }
+    }
+
     if challenger.agent_trace + DEADZONE < MIN_AGENT_TRACE {
         failed.push(GateFail::AgentTrace);
+    }
+
+    if !challenger.contaminated_fingerprints.is_empty() {
+        failed.push(GateFail::Contamination);
+    }
+
+    for task in HoldoutTask::VISION {
+        let Some(ev) = challenger.vision_shuffle.get(&task) else {
+            continue;
+        };
+        if !ev.uses_the_image() {
+            failed.push(GateFail::IgnoresTheImage { task });
+        }
     }
 
     failed.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
@@ -217,13 +345,32 @@ mod tests {
         ExampleSeries::from_pairs((0..n).map(|i| (format!("{prefix}{i}"), val)))
     }
 
+    fn vision_ok() -> BTreeMap<HoldoutTask, ShuffleEvidence> {
+        HoldoutTask::VISION
+            .into_iter()
+            .map(|t| {
+                (
+                    t,
+                    ShuffleEvidence {
+                        items: 40,
+                        score: 0.70,
+                        shuffled_score: 0.40,
+                    },
+                )
+            })
+            .collect()
+    }
+
     fn slice(hold: f64, public: f64, pert: f64, canary: f64, trace: f64) -> SliceScores {
         SliceScores {
             holdout: series("h", 120, hold),
             public: series("p", 120, public),
             perturbed: series("x", 120, pert),
             canaries: series("c", 40, canary),
+            general_canary: series("g", 40, 0.97),
             agent_trace: trace,
+            vision_shuffle: vision_ok(),
+            contaminated_fingerprints: Vec::new(),
         }
     }
 
@@ -247,11 +394,22 @@ mod tests {
     }
 
     #[test]
-    fn public_private_gap_blocks() {
+    fn public_far_above_holdout_blocks() {
         let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
         let leak = slice(0.80, 0.99, 0.79, 0.99, 0.9);
         let v = judge_challenger(&champ, &leak);
         assert!(v.failed.contains(&GateFail::PublicPrivateGap));
+        assert!(!v.eligible);
+        assert_eq!(v.lattice, 0);
+    }
+
+    #[test]
+    fn empty_public_is_fail_closed() {
+        let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
+        let mut chal = slice(0.80, 0.80, 0.79, 0.99, 0.9);
+        chal.public = ExampleSeries::default();
+        let v = judge_challenger(&champ, &chal);
+        assert!(v.failed.contains(&GateFail::PublicEvidenceMissing));
         assert!(!v.eligible);
     }
 
@@ -262,6 +420,90 @@ mod tests {
         let v = judge_challenger(&champ, &forget);
         assert!(v.failed.contains(&GateFail::Canaries));
         assert!(!v.eligible);
+    }
+
+    #[test]
+    fn general_canary_regression_is_a_hard_zero_off_the_lattice() {
+        let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
+        let mut chal = slice(0.80, 0.80, 0.79, 0.99, 0.9);
+        chal.general_canary = series("g", 40, 0.70);
+        let v = judge_challenger(&champ, &chal);
+        assert!(
+            v.failed
+                .iter()
+                .any(|f| matches!(f, GateFail::CanaryRegression { .. })),
+            "{:?}",
+            v.failed
+        );
+        assert!(!v.eligible);
+        assert_eq!(v.lattice, 0);
+        assert!(
+            v.paired.expect("holdout still ran").displaces,
+            "canary must not be mixed into the holdout win"
+        );
+    }
+
+    #[test]
+    fn missing_general_canary_is_fail_closed() {
+        let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
+        let mut chal = slice(0.80, 0.80, 0.79, 0.99, 0.9);
+        chal.general_canary = ExampleSeries::default();
+        let v = judge_challenger(&champ, &chal);
+        assert!(v.failed.contains(&GateFail::CanaryEvidenceMissing));
+        assert_eq!(v.lattice, 0);
+    }
+
+    #[test]
+    fn noise_inside_canary_epsilon_is_tolerated() {
+        let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
+        let mut chal = slice(0.80, 0.80, 0.79, 0.99, 0.9);
+        chal.general_canary = series("g", 40, 0.96);
+        assert!(judge_challenger(&champ, &chal).eligible);
+    }
+
+    #[test]
+    fn contamination_blocks_promotion() {
+        let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
+        let mut chal = slice(0.80, 0.80, 0.79, 0.99, 0.9);
+        chal.contaminated_fingerprints = vec!["id:900".into()];
+        let v = judge_challenger(&champ, &chal);
+        assert!(v.failed.contains(&GateFail::Contamination));
+        assert!(!v.eligible);
+        assert_eq!(v.lattice, 0);
+    }
+
+    #[test]
+    fn pixel_shuffle_is_required_on_every_vision_family() {
+        let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
+        for task in HoldoutTask::VISION {
+            let mut chal = slice(0.80, 0.80, 0.79, 0.99, 0.9);
+            chal.vision_shuffle.insert(
+                task,
+                ShuffleEvidence {
+                    items: 40,
+                    score: 0.80,
+                    shuffled_score: 0.79,
+                },
+            );
+            let v = judge_challenger(&champ, &chal);
+            assert!(
+                v.failed.contains(&GateFail::IgnoresTheImage { task }),
+                "family {task:?} must take the shuffle control, failed={:?}",
+                v.failed
+            );
+            assert_eq!(v.lattice, 0);
+        }
+    }
+
+    #[test]
+    fn text_only_holdout_does_not_require_shuffle() {
+        let champ = slice(0.50, 0.50, 0.49, 0.99, 0.9);
+        let mut chal = slice(0.80, 0.80, 0.79, 0.99, 0.9);
+        chal.vision_shuffle.clear();
+        assert!(
+            judge_challenger(&champ, &chal).eligible,
+            "no images ⇒ no shuffle gate"
+        );
     }
 
     #[test]

--- a/crates/relearn-store/Cargo.toml
+++ b/crates/relearn-store/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2"
 
 [dev-dependencies]
 prism-competition = { path = "../prism-competition" }
+serde_json = "1"
 
 [lints]
 workspace = true

--- a/crates/relearn-store/src/lib.rs
+++ b/crates/relearn-store/src/lib.rs
@@ -1,6 +1,9 @@
 //! In-memory Relearn store: submissions, sealed holdout, champion.
 //!
-//! Holdout items stay sealed until the submission digest is frozen.
+//! Holdout records are loaded once from an operator file, verified against
+//! the commitment in `config/relearn-pin.toml`, and are only readable after a
+//! submission digest has been frozen. The public view carries the commitment
+//! and the size, never ids, prompts, or image hashes.
 
 #![forbid(unsafe_code)]
 #![allow(
@@ -12,7 +15,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
-use relearn_challenge_task::HOLDOUT_DOMAIN;
+use relearn_challenge_task::{verify_holdout_items, HoldoutError, HoldoutItem, HOLDOUT_DOMAIN};
 use relearn_score::{PromoteVerdict, SliceScores};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -34,6 +37,18 @@ pub enum SubmissionState {
     Champion,
 }
 
+/// Training metadata the contamination gate reads.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ArtifactManifest {
+    /// Item ids present in the submitted training metadata.
+    pub train_item_ids: Vec<u32>,
+    /// Image hashes present in the submitted training metadata.
+    pub train_image_hashes: Vec<String>,
+    /// Dataset ids present in the submitted training metadata.
+    pub train_dataset_ids: Vec<String>,
+}
+
 /// One miner submission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Submission {
@@ -45,6 +60,9 @@ pub struct Submission {
     pub artifact_digest: String,
     /// Optional locator (HF repo, object URL). Never the scored teacher payload.
     pub artifact_uri: Option<String>,
+    /// Declared training fingerprints.
+    #[serde(default)]
+    pub manifest: ArtifactManifest,
     /// Digest freeze nonce (hex).
     pub nonce: String,
     /// `sha256(hotkey || 0xff || artifact || 0xff || nonce)`.
@@ -59,15 +77,17 @@ pub struct Submission {
     pub detail: Option<String>,
 }
 
-/// Sealed holdout: items hidden until `unseal_after`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Holdout {
+/// Public description of the sealed holdout. Carries no item ids or prompts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HoldoutSeal {
     /// Slice id bound into the paired test.
     pub slice_id: String,
-    /// Hex seed. Empty in the public view until unsealed.
-    pub seed_hex: String,
-    /// Whether the seed has been revealed for this submission.
-    pub unsealed: bool,
+    /// Commitment pinned in `config/relearn-pin.toml`.
+    pub commitment: String,
+    /// Number of holdout items.
+    pub size: usize,
+    /// Whether the operator has loaded matching records on this host.
+    pub loaded: bool,
 }
 
 /// Store errors.
@@ -82,6 +102,9 @@ pub enum StoreError {
     /// Illegal state transition.
     #[error("illegal state {0}")]
     Illegal(String),
+    /// Operator holdout file did not match the committed digest.
+    #[error("holdout: {0}")]
+    Holdout(#[from] HoldoutError),
 }
 
 /// In-memory store (v0). Postgres can replace this without changing the HTTP surface.
@@ -95,12 +118,12 @@ struct Inner {
     next: u64,
     submissions: BTreeMap<String, Submission>,
     champion_id: Option<String>,
-    /// Per-submission holdout slices (in-memory; not serialized on the HTTP row).
     scores: BTreeMap<String, SliceScores>,
-    /// Live champion slices (promoted miner). Displacement is vs this, not the base.
     champion_scores: Option<SliceScores>,
-    /// Baseline champion scores (base model) until a miner is promoted.
     base_champion: Option<SliceScores>,
+    holdout: Option<Vec<HoldoutItem>>,
+    holdout_commitment: String,
+    holdout_size: usize,
 }
 
 impl MemoryStore {
@@ -112,6 +135,57 @@ impl MemoryStore {
 
     fn lock(&self) -> Result<std::sync::MutexGuard<'_, Inner>, StoreError> {
         self.inner.lock().map_err(|_| StoreError::Poison)
+    }
+
+    /// Record the pin's holdout commitment before any records are loaded.
+    pub fn set_holdout_commitment(&self, commitment: &str, size: usize) -> Result<(), StoreError> {
+        let mut g = self.lock()?;
+        g.holdout_commitment = commitment.trim().to_ascii_lowercase();
+        g.holdout_size = size;
+        Ok(())
+    }
+
+    /// Load operator-supplied holdout records, verified against the pin.
+    ///
+    /// Nothing is stored on failure: a host with a bad holdout file scores
+    /// nothing rather than silently falling back to a reconstructable seed.
+    pub fn load_holdout(
+        &self,
+        records: Vec<HoldoutItem>,
+        public: &[HoldoutItem],
+        public_ids: &[u32],
+    ) -> Result<(), StoreError> {
+        let (commitment, size) = {
+            let g = self.lock()?;
+            (g.holdout_commitment.clone(), g.holdout_size)
+        };
+        verify_holdout_items(&records, public, public_ids, &commitment, size)?;
+        self.lock()?.holdout = Some(records);
+        Ok(())
+    }
+
+    /// Public seal description (no ids, no prompts).
+    pub fn holdout_seal(&self) -> Result<HoldoutSeal, StoreError> {
+        let g = self.lock()?;
+        Ok(HoldoutSeal {
+            slice_id: relearn_score::HOLDOUT_SLICE_ID.to_owned(),
+            commitment: g.holdout_commitment.clone(),
+            size: g.holdout_size,
+            loaded: g.holdout.is_some(),
+        })
+    }
+
+    /// Holdout records, readable only after a submission digest is frozen.
+    pub fn unseal_holdout(&self, frozen_digest: &str) -> Result<Vec<HoldoutItem>, StoreError> {
+        if frozen_digest.trim().is_empty() {
+            return Err(StoreError::Illegal(
+                "holdout stays sealed until the submission digest is frozen".into(),
+            ));
+        }
+        let g = self.lock()?;
+        g.holdout
+            .clone()
+            .ok_or_else(|| StoreError::Illegal("no verified holdout loaded".into()))
     }
 
     /// Insert a newly accepted submission.
@@ -257,150 +331,154 @@ pub fn freeze_submission_digest(hotkey: &str, artifact_digest: &str, nonce: &str
     hex::encode(h.finalize())
 }
 
-/// Build a holdout that is sealed until `digest` is recorded.
+/// Per-epoch slice id derived from the holdout commitment (never from a digest).
 #[must_use]
-pub fn sealed_holdout(epoch: u64, digest: &str) -> Holdout {
+pub fn holdout_slice_id(epoch: u64, commitment: &str) -> String {
     let mut h = Sha256::new();
     h.update(HOLDOUT_DOMAIN);
     h.update(epoch.to_le_bytes());
-    h.update(digest.as_bytes());
-    let seed = hex::encode(h.finalize());
-    Holdout {
-        slice_id: format!("relearn-holdout-{epoch}"),
-        seed_hex: String::new(),
-        unsealed: false,
-    }
-    .with_pending_seed(seed)
-}
-
-trait WithPending {
-    fn with_pending_seed(self, seed: String) -> Self;
-}
-
-impl WithPending for Holdout {
-    fn with_pending_seed(mut self, seed: String) -> Self {
-        // Keep seed off the public struct until unseal.
-        self.seed_hex = seed;
-        self.unsealed = false;
-        self
-    }
-}
-
-/// Reveal holdout seed only after the submission digest is frozen.
-#[must_use]
-pub fn unseal_holdout(pending: &Holdout, frozen_digest: &str) -> Option<Holdout> {
-    if frozen_digest.is_empty() || pending.seed_hex.is_empty() {
-        return None;
-    }
-    Some(Holdout {
-        slice_id: pending.slice_id.clone(),
-        seed_hex: pending.seed_hex.clone(),
-        unsealed: true,
-    })
-}
-
-/// Public view: seed stripped until unsealed.
-#[must_use]
-pub fn public_holdout(h: &Holdout) -> Holdout {
-    if h.unsealed {
-        h.clone()
-    } else {
-        Holdout {
-            slice_id: h.slice_id.clone(),
-            seed_hex: String::new(),
-            unsealed: false,
-        }
-    }
+    h.update(commitment.as_bytes());
+    format!(
+        "relearn-holdout-{epoch}-{}",
+        hex::encode(&h.finalize()[..4])
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    use prism_competition::ExampleSeries;
+    use relearn_challenge_task::holdout_commitment;
+    use relearn_score::SliceScores;
+
     use super::*;
+
+    fn items() -> Vec<HoldoutItem> {
+        (900..=903)
+            .map(|id| HoldoutItem {
+                id,
+                prompt: format!("holdout prompt {id} with enough words to trigram"),
+                dataset_id: "dev".into(),
+                task: relearn_challenge_task::HoldoutTask::Text,
+                image_hash: String::new(),
+            })
+            .collect()
+    }
+
+    fn seeded_store() -> MemoryStore {
+        let st = MemoryStore::new();
+        let recs = items();
+        st.set_holdout_commitment(&holdout_commitment(&recs), recs.len())
+            .expect("commit");
+        st
+    }
+
+    fn slice(v: f64) -> SliceScores {
+        SliceScores {
+            holdout: ExampleSeries::from_pairs((0..8).map(|i| (format!("h{i}"), v))),
+            public: ExampleSeries::from_pairs((0..8).map(|i| (format!("p{i}"), v))),
+            perturbed: ExampleSeries::from_pairs((0..8).map(|i| (format!("x{i}"), v))),
+            canaries: ExampleSeries::from_pairs((0..8).map(|i| (format!("c{i}"), 0.99))),
+            general_canary: ExampleSeries::from_pairs((0..8).map(|i| (format!("g{i}"), 0.97))),
+            agent_trace: 0.9,
+            ..SliceScores::default()
+        }
+    }
+
+    fn row(state: SubmissionState, verdict: Option<PromoteVerdict>) -> Submission {
+        Submission {
+            id: String::new(),
+            miner_hotkey: "00".repeat(32),
+            artifact_digest: "11".repeat(32),
+            artifact_uri: None,
+            manifest: ArtifactManifest::default(),
+            nonce: "aa".into(),
+            submission_digest: "bb".repeat(32),
+            state,
+            receipt_json: None,
+            verdict,
+            detail: None,
+        }
+    }
 
     #[test]
     fn digest_stable_and_distinct() {
         let a = freeze_submission_digest("aa", "bb", "n1");
-        let b = freeze_submission_digest("aa", "bb", "n1");
-        let c = freeze_submission_digest("aa", "bb", "n2");
-        assert_eq!(a, b);
-        assert_ne!(a, c);
+        assert_eq!(a, freeze_submission_digest("aa", "bb", "n1"));
+        assert_ne!(a, freeze_submission_digest("aa", "bb", "n2"));
         assert_eq!(a.len(), 64);
     }
 
     #[test]
-    fn holdout_stays_sealed_in_public_view() {
-        let h = sealed_holdout(7, "deadbeef");
-        assert!(!h.unsealed);
-        assert!(!h.seed_hex.is_empty());
-        let pub_v = public_holdout(&h);
-        assert!(pub_v.seed_hex.is_empty());
-        let open = unseal_holdout(&h, "deadbeef").expect("unseal");
-        assert!(open.unsealed);
-        assert!(!open.seed_hex.is_empty());
+    fn holdout_loads_only_when_it_matches_the_commitment() {
+        let st = seeded_store();
+        assert!(!st.holdout_seal().expect("seal").loaded);
+
+        let mut tampered = items();
+        tampered[0].prompt = "leaked".into();
+        assert!(st.load_holdout(tampered, &[], &[]).is_err());
+        assert!(!st.holdout_seal().expect("seal").loaded);
+
+        st.load_holdout(items(), &[], &[]).expect("verified load");
+        assert!(st.holdout_seal().expect("seal").loaded);
+    }
+
+    #[test]
+    fn seal_never_exposes_item_ids_or_prompts() {
+        let st = seeded_store();
+        st.load_holdout(items(), &[], &[]).expect("load");
+        let seal = st.holdout_seal().expect("seal");
+        let json = serde_json::to_string(&seal).expect("json");
+        assert!(!json.contains("holdout prompt"));
+        assert!(!json.contains("prompt"));
+        assert!(json.contains("commitment"));
+        assert_eq!(seal.size, 4);
+        assert!(seal.loaded);
+    }
+
+    #[test]
+    fn unseal_requires_a_frozen_digest_and_loaded_records() {
+        let st = seeded_store();
+        assert!(st.unseal_holdout("deadbeef").is_err());
+        st.load_holdout(items(), &[], &[]).expect("load");
+        assert!(st.unseal_holdout("").is_err());
+        assert_eq!(st.unseal_holdout("deadbeef").expect("unseal").len(), 4);
     }
 
     #[test]
     fn promote_refuses_ineligible() {
         let st = MemoryStore::new();
         let row = st
-            .insert(Submission {
-                id: String::new(),
-                miner_hotkey: "00".repeat(32),
-                artifact_digest: "11".repeat(32),
-                artifact_uri: None,
-                nonce: "aa".into(),
-                submission_digest: "bb".repeat(32),
-                state: SubmissionState::AwaitingAdmin,
-                receipt_json: None,
-                verdict: None,
-                detail: None,
-            })
+            .insert(row(SubmissionState::AwaitingAdmin, None))
             .expect("insert");
         assert!(st.promote(&row.id).is_err());
     }
 
     #[test]
     fn champion_scores_follow_promote_not_base() {
-        use prism_competition::ExampleSeries;
-        use relearn_score::SliceScores;
-
-        fn series(prefix: &str, n: usize, val: f64) -> ExampleSeries {
-            ExampleSeries::from_pairs((0..n).map(|i| (format!("{prefix}{i}"), val)))
-        }
-        fn slice(v: f64) -> SliceScores {
-            SliceScores {
-                holdout: series("h", 8, v),
-                public: series("p", 8, v),
-                perturbed: series("x", 8, v),
-                canaries: series("c", 8, v),
-                agent_trace: 0.9,
-            }
-        }
-
         let st = MemoryStore::new();
         st.set_base_champion(slice(0.4)).expect("base");
         let row = st
-            .insert(Submission {
-                id: String::new(),
-                miner_hotkey: "00".repeat(32),
-                artifact_digest: "11".repeat(32),
-                artifact_uri: None,
-                nonce: "aa".into(),
-                submission_digest: "bb".repeat(32),
-                state: SubmissionState::AwaitingAdmin,
-                receipt_json: None,
-                verdict: Some(relearn_score::PromoteVerdict {
+            .insert(row(
+                SubmissionState::AwaitingAdmin,
+                Some(PromoteVerdict {
                     eligible: true,
                     paired: None,
                     failed: Vec::new(),
                     lattice: 12,
                 }),
-                detail: None,
-            })
+            ))
             .expect("insert");
         st.record_scores(&row.id, slice(0.8)).expect("scores");
         st.promote(&row.id).expect("promote");
         let got = st.champion_scores().expect("read").expect("some");
         assert!((SliceScores::mean(&got.holdout).unwrap_or(0.0) - 0.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn slice_ids_track_epoch_and_commitment() {
+        let a = holdout_slice_id(3, "aa");
+        assert_eq!(a, holdout_slice_id(3, "aa"));
+        assert_ne!(a, holdout_slice_id(4, "aa"));
+        assert_ne!(a, holdout_slice_id(3, "bb"));
     }
 }

--- a/deploy/env/relearn-challenge.env.example
+++ b/deploy/env/relearn-challenge.env.example
@@ -12,5 +12,13 @@ RELEARN_TEACHER_API_URL=
 RELEARN_TEACHER_MODEL=
 RELEARN_TEACHER_API_KEY=
 
+# Frozen holdout records. Never commit. Verified at boot against
+# holdout_commitment in config/relearn-pin.toml. Missing/mismatch → 503.
+# RELEARN_HOLDOUT_FILE=/run/base/relearn/holdout.json
+#
+#   cargo run -p xtask -- relearn-holdout --catalog <catalog.json> \
+#     --salt "$RELEARN_HOLDOUT_SALT" --size 120 --exclude <each public id> \
+#     --out deploy/secrets/relearn/holdout.json
+
 # Operator bearer tokens for POST /v1/admin/promote.
 # RELEARN_ADMIN_TOKENS_FILE=/run/base/relearn/admin_tokens

--- a/deploy/scripts/local-e2e.sh
+++ b/deploy/scripts/local-e2e.sh
@@ -367,15 +367,48 @@ ensure_secrets() {
   [[ -e deploy/secrets/bounty/session_secret ]] || dd if=/dev/urandom bs=32 count=1 status=none of=deploy/secrets/bounty/session_secret
   # Relearn T2I refuses submissions without holdout records matching the pin
   # commitment. Local smoke materializes them from the documented dev salt.
+  ensure_relearn_holdout
   ensure_t2i_holdout
   local guarded=(deploy/secrets/bounty/session_secret)
   for area in relearn relearn-t2i relearn-mm bounty; do
     guarded+=("deploy/secrets/$area/admin_tokens")
   done
+  [[ -e deploy/secrets/relearn/holdout.json ]] \
+    && guarded+=(deploy/secrets/relearn/holdout.json)
   [[ -e deploy/secrets/relearn-t2i/holdout.json ]] \
     && guarded+=(deploy/secrets/relearn-t2i/holdout.json)
   chown 65532:65532 "${guarded[@]}" 2>/dev/null || true
   chmod 0400 "${guarded[@]}" 2>/dev/null || true
+}
+
+# Materialize Relearn holdout records for a local run from the synthetic
+# catalog + local salt (never the T2I/dev salt). Matches the committed pin.
+ensure_relearn_holdout() {
+  [[ -s deploy/secrets/relearn/holdout.json ]] && return 0
+  mkdir -p deploy/secrets/relearn
+  local -a excludes=()
+  local id
+  while read -r id; do
+    excludes+=(--exclude "$id")
+  done < <(relearn_public_ids)
+  log "generating relearn holdout records (synthetic catalog, local salt)"
+  cargo run -q -p xtask -- relearn-holdout \
+    --synthetic \
+    --salt "${RELEARN_HOLDOUT_SALT:-cortex-relearn-dev-holdout-v0}" \
+    --size 120 \
+    "${excludes[@]}" \
+    --out "$ROOT/deploy/secrets/relearn/holdout.json"
+}
+
+# Public item ids from the committed Relearn pin, one per line.
+relearn_public_ids() {
+  python3 -c '
+import sys, tomllib
+from pathlib import Path
+doc = tomllib.loads(Path(sys.argv[1]).read_text())
+for i in doc.get("public_ids", []):
+    print(i)
+' "$ROOT/config/relearn-pin.toml"
 }
 
 # Materialize Relearn T2I holdout prompt records for a local run.

--- a/deploy/secrets/README.md
+++ b/deploy/secrets/README.md
@@ -37,9 +37,31 @@ Local dummy for development: decrypt with age:
 
 | Path | Used by | Notes |
 |------|---------|-------|
+| `relearn/holdout.json` | relearn-challenge | Frozen holdout items. **Never commit.** Verified at boot against `holdout_commitment` in `config/relearn-pin.toml`; a mismatch means submissions answer **503**. Mode **0400**, uid **65532** |
 | `relearn-t2i/holdout.json` | relearn-t2i-challenge | Frozen holdout prompt records. **Never commit.** Verified at boot against `holdout_commitment` in `config/relearn-t2i-pin.toml`; a mismatch means submissions answer **503** rather than falling back to the public split. Mode **0400**, uid **65532** |
 | `relearn-t2i/admin_tokens` | relearn-t2i-challenge | One operator bearer per line for `POST /v1/admin/promote` |
 | `relearn-mm/admin_tokens` | relearn-mm-challenge | One operator bearer per line for `POST /v1/admin/promote` |
+
+Regenerate the Relearn holdout with a **private** salt (never the T2I/dev salt
+and never a salt that is committed to git):
+
+```bash
+mkdir -p deploy/secrets/relearn
+mapfile -t EXCLUDE < <(python3 -c '
+import tomllib
+from pathlib import Path
+doc = tomllib.loads(Path("config/relearn-pin.toml").read_text())
+for i in doc.get("public_ids", []):
+    print(f"--exclude={i}")
+')
+cargo run -p xtask -- relearn-holdout \
+  --catalog ~/.base-secrets/relearn-catalog.json \
+  --salt "$RELEARN_HOLDOUT_SALT" \
+  --size 120 "${EXCLUDE[@]}" \
+  --out deploy/secrets/relearn/holdout.json
+# Paste the printed holdout_commitment into config/relearn-pin.toml and
+# re-sign the trust root (config/CEREMONY.md).
+```
 
 Regenerate the T2I holdout with the private salt (keep the salt off git — it is
 what makes the holdout unguessable):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,7 @@ services:
       RELEARN_TEACHER_BACKEND: "${RELEARN_TEACHER_BACKEND:-http_api}"
       RELEARN_TEACHER_API_URL: "${RELEARN_TEACHER_API_URL:-}"
       RELEARN_TEACHER_MODEL: "${RELEARN_TEACHER_MODEL:-}"
+      RELEARN_HOLDOUT_FILE: /run/base/relearn/holdout.json
       RELEARN_ADMIN_TOKENS_FILE: /run/base/relearn/admin_tokens
       BASE_CHALLENGE_GATEWAY_ENDPOINT: ${BASE_CHALLENGE_GATEWAY_ENDPOINT:-http://gateway:8080}
     env_file:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,7 @@ Runbooks: [`runbooks/`](./runbooks/).
 |----------------|------|
 | `gateway` | Master-only: registry, reverse proxy, bundle seal/serve, sole TLS owner; mounts marketing [`SITE_API.md`](./SITE_API.md) (`GET /v1/site/*`) |
 | `validator` | Fetch/mirror bundle, verify, recompute, peer cross-check, CRV4 submit, dissent |
-| `relearn-challenge` | **Master-only:** digest freeze, holdout unseal, Lium/sim eval, operator promote, sign leaves |
+| `relearn-challenge` | **Master-only:** digest freeze, operator holdout unseal (commitment-checked), Lium/sim eval, contamination / public–holdout / canary / shuffle gates, operator promote, sign leaves |
 | `relearn-t2i-challenge` | **Master-only:** frozen prompt cells at pinned seeds, Q-Judger scoring, pillar / replay / contamination gates, sign leaves |
 | `relearn-mm-challenge` | **Master-only:** text-intact rerun (hard gate), vision + agentic holdout with a pixel-shuffle control, sign leaves |
 | `bounty-challenge` | **Master-only:** internal pair/reports/adjudicate; **reads** CortexLM/backend public API for scoring; sign leaves |

--- a/docs/COMPLETENESS.md
+++ b/docs/COMPLETENESS.md
@@ -53,10 +53,11 @@ Removed as **live products**. Shared rails (`prism-lium*`, `prism-competition` p
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Crates (`crates/relearn-*`) | **done** | task, score, store, eval, http, challenge. |
+| Crates (`crates/relearn-*`) | **done** | task (holdout commitment + contamination fingerprints), score (public–holdout gap, contamination, vision shuffle, off-path general-bench canary), store, eval, http, challenge. |
 | Binary (`bins/relearn-challenge`) | **done** | HTTP API on `:8095`. |
 | Compose / images | **done** | Default compose + `images.yml` target `relearn-challenge`. |
 | Eval pin | **v0** | `config/relearn-pin.toml` — digest + `CortexLM/relearn` SHA empty until first green challenge CI. |
+| Holdout | **done** | Commitment in git, records operator-side (`RELEARN_HOLDOUT_FILE`) and verified at boot. Mismatch → submissions 503. |
 | Teacher | **v0** | HTTP API from operator env (`RELEARN_TEACHER_API_URL`, `RELEARN_TEACHER_MODEL`, `RELEARN_TEACHER_API_KEY`). Missing URL/key → sim. Judge-only; miner weights never served via that API. |
 | Emission | **4000 bps** | Default share (sum across all four challenges is `10000`). |
 | Spec | live | [`RELEARN.md`](RELEARN.md). |
@@ -157,6 +158,7 @@ Agent/operator contracts: root [`AGENTS.md`](../AGENTS.md), [`deploy/AGENTS.md`]
 | DCAP error classification | Matches on `anyhow` message text; re-run `cargo test -p attest-policy --features dcap` after any `dcap-qvl` bump. |
 | Relearn eval image digests | Empty until `CortexLM/relearn` CI publishes digest-pinned `relearn-eval`, `relearn-t2i-eval`, and `relearn-mm-eval` images. Live Lium rent is refused until then. |
 | Relearn T2I holdout salt | The committed `holdout_commitment` uses the documented **dev** salt so local and staging work out of the box. Production must rotate to a private salt, replace the commitment, and re-sign. |
+| Relearn holdout salt | The committed `holdout_commitment` uses the local salt `cortex-relearn-dev-holdout-v0` (not the T2I/dev salt) over a synthetic catalog so CI can boot. Production must rotate to a private salt **and** a private catalog, replace the commitment, and re-sign. |
 | Relearn Multimodal champion LM hash | `RELEARN_MM_CHAMPION_LM_HASH` is operator-supplied. Unset means encoder-only submissions are rejected (they cannot prove the LM is unchanged). |
 | Relearn public repo | [`CortexLM/relearn`](https://github.com/CortexLM/relearn) exists; this repo pins `relearn_git_sha`. Seed mirror: `docs/external-miner/relearn-seed/`. |
 | Mainnet (netuid 100) | Owner wallet not yet on this machine, so prod runs with `BASE_GATEWAY_REQUIRE_OWNER=0`. |

--- a/docs/RELEARN.md
+++ b/docs/RELEARN.md
@@ -22,3 +22,34 @@ This repo pins them in `config/relearn-pin.toml`.
 
 Miner pays Lium (`LIUM_API_KEY` / `X-Lium-Api-Key`). Operator promote is
 `POST /v1/admin/promote`. Epoch emit is champion lattice; others `NoScore` (D24).
+
+## Holdout and anti-overfit gates
+
+The holdout is **not** in git. `config/relearn-pin.toml` carries only
+`holdout_commitment` and `holdout_size`. Records come from
+`RELEARN_HOLDOUT_FILE` and are verified at boot; a missing or mismatched file
+means submissions answer **503** rather than scoring a reconstructable seed
+or the public split.
+
+Promotion requires every gate:
+
+| Gate | Rule |
+|------|------|
+| Holdout displacement | Bootstrap paired test on the private split (the only series that may enter the lattice) |
+| Public–holdout gap | Public far above holdout signals memorization; empty public is fail-closed |
+| Contamination | Any holdout id / image hash in submitted training metadata rejects the run |
+| Pixel shuffle | Every vision family present in the holdout (caption / VQA / OCR / spatial) must drop ≥ `MIN_SHUFFLE_DROP` when pixels are shuffled |
+| General-bench canary | MMLU / MMMU-style slice is **off** the visible score. Regression past `CANARY_EPSILON` vs the champion is a hard zero |
+| Perturbation / base canaries / agent-trace | Existing retention floors still apply |
+
+```bash
+# Rotate the holdout (records never enter git). Never reuse the T2I/dev salt.
+cargo run -p xtask -- relearn-holdout \
+  --catalog ~/.base-secrets/relearn-catalog.json \
+  --salt "$RELEARN_HOLDOUT_SALT" --size 120 \
+  --exclude 1 --exclude 2 … \
+  --out deploy/secrets/relearn/holdout.json
+```
+
+Paste the printed `holdout_commitment` into `config/relearn-pin.toml`, then
+re-sign the trust root ([`../config/CEREMONY.md`](../config/CEREMONY.md)).

--- a/docs/external-miner/relearn.md
+++ b/docs/external-miner/relearn.md
@@ -12,6 +12,20 @@ Teacher is an HTTP API. The operator sets `RELEARN_TEACHER_API_URL`,
 `RELEARN_TEACHER_MODEL`, and `RELEARN_TEACHER_API_KEY` on the host. You
 do not.
 
+## How you are scored
+
+You are judged against the live champion on a **private** holdout. The public
+ids on `GET /challenge/relearn/v1/status` are the only split you may train on.
+The holdout commitment and size are published; the items are not.
+
+| Gate | What it means for you |
+|------|----------------------|
+| **Holdout win** | Paired win on the private split. This is the only number that can become lattice |
+| **Public–holdout gap** | A huge public score with a flat holdout is rejected as overfitting |
+| **No contamination** | If a holdout item id or image hash shows up in `manifest.train_*`, the run is rejected |
+| **Pixel shuffle** | Vision families (caption / VQA / OCR / spatial) must get worse when pixels are shuffled |
+| **General benches** | MMLU / MMMU-style canaries are **not** in the visible score. A drop past ε vs the champion zeros the run |
+
 ## Submit
 
 ```bash
@@ -21,7 +35,12 @@ curl -sS -X POST https://<gateway>/challenge/relearn/v1/submissions \
   -d '{
     "miner_hotkey": "<64-hex hotkey>",
     "artifact_digest": "<sha256 of your artifact>",
-    "artifact_uri": "optional-url"
+    "artifact_uri": "optional-url",
+    "manifest": {
+      "train_item_ids": [],
+      "train_image_hashes": [],
+      "train_dataset_ids": []
+    }
   }'
 ```
 

--- a/docs/external-miner/troubleshoot.md
+++ b/docs/external-miner/troubleshoot.md
@@ -12,6 +12,10 @@
 | `awaiting_admin` but no weights | Operator has not promoted | `POST /v1/admin/promote` is operator-only |
 | `rejected` with `Regression` | Challenger did not displace the champion | Improve the artifact; regressions are never crowned |
 | `rejected` with `PublicPrivateGap` | Overfit / contamination | Public-private gap exceeded the gate |
+| `rejected` with `Contamination` | Training metadata overlapped the holdout | Drop holdout ids / image hashes from `manifest.train_*` |
+| `rejected` with `CanaryRegression` | General-bench drop past ε | Off-path MMLU/MMMU canary; not in the visible score |
+| `rejected` with `IgnoresTheImage` | Pixel-shuffle control | Vision family scored the same on shuffled pixels |
+| `503` on submit | Holdout file missing or mismatched | Operator: `RELEARN_HOLDOUT_FILE` must match the pin commitment |
 | `rejected` with `Canaries` | Catastrophic forgetting | Base-model canaries must stay ≥ 0.95 |
 | Live Lium skipped | No `eval_image_digest` pin or no `X-Lium-Api-Key` | Cortex refuses rent until relearn CI publishes a digest; sim still scores |
 | Teacher 4xx | Miner weights sent to the judge API | Teacher is judge-only; never the scored artifact |

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,6 +19,7 @@ frame-metadata = { version = "16", features = ["std", "decode"] }
 hex = "0.4"
 parity-scale-codec = { version = "3.7", features = ["derive"] }
 regex = "1.11"
+relearn-challenge-task = { path = "../crates/relearn-challenge-task" }
 relearn-t2i-task = { path = "../crates/relearn-t2i-task" }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls-native-roots"] }
 scale-info = { version = "2.11", default-features = false, features = ["std"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@
 //! - `design-check` — fail if `docs/DESIGN_CHALLENGE.md` is missing freeze pins
 //! - `external-docs-check` — fail if external miner docs `protocol_version` ≠ bundle, or D19 drifts
 //! - `relearn-t2i-holdout` — select a Relearn T2I holdout slice and print its commitment
+//! - `relearn-holdout` — select a Relearn holdout slice and print its commitment
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 mod consensus_lint;
@@ -17,6 +18,7 @@ mod external_docs_check;
 mod loc_cap;
 mod metadata_snapshot;
 mod natural_pack;
+mod relearn_holdout;
 mod spec_check;
 mod t2i_holdout;
 
@@ -88,6 +90,30 @@ enum Command {
     DesignCheck,
     /// Fail if external miner docs `protocol_version` differs from `bundle`, or `THREAT_MODEL` D19 drifts.
     ExternalDocsCheck,
+    /// Select a Relearn holdout slice and print its pin commitment.
+    ///
+    /// Item ids are never printed. Production salts stay off git. Refuses the
+    /// documented T2I/dev salt.
+    RelearnHoldout {
+        /// Operator catalog JSON (array of holdout items).
+        #[arg(long)]
+        catalog: Option<PathBuf>,
+        /// Selection salt. Never reuse the T2I/dev salt.
+        #[arg(long)]
+        salt: String,
+        /// Holdout item count.
+        #[arg(long, default_value_t = 120)]
+        size: usize,
+        /// Item ids published in the pin's public split (repeatable).
+        #[arg(long = "exclude")]
+        exclude: Vec<u32>,
+        /// Build a local-only synthetic catalog.
+        #[arg(long)]
+        synthetic: bool,
+        /// Write records here (outside the repo, mode 0600).
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Select a Relearn T2I holdout slice and print its pin commitment.
     ///
     /// Prompt ids are never printed. Production salts stay off git.
@@ -172,6 +198,21 @@ fn main() -> ExitCode {
         Command::SpecCheck => spec_check::run(&root),
         Command::DesignCheck => design_check::run(&root),
         Command::ExternalDocsCheck => external_docs_check::run(&root),
+        Command::RelearnHoldout {
+            catalog,
+            salt,
+            size,
+            exclude,
+            synthetic,
+            out,
+        } => relearn_holdout::run(&relearn_holdout::HoldoutArgs {
+            catalog,
+            salt,
+            size,
+            exclude,
+            synthetic,
+            out,
+        }),
         Command::RelearnT2iHoldout {
             bench,
             salt,

--- a/xtask/src/relearn_holdout.rs
+++ b/xtask/src/relearn_holdout.rs
@@ -1,0 +1,206 @@
+//! Relearn holdout ceremony helper.
+//!
+//! Selects a holdout slice from an operator catalog (or a local synthetic
+//! catalog), writes the frozen records to an operator file, and prints the
+//! commitment that belongs in `config/relearn-pin.toml`.
+//!
+//! The records never enter git. The commitment does. Production salts and
+//! catalogs stay off git — a documented salt plus a public catalog would let
+//! miners reconstruct the scored split.
+//!
+//! Selection is `sha256(domain || salt || id)`, lowest digests first. The
+//! domain and salt are distinct from the T2I ceremony.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use relearn_challenge_task::{holdout_commitment, HoldoutItem, HoldoutTask};
+use sha2::{Digest, Sha256};
+
+/// Domain tag for holdout selection. Distinct from T2I and from the commitment domain.
+const SELECT_DOMAIN: &[u8] = b"base-relearn-holdout-select-v1";
+
+/// Arguments for the holdout ceremony.
+#[derive(Debug)]
+pub struct HoldoutArgs {
+    /// Catalog JSON array of [`HoldoutItem`]. Ignored when `synthetic` is set.
+    pub catalog: Option<PathBuf>,
+    /// Selection salt. Dev salts are local-only; production salts stay off git.
+    pub salt: String,
+    /// Holdout item count.
+    pub size: usize,
+    /// Item ids already published in the pin's public split.
+    pub exclude: Vec<u32>,
+    /// Build a local-only synthetic catalog (never a production source).
+    pub synthetic: bool,
+    /// Where to write the records (never inside the repo).
+    pub out: Option<PathBuf>,
+}
+
+/// Run the ceremony helper.
+///
+/// # Errors
+///
+/// Empty salt, a missing catalog, or a size the catalog cannot satisfy.
+pub fn run(args: &HoldoutArgs) -> Result<(), String> {
+    if args.salt.trim().is_empty() {
+        return Err("--salt must not be empty".into());
+    }
+    if args.salt.trim() == "cortex-t2i-dev-holdout-v0" {
+        return Err("refusing the documented T2I/dev salt; use a Relearn-specific salt".into());
+    }
+    let rows = if args.synthetic {
+        synthetic_catalog()
+    } else {
+        let path = args
+            .catalog
+            .as_ref()
+            .ok_or("--catalog is required unless --synthetic")?;
+        read_catalog(path)?
+    };
+    let excluded: BTreeSet<u32> = args.exclude.iter().copied().collect();
+    let records = select(&rows, &args.salt, args.size, &excluded)?;
+    let commitment = holdout_commitment(&records);
+
+    if let Some(out) = &args.out {
+        refuse_repo_path(out)?;
+        let body = serde_json::to_string_pretty(&records)
+            .map_err(|e| format!("serialize records: {e}"))?;
+        if let Some(parent) = out.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+        }
+        fs::write(out, format!("{body}\n")).map_err(|e| format!("write {}: {e}", out.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(out, fs::Permissions::from_mode(0o600));
+        }
+        println!(
+            "wrote {} holdout records to {}",
+            records.len(),
+            out.display()
+        );
+    }
+
+    println!("holdout_size = {}", records.len());
+    println!("holdout_commitment = \"{commitment}\"");
+    Ok(())
+}
+
+fn refuse_repo_path(out: &Path) -> Result<(), String> {
+    let text = out.to_string_lossy();
+    if text.contains("/config/") || text.starts_with("config/") || text.contains("/docs/") {
+        return Err(format!(
+            "refusing to write holdout records under a tracked path: {text}"
+        ));
+    }
+    Ok(())
+}
+
+fn read_catalog(path: &Path) -> Result<Vec<HoldoutItem>, String> {
+    let body = fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_str(&body).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+/// Local/CI catalog. Production must use a private operator catalog.
+fn synthetic_catalog() -> Vec<HoldoutItem> {
+    (1..=200)
+        .map(|id| {
+            let (task, image_hash) = match id % 5 {
+                1 => (HoldoutTask::Captioning, format!("{:064x}", id + 10_000)),
+                2 => (HoldoutTask::Vqa, format!("{:064x}", id + 20_000)),
+                3 => (HoldoutTask::Ocr, format!("{:064x}", id + 30_000)),
+                4 => (HoldoutTask::Spatial, format!("{:064x}", id + 40_000)),
+                _ => (HoldoutTask::Text, String::new()),
+            };
+            HoldoutItem {
+                id,
+                prompt: format!(
+                    "synthetic relearn item {id} describing a unique scene for family {}",
+                    task.as_str()
+                ),
+                dataset_id: "synthetic-dev".into(),
+                task,
+                image_hash,
+            }
+        })
+        .collect()
+}
+
+fn select(
+    rows: &[HoldoutItem],
+    salt: &str,
+    size: usize,
+    excluded: &BTreeSet<u32>,
+) -> Result<Vec<HoldoutItem>, String> {
+    let mut ranked: Vec<([u8; 32], HoldoutItem)> = rows
+        .iter()
+        .filter(|r| !excluded.contains(&r.id) && !r.prompt.trim().is_empty())
+        .map(|r| (rank(salt, r.id), r.clone()))
+        .collect();
+    if ranked.len() < size {
+        return Err(format!(
+            "catalog has {} eligible items after exclusions, need {size}",
+            ranked.len()
+        ));
+    }
+    ranked.sort_unstable_by(|a, b| a.0.cmp(&b.0).then(a.1.id.cmp(&b.1.id)));
+    let mut out: Vec<HoldoutItem> = ranked.into_iter().take(size).map(|(_, r)| r).collect();
+    out.sort_by_key(|r| r.id);
+    Ok(out)
+}
+
+fn rank(salt: &str, id: u32) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(SELECT_DOMAIN);
+    h.update([0xff]);
+    h.update(salt.as_bytes());
+    h.update([0xff]);
+    h.update(id.to_le_bytes());
+    h.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selection_is_deterministic_per_salt() {
+        let rows = synthetic_catalog();
+        let a = select(&rows, "salt-a", 10, &BTreeSet::new()).expect("a");
+        let b = select(&rows, "salt-a", 10, &BTreeSet::new()).expect("b");
+        let c = select(&rows, "salt-b", 10, &BTreeSet::new()).expect("c");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a.len(), 10);
+    }
+
+    #[test]
+    fn selection_honors_exclusions() {
+        let rows = synthetic_catalog();
+        let all: BTreeSet<u32> = (1..=190).collect();
+        let picked = select(&rows, "salt", 10, &all).expect("picked");
+        assert!(picked.iter().all(|r| r.id > 190));
+    }
+
+    #[test]
+    fn refuses_the_t2i_dev_salt() {
+        let err = run(&HoldoutArgs {
+            catalog: None,
+            salt: "cortex-t2i-dev-holdout-v0".into(),
+            size: 10,
+            exclude: Vec::new(),
+            synthetic: true,
+            out: None,
+        })
+        .expect_err("t2i salt");
+        assert!(err.contains("T2I"), "{err}");
+    }
+
+    #[test]
+    fn tracked_output_paths_are_refused() {
+        assert!(refuse_repo_path(Path::new("config/holdout.json")).is_err());
+        refuse_repo_path(Path::new("/root/.base-secrets/relearn-holdout.json")).expect("ok");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Locks the live **Relearn LLM** (`relearn`) pin/score path — not encoder-MM, T2I, or Bounty. Model ids in `config/relearn-pin.toml` are left as Développeur set them (`Qwen/Qwen3.8-Flash-Next` / `kimi-k3`). `challenges.toml` emission is untouched.

Git now carries only `holdout_commitment` + `holdout_size` + `public_ids`. Records load from `RELEARN_HOLDOUT_FILE` and are verified at boot. Missing or mismatched file → submissions **503**. The reconstructable `sha256(HOLDOUT_DOMAIN ‖ epoch ‖ digest)` seed is gone.

## Exploit report (five holes)

### 1. `holdout_commitment` missing / reconstructable — **confirmed, closed**

**Before:** no commitment in the pin. The scored split was `sha256(HOLDOUT_DOMAIN ‖ epoch ‖ digest)` with domain `base-relearn-holdout-v1` in git. Anyone with the pin + epoch could regenerate the sim scores and train on the exact items.

**Now:**
- Pin requires a 64-hex `holdout_commitment` and `holdout_size ≥ 100`.
- Operator file (`RELEARN_HOLDOUT_FILE` → `/run/base/relearn/holdout.json`) is the only source of records.
- Load verifies size, public-id exclusion, near-duplicates, and the digest. Failure stores nothing.
- HTTP unseal before eval; no file / mismatch → **503**, not a public-split fallback.
- Ceremony: `cargo run -p xtask -- relearn-holdout`. Refuses the documented T2I salt `cortex-t2i-dev-holdout-v0`. Local/CI salt is `cortex-relearn-dev-holdout-v0` over a synthetic catalog. **Production must rotate salt + catalog** and re-sign.

### 2. Public split unused by the judge — **partially discarded, remainder closed**

**Honest disagreement:** `judge_challenger` already compared `challenger.public` vs holdout (`PublicPrivateGap`, 0.08). The HTTP `public_holdout` view was a stripped seed, not the unused-judge story.

**What was still broken:** empty public **silently skipped** the gap. No committed `public_ids`. Sim public used the same reconstructable seed.

**Now:** empty public is `PublicEvidenceMissing` (fail-closed). Pin publishes `public_ids = 1..=40`. Status publishes the seal + those ids only — never holdout prompts or image hashes. Sim public uses a salt that does not include holdout prompts.

### 3. Contamination + public–holdout gap — **gap existed; contamination did not**

**Honest disagreement:** the 0.08 public–holdout gap was already a gate.

**Missing:**
- train-metadata ∩ holdout fingerprints
- public↔holdout near-dupes (id / image-hash / dataset+id / prompt 3-gram Jaccard > 0.80)

**Now:** `Contamination` rejects any holdout id or image hash in `manifest.train_*`. `verify_holdout_items` refuses public-id overlap and near-duplicates at load. Gap remains; empty public no longer skips it.

### 4. Pixel-shuffle only on a subset of vision tasks — **N/A then; applied now if images exist**

Relearn LLM scoring was text-only. The live base is a native VLM, so holdout items may carry images (`captioning` / `vqa` / `ocr` / `spatial`).

**Now:** every **vision family present** in the holdout must drop ≥ `MIN_SHUFFLE_DROP` (0.10) when pixels are shuffled (`IgnoresTheImage { task }`). Text-only holdout skips the gate. Shuffle never enters the lattice.

### 5. General-bench canary on the visible score — **incomplete, closed**

Existing `canaries` were a 0.95 floor, skipped if empty, not champion-relative, not MMLU/MMMU. Lattice already excluded them (good).

**Now:** `general_canary` is a separate series, **off** the lattice. Regression vs champion past `CANARY_EPSILON = 0.02` is `CanaryRegression` → lattice 0. Missing evidence is `CanaryEvidenceMissing`. Noise inside ε is tolerated.

## What a miner could reconstruct before

1. Read `HOLDOUT_DOMAIN` from git.
2. Compute `sha256(domain ‖ epoch ‖ digest)` for the current epoch.
3. Replay `sim_slice_scores` (or the live seed) and train on that exact split.
4. Submit a digest that wins the paired test on the reconstructed items.
5. Skip contamination (there was none) and skip public evidence (empty public was ignored).

That path is gone. The scored records are not in git and are not derivable from the pin without the operator salt + catalog.

## What this PR does **not** do

- Does not edit `relearn-mm-*`, T2I, Bounty, or `challenges.toml`.
- Does not recale `base_model` / `teacher_model` / `BASE_MODEL_ID`.
- Does not commit holdout JSON, Modal tokens, teacher hosts, or the T2I salt.
- Does not treat the local/CI commitment as a production seal. Rotate before live.

## Test plan

- [x] Focused crate tests: contamination cannot promote; 503 without holdout; public gap / empty public; canary regression = lattice 0; shuffle on all four vision families; text-only skips shuffle; commitment mismatch not loaded; seal leaks no prompts; committed pin has 64-hex commitment and no T2I salt / secrets
- [x] `cargo test -p relearn-score -p relearn-store -p relearn-eval -p relearn-http -p relearn-challenge-task -p relearn-challenge -p xtask` (101 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p relearn-score -p relearn-store -p relearn-eval -p relearn-http -p relearn-challenge-task -p relearn-challenge -p xtask --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- loc-cap`
- [x] `cargo run -p xtask -- external-docs-check`

## Risk

- **Deploy:** `RELEARN_HOLDOUT_FILE` must be present and match the pin or miners get 503. Local e2e materializes the synthetic split. Production must rotate salt + catalog and re-sign.
- **Emission:** lattice still holdout-only. New gates can only zero a run. `challenges.toml` unchanged.
- **Domains:** `base-relearn-holdout-v1` stays as the commitment domain tag (not a seed). Selection uses `base-relearn-holdout-select-v1`. No `BASE_*` renames.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae254efd-e93d-49f3-ba4d-329dd38e893c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae254efd-e93d-49f3-ba4d-329dd38e893c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

