### PR TITLE
fix(bounty): refuse a stable torn leaderboard/reports pair

### DIFF
--- a/crates/bounty-challenge/Cargo.toml
+++ b/crates/bounty-challenge/Cargo.toml
@@ -18,6 +18,7 @@ chain = { path = "../chain" }
 challenge-common = { path = "../challenge-common" }
 hex = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"

--- a/crates/bounty-challenge/src/backend.rs
+++ b/crates/bounty-challenge/src/backend.rs
@@ -14,10 +14,13 @@
 //! under-count a miner's valid rows or drop it to `NotAttempted`, while
 //! `/leaderboard` sets the champion walk order. The pair is therefore read
 //! until two consecutive reads agree, and a feed that never holds still is an
-//! error rather than a guess.
+//! error rather than a guess. Consecutive equals are not enough on their own:
+//! a host that always serves leaderboard A beside reports B would agree with
+//! itself. `valid_count` on each leaderboard row must match the `valid`
+//! reports for that hotkey, or the pair is refused.
 
 use bounty_challenge_task::backend_public_url;
-use bounty_score::{parse_leaderboard, parse_reports, PublicSnapshot};
+use bounty_score::{parse_leaderboard, parse_reports, snapshot_halves_agree, PublicSnapshot};
 use thiserror::Error;
 
 /// Fetch / parse errors. Never embed secrets or hosts from env into Display
@@ -37,6 +40,11 @@ pub enum BackendError {
     /// revision could be pinned.
     #[error("backend public feed changed under every read")]
     Inconsistent,
+    /// Leaderboard `valid_count` does not match the `valid` reports. A feed
+    /// that always serves one revision on `/leaderboard` and another on
+    /// `/reports` is stable under re-read and must still be refused.
+    #[error("backend public leaderboard and reports do not agree")]
+    Mismatched,
 }
 
 /// How many times one call re-reads the pair of routes looking for two
@@ -58,9 +66,10 @@ pub fn public_path(base: &str, tail: &str) -> String {
 /// # Errors
 /// [`BackendError::Unset`] when neither the argument nor the env carries a
 /// base URL, [`BackendError::Fetch`] on transport or non-2xx,
-/// [`BackendError::Json`] when a body does not match the public DTO, and
-/// [`BackendError::Inconsistent`] when the feed never held still long enough
-/// to read both routes at one revision.
+/// [`BackendError::Json`] when a body does not match the public DTO,
+/// [`BackendError::Mismatched`] when the two routes describe different
+/// publications, and [`BackendError::Inconsistent`] when the feed never held
+/// still long enough to read both routes at one revision.
 pub async fn fetch_public_snapshot(base: Option<&str>) -> Result<PublicSnapshot, BackendError> {
     let url = match base {
         Some(u) if !u.trim().is_empty() => u.trim().to_owned(),
@@ -74,7 +83,10 @@ pub async fn fetch_public_snapshot(base: Option<&str>) -> Result<PublicSnapshot,
     for _ in 1..MAX_PAIR_READS {
         let next = read_pair(&client, &url).await?;
         if next == prev {
-            return Ok(next);
+            if snapshot_halves_agree(&next) {
+                return Ok(next);
+            }
+            return Err(BackendError::Mismatched);
         }
         prev = next;
     }

--- a/crates/bounty-challenge/src/backend.rs
+++ b/crates/bounty-challenge/src/backend.rs
@@ -82,9 +82,12 @@ pub async fn fetch_public_snapshot(base: Option<&str>) -> Result<PublicSnapshot,
     let mut prev = read_pair(&client, &url).await?;
     for _ in 1..MAX_PAIR_READS {
         let next = read_pair(&client, &url).await?;
-        if next == prev {
-            if snapshot_halves_agree(&next) {
-                return Ok(next);
+        if next.snap == prev.snap
+            && next.lb_token == prev.lb_token
+            && next.rp_token == prev.rp_token
+        {
+            if snapshot_halves_agree(&next.snap) && publication_tokens_agree(&next) {
+                return Ok(next.snap);
             }
             return Err(BackendError::Mismatched);
         }
@@ -93,24 +96,63 @@ pub async fn fetch_public_snapshot(base: Option<&str>) -> Result<PublicSnapshot,
     Err(BackendError::Inconsistent)
 }
 
+/// One GET-pair, plus any publication token the backend put on each route.
+struct PairRead {
+    snap: PublicSnapshot,
+    lb_token: Option<String>,
+    rp_token: Option<String>,
+}
+
+fn publication_tokens_agree(pair: &PairRead) -> bool {
+    match (&pair.lb_token, &pair.rp_token) {
+        (Some(a), Some(b)) => a == b,
+        _ => true,
+    }
+}
+
+/// JSON envelope `revision` / `snapshot_id`, else HTTP ETag.
+fn publication_token(body: &str, etag: Option<String>) -> Option<String> {
+    envelope_token(body).or(etag)
+}
+
+fn envelope_token(raw: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+    for key in ["revision", "snapshot_id", "etag"] {
+        if let Some(s) = v.get(key).and_then(serde_json::Value::as_str) {
+            let t = s.trim();
+            if !t.is_empty() {
+                return Some(t.to_owned());
+            }
+        }
+    }
+    None
+}
+
 /// Read both public routes once.
 ///
 /// Comparing the parsed snapshot rather than the raw bodies keeps the
 /// consistency check at the granularity scoring actually uses: a field the
 /// public DTO does not model (a `generated_at` stamp, say) cannot make a
 /// stable feed look like a moving one.
-async fn read_pair(client: &reqwest::Client, base: &str) -> Result<PublicSnapshot, BackendError> {
-    let lb_text = get_text(client, &public_path(base, "leaderboard")).await?;
-    let rp_text = get_text(client, &public_path(base, "reports")).await?;
+async fn read_pair(client: &reqwest::Client, base: &str) -> Result<PairRead, BackendError> {
+    let (lb_text, lb_etag) = get_text(client, &public_path(base, "leaderboard")).await?;
+    let (rp_text, rp_etag) = get_text(client, &public_path(base, "reports")).await?;
     let leaderboard = parse_leaderboard(&lb_text).map_err(BackendError::Json)?;
     let reports = parse_reports(&rp_text).map_err(BackendError::Json)?;
-    Ok(PublicSnapshot {
-        leaderboard,
-        reports,
+    Ok(PairRead {
+        snap: PublicSnapshot {
+            leaderboard,
+            reports,
+        },
+        lb_token: publication_token(&lb_text, lb_etag),
+        rp_token: publication_token(&rp_text, rp_etag),
     })
 }
 
-async fn get_text(client: &reqwest::Client, url: &str) -> Result<String, BackendError> {
+async fn get_text(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<(String, Option<String>), BackendError> {
     let resp = client
         .get(url)
         .send()
@@ -119,7 +161,15 @@ async fn get_text(client: &reqwest::Client, url: &str) -> Result<String, Backend
     if !resp.status().is_success() {
         return Err(BackendError::Fetch);
     }
-    resp.text().await.map_err(|_| BackendError::Fetch)
+    let etag = resp
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned);
+    let text = resp.text().await.map_err(|_| BackendError::Fetch)?;
+    Ok((text, etag))
 }
 
 /// Parse a snapshot from two JSON bodies (unit tests / mocks).

--- a/crates/bounty-challenge/tests/emit_fail_closed.rs
+++ b/crates/bounty-challenge/tests/emit_fail_closed.rs
@@ -236,7 +236,7 @@ async fn spawn_shifting_backend(freeze_after: usize) -> String {
             "/v1/bounty/public/reports",
             get(|State((served, freeze)): State<Shifting>| async move {
                 let rev = next_revision(&served, freeze);
-                let items: Vec<_> = (0..=(3 + rev))
+                let items: Vec<_> = (0..(3 + rev))
                     .map(|i| champion_valid_row(i, &format!("regression {i}")))
                     .collect();
                 Json(serde_json::json!({ "items": items }))
@@ -248,6 +248,26 @@ async fn spawn_shifting_backend(freeze_after: usize) -> String {
 
 fn next_revision(served: &AtomicUsize, freeze_after: usize) -> usize {
     served.fetch_add(1, Ordering::Relaxed).min(freeze_after)
+}
+
+/// Leaderboard always publishes three valids; reports always publishes one.
+/// The mixed pair is identical on every request, so consecutive re-reads
+/// agree — and must still be refused.
+async fn spawn_stable_torn_backend() -> String {
+    let app = Router::new()
+        .route(
+            "/v1/bounty/public/leaderboard",
+            get(|| async {
+                Json(serde_json::json!({
+                    "items": [{ "hotkey": hex::encode(CHAMPION), "valid_count": 3 }]
+                }))
+            }),
+        )
+        .route(
+            "/v1/bounty/public/reports",
+            get(|| async { Json(serde_json::json!({ "items": [champion_valid_row(0, "one")] })) }),
+        );
+    serve(app).await
 }
 
 async fn serve(app: Router) -> String {
@@ -460,6 +480,30 @@ async fn a_feed_that_never_holds_still_is_never_signed_as_one_snapshot() {
         0,
         "a snapshot that could not be pinned is not a score"
     );
+}
+
+/// A feed that always serves leaderboard revision A beside reports revision B
+/// is stable under consecutive re-reads. Signing it would pay from a state the
+/// backend never published atomically.
+#[tokio::test]
+async fn a_stable_torn_pair_is_never_signed_as_one_snapshot() {
+    let backend = spawn_stable_torn_backend().await;
+    let (gateway, accepted) = spawn_gateway().await;
+    let em = emitter(Some(backend.clone()), &gateway);
+
+    let err = fetch_public_snapshot(Some(&backend))
+        .await
+        .expect_err("leaderboard A + reports B is not one snapshot");
+    assert!(matches!(err, BackendError::Mismatched), "{err}");
+
+    match em.tick().await.expect("burn covers E") {
+        EmitOutcome::Burned { reason, .. } => {
+            assert!(reason.contains("do not agree"), "{reason}");
+        }
+        other => panic!("a stable torn feed must pay nobody: {other:?}"),
+    }
+    assert_burn_covers_e(&accepted);
+    assert_eq!(em.scored_epoch(), 0);
 }
 
 /// Re-reading is a retry, not a refusal: a feed that settles after a publish

--- a/crates/bounty-challenge/tests/emit_fail_closed.rs
+++ b/crates/bounty-challenge/tests/emit_fail_closed.rs
@@ -270,6 +270,31 @@ async fn spawn_stable_torn_backend() -> String {
     serve(app).await
 }
 
+/// Matching `valid_count` with distinct envelope revisions: Greptile's stable
+/// torn case (leaderboard A, reports B) where a count-only check would pass.
+async fn spawn_stable_torn_revision_backend() -> String {
+    let app = Router::new()
+        .route(
+            "/v1/bounty/public/leaderboard",
+            get(|| async {
+                Json(serde_json::json!({
+                    "revision": "A",
+                    "items": [{ "hotkey": hex::encode(CHAMPION), "valid_count": 1 }]
+                }))
+            }),
+        )
+        .route(
+            "/v1/bounty/public/reports",
+            get(|| async {
+                Json(serde_json::json!({
+                    "revision": "B",
+                    "items": [champion_valid_row(0, "report-from-revision-B")]
+                }))
+            }),
+        );
+    serve(app).await
+}
+
 async fn serve(app: Router) -> String {
     let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await
@@ -504,6 +529,25 @@ async fn a_stable_torn_pair_is_never_signed_as_one_snapshot() {
     }
     assert_burn_covers_e(&accepted);
     assert_eq!(em.scored_epoch(), 0);
+}
+
+/// Same `valid_count`, different envelope `revision`: the count check would
+/// accept this. Publication tokens must not.
+#[tokio::test]
+async fn mismatched_publication_tokens_are_never_signed_as_one_snapshot() {
+    let backend = spawn_stable_torn_revision_backend().await;
+    let (gateway, accepted) = spawn_gateway().await;
+    let em = emitter(Some(backend.clone()), &gateway);
+
+    let err = fetch_public_snapshot(Some(&backend))
+        .await
+        .expect_err("revision A beside revision B is not one snapshot");
+    assert!(matches!(err, BackendError::Mismatched), "{err}");
+    assert!(matches!(
+        em.tick().await.expect("burn covers E"),
+        EmitOutcome::Burned { .. }
+    ));
+    assert_burn_covers_e(&accepted);
 }
 
 /// Re-reading is a retry, not a refusal: a feed that settles after a publish

--- a/crates/bounty-score/src/lib.rs
+++ b/crates/bounty-score/src/lib.rs
@@ -35,8 +35,8 @@ use serde::{Deserialize, Serialize};
 mod public;
 pub use public::{
     holdouts_from_reports, parse_leaderboard, parse_reports, rank_leaderboard, scorable,
-    score_plan_from_snapshot, LeaderboardRow, PublicReport, PublicScorePlan, PublicSnapshot,
-    PublicStatus,
+    score_plan_from_snapshot, snapshot_halves_agree, LeaderboardRow, PublicReport, PublicScorePlan,
+    PublicSnapshot, PublicStatus,
 };
 
 /// Credit applied to a valid unique reproducing bug, before severity weighting.

--- a/crates/bounty-score/src/public.rs
+++ b/crates/bounty-score/src/public.rs
@@ -106,6 +106,43 @@ pub fn scorable(report: &PublicReport) -> bool {
         && !report.justification.trim().is_empty()
 }
 
+/// True when `/leaderboard` and `/reports` describe the same publication.
+///
+/// Consecutive identical pair-reads only prove each route was still; they do
+/// not prove the two routes came from one backend publish. A host that always
+/// serves leaderboard revision A beside reports revision B would pass that
+/// check and sign a state the backend never published. `valid_count` on each
+/// leaderboard row must match the number of `valid` reports for that hotkey,
+/// and every hotkey with a `valid` report must appear on the leaderboard.
+#[must_use]
+pub fn snapshot_halves_agree(snap: &PublicSnapshot) -> bool {
+    let mut from_reports: BTreeMap<[u8; 32], u64> = BTreeMap::new();
+    for r in &snap.reports {
+        if r.status != PublicStatus::Valid {
+            continue;
+        }
+        let Ok(bytes) = parse_hotkey(&r.hotkey) else {
+            return false;
+        };
+        *from_reports.entry(bytes).or_insert(0) += 1;
+    }
+    let mut from_lb: BTreeMap<[u8; 32], u64> = BTreeMap::new();
+    for row in &snap.leaderboard {
+        let Ok(bytes) = parse_hotkey(&row.hotkey) else {
+            return false;
+        };
+        if from_lb.insert(bytes, row.valid_count).is_some() {
+            return false;
+        }
+    }
+    if from_reports.iter().any(|(k, n)| from_lb.get(k) != Some(n)) {
+        return false;
+    }
+    from_lb
+        .iter()
+        .all(|(k, n)| from_reports.get(k).copied().unwrap_or(0) == *n)
+}
+
 /// Parse a leaderboard list (`{ "items": [...] }` or a bare array).
 pub fn parse_leaderboard(raw: &str) -> Result<Vec<LeaderboardRow>, String> {
     parse_items(raw)
@@ -412,5 +449,75 @@ mod tests {
         let raw = r#"{"items":[{"hotkey":"a","valid_count":2}]}"#;
         let rows = parse_leaderboard(raw).expect("parse");
         assert_eq!(rows[0].valid_count, 2);
+    }
+
+    #[test]
+    fn matching_halves_agree() {
+        let reports: Vec<PublicReport> = (1..=3)
+            .map(|i| {
+                report(
+                    &i.to_string(),
+                    HK_A,
+                    PublicStatus::Valid,
+                    &format!("bug {i}"),
+                    "reproduced",
+                )
+            })
+            .collect();
+        let snap = PublicSnapshot {
+            leaderboard: vec![LeaderboardRow {
+                hotkey: HK_A.into(),
+                valid_count: 3,
+                weight: None,
+            }],
+            reports,
+        };
+        assert!(snapshot_halves_agree(&snap));
+    }
+
+    #[test]
+    fn a_zero_count_leaderboard_row_still_agrees() {
+        let reports: Vec<PublicReport> = (1..=3)
+            .map(|i| {
+                report(
+                    &i.to_string(),
+                    HK_A,
+                    PublicStatus::Valid,
+                    &format!("bug {i}"),
+                    "reproduced",
+                )
+            })
+            .collect();
+        let snap = PublicSnapshot {
+            leaderboard: vec![
+                LeaderboardRow {
+                    hotkey: HK_A.into(),
+                    valid_count: 3,
+                    weight: None,
+                },
+                LeaderboardRow {
+                    hotkey: HK_B.into(),
+                    valid_count: 0,
+                    weight: None,
+                },
+            ],
+            reports,
+        };
+        assert!(snapshot_halves_agree(&snap));
+    }
+
+    /// Leaderboard A + reports B, held still: the consecutive-read check
+    /// would accept this. Scoring must not.
+    #[test]
+    fn a_stable_torn_pair_does_not_agree() {
+        let snap = PublicSnapshot {
+            leaderboard: vec![LeaderboardRow {
+                hotkey: HK_A.into(),
+                valid_count: 3,
+                weight: None,
+            }],
+            reports: vec![report("1", HK_A, PublicStatus::Valid, "one", "reproduced")],
+        };
+        assert!(!snapshot_halves_agree(&snap));
     }
 }

--- a/docs/BOUNTY.md
+++ b/docs/BOUNTY.md
@@ -120,10 +120,14 @@ routes, and a mixed pair is worse than no pair: every tally comes from
 the backend never published either way. Each tick therefore re-reads the pair
 until two consecutive reads agree (bounded, so a settling feed is a retry
 rather than a lost epoch) and compares the *parsed* snapshot, so a field the
-public DTO does not model cannot make a still feed look like a moving one. A
-feed that never holds still is an error, and the paragraphs above apply. No
-backend change is needed for this; a published revision or ETag on both routes
-would let it collapse to a single round.
+public DTO does not model cannot make a still feed look like a moving one. Two
+equal composites are still refused when `/leaderboard` `valid_count` does not
+match the `valid` rows on `/reports`: a feed that always serves revision A on
+one route and revision B on the other is stable under re-read and must not be
+signed. A feed that never holds still, or whose halves disagree, is an error,
+and the paragraphs above apply. No backend change is needed for this; a
+published revision or ETag on both routes would let the moving-feed check
+collapse to a single round.
 
 A failed tick also tries not to take back a score. Once the process has scored
 an epoch, a feed outage inside that same epoch **holds** instead of superseding

--- a/docs/COMPLETENESS.md
+++ b/docs/COMPLETENESS.md
@@ -112,7 +112,7 @@ Removed as **live products**. Shared rails (`prism-lium*`, `prism-competition` p
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Crates (`crates/bounty-*`) | **done** | task (pairing), score (precision × severity, triage-noise canary off the lattice), store, http (fail-closed ingest + quotas), challenge (backend public **consumer** + fail-closed leaf emitter; the two public routes are re-read until they agree, so a mid-publish pair is never signed as one snapshot). |
+| Crates (`crates/bounty-*`) | **done** | task (pairing), score (precision × severity, triage-noise canary off the lattice), store, http (fail-closed ingest + quotas), challenge (backend public **consumer** + fail-closed leaf emitter; the two public routes are re-read until they agree, and `/leaderboard` `valid_count` must match the `valid` reports, so a mid-publish pair or a stable A+B mix is never signed as one snapshot). |
 | Binary (`bins/bounty-challenge`) | **done** | Internal HTTP on `:8096` plus the emitter (backend feed → exact-`E` leaves → gateway `POST /v1/weights/raw`, `BOUNTY_EMIT_POLL_SECS`). Does **not** serve `/v1/public/*`. No feed (or an unreadable one) pays nobody: `E` is covered with `NoScore(ChallengeInternal)` so D24 holds and the share burns to uid 0. A scored epoch is never downgraded to a burn mid-epoch. |
 | Miner CLI (`bins/cortex-bounty`) | **done** | `pair --hotkey`; Chat inject from `BOUNTY_CHAT_COMMAND`. |
 | Compose / images | **done** | Default compose + `images.yml` target `bounty-challenge`. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #204. Greptile P1: two consecutive equal pair-reads only prove each route was still. A backend that always serves leaderboard revision A beside reports revision B produces the same mixed composite twice and would have been signed.

Two Cortex-side pins, neither requiring a new backend endpoint:

1. `/leaderboard` `valid_count` must match the `valid` rows on `/reports` (`snapshot_halves_agree`).
2. When both routes carry a publication token (`revision` / `snapshot_id` / `etag` in the JSON envelope, or HTTP `ETag`), those tokens must be equal.

A stable torn pair is `BackendError::Mismatched` and the emitter burns (covers `E` with `ChallengeInternal`). A moving feed that never holds still is still `Inconsistent`.

`relearn-eval` stays unpinned; `sha256:cbc4bbb8` is not re-pinned.

## Greptile

- [x] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

Fixes the P1 on #204 (`crates/bounty-challenge/src/backend.rs`). T-Rex's stable torn harness (leaderboard A `valid_count=1`, reports B) is the `mismatched_publication_tokens` case when the envelope carries `revision`.

## Test plan

- [x] `cargo test -p bounty-challenge --test emit_fail_closed`
- [x] `cargo clippy -p bounty-challenge --all-targets -- -D warnings`
- [ ] GitHub CI `fmt · clippy · test · deny · xtask`

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths (`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or `base-*-v1` cryptographic domain tags.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9aac44b-0626-4f29-9feb-0287db82b3a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9aac44b-0626-4f29-9feb-0287db82b3a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

