### PR TITLE
feat(ctx): rebase universal CLI onto bounty+proof (off relearn cmds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,30 @@ Missing evidence fails closed rather than passing.
 Some env vars and host paths still spell `BASE_*`. That is leftover naming,
 not a second product.
 
-- **[How to mine — Bounty](docs/external-miner/bounty.md)**
-- **[How to mine — Proof](docs/external-miner/proof.md)**
-- **[How to validate](docs/external-miner/validators.md)**
+## Mine
+
+Miners and validators talk to one public gateway:
+**`https://network.cortex.foundation`**. Install the subnet CLI:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
+
+ctx challenges   # the two live challenges and what they pay for
+ctx status       # can each challenge score right now, and is the epoch sealed
+```
+
+`ctx` ([`bins/ctx`](bins/ctx)) submits to the two live challenges and handles
+Bounty pairing. `ctx relearn|image|agent` still exist for a local stack;
+those challenges are **off** and earn nothing. `curl` works against the same
+routes.
+
+| Challenge | Start with | Guide |
+|-----------|-----------|-------|
+| Bounty | `ctx bounty pair` | **[How to mine — Bounty](docs/external-miner/bounty.md)** |
+| Proof | `ctx proof submit` | **[How to mine — Proof](docs/external-miner/proof.md)** |
+
+Start at **[docs/external-miner/](docs/external-miner/README.md)** for the
+A→Z, and **[How to validate](docs/external-miner/validators.md)** if you run a
+validator.
 
 Apache License 2.0 — see [LICENSE](./LICENSE).

--- a/bins/ctx/src/catalog.rs
+++ b/bins/ctx/src/catalog.rs
@@ -45,10 +45,52 @@ pub const LIVE: [Challenge; 2] = [
     },
 ];
 
-/// Resolve a challenge by id or by its `ctx` subcommand name.
+/// Off challenges. Commands exist for a local stack; they earn nothing.
+pub const OFF: [Challenge; 3] = [
+    Challenge {
+        id: "relearn",
+        label: "Relearn",
+        command: "relearn",
+        entry: "ctx relearn submit (off: no emission)",
+        emission_bps: 0,
+        work: "post-train Qwen/Qwen3.8-27B",
+        guide: "docs/external-miner/relearn.md",
+    },
+    Challenge {
+        id: "relearn-image",
+        label: "Relearn Image",
+        command: "image",
+        entry: "ctx image submit (off: no emission)",
+        emission_bps: 0,
+        work: "fine-tune nvidia/Cosmos3-Super-Text2Image, judged by Q-Judger",
+        guide: "docs/external-miner/relearn-image.md",
+    },
+    Challenge {
+        id: "relearn-agent",
+        label: "Relearn Agent",
+        command: "agent",
+        entry: "ctx agent submit (off: no emission)",
+        emission_bps: 0,
+        work: "post-train the same checkpoint into a tool-using agent",
+        guide: "docs/external-miner/relearn-agent.md",
+    },
+];
+
+/// Resolve a live challenge by id or by its `ctx` subcommand name.
 #[must_use]
 pub fn find(name: &str) -> Option<&'static Challenge> {
     LIVE.iter().find(|c| c.id == name || c.command == name)
+}
+
+/// Resolve an off challenge. Never used for emission or `ctx challenges`.
+#[must_use]
+pub fn find_off(name: &str) -> Option<&'static Challenge> {
+    OFF.iter()
+        .find(|c| c.id == name || c.command == name)
+        .or_else(|| match name {
+            "relearn-t2i" | "t2i" => find_off("relearn-image"),
+            _ => None,
+        })
 }
 
 /// Print the live challenge table.
@@ -64,6 +106,8 @@ pub fn print_challenges() {
     }
     println!("relearn, relearn-image, relearn-agent, relearn-mm, design, and prism");
     println!("are off: no trust-root row, no emission. Submitting to them earns nothing.");
+    println!("`ctx relearn|image|agent` still talk to a local stack (`--gateway`);");
+    println!("they are not live work.");
     println!();
     println!("Bounty pays precision times severity. Proof pays the mean of per-topic");
     println!("lattices over currently open ids; an empty eval digest cannot score.");
@@ -84,6 +128,20 @@ pub async fn fetch_status(client: &Client, challenge_id: &str) -> Result<Value, 
 
 /// Print the status of every live challenge plus the sealed weights vector.
 pub async fn print_status(client: &Client, only: Option<&str>, json: bool) -> Result<(), String> {
+    if let Some(want) = only {
+        if find(want).is_none() {
+            if let Some(off) = find_off(want) {
+                return Err(format!(
+                    "{} is off: no trust-root row, no emission. Live ids: bounty, proof. \
+                     Use `ctx {} status` against a local stack.",
+                    off.id, off.command
+                ));
+            }
+            return Err(format!(
+                "unknown challenge {want:?}. Live ids: bounty, proof."
+            ));
+        }
+    }
     let mut collected = serde_json::Map::new();
     if only.is_none() && !json {
         println!("gateway: {}", client.gateway());
@@ -229,6 +287,10 @@ mod tests {
         ] {
             assert!(find(off).is_none(), "{off} must not be live");
         }
+        assert_eq!(find_off("relearn").map(|c| c.emission_bps), Some(0));
+        assert_eq!(find_off("image").map(|c| c.id), Some("relearn-image"));
+        assert_eq!(find_off("t2i").map(|c| c.id), Some("relearn-image"));
+        assert!(find_off("relearn-mm").is_none());
     }
 
     #[test]

--- a/bins/ctx/src/main.rs
+++ b/bins/ctx/src/main.rs
@@ -10,6 +10,7 @@
 mod api;
 mod bounty;
 mod catalog;
+mod off;
 mod proof;
 
 use std::path::PathBuf;
@@ -30,7 +31,8 @@ use proof::SubmitInput;
     long_about = "ctx talks to the public Cortex gateway at https://network.cortex.foundation.
 
 Live challenges: bounty (7000 bps) and proof (3000 bps). relearn*, design, and
-prism are off and earn nothing.
+prism are off and earn nothing. `ctx relearn|image|agent` still exist for a
+local stack; they are not live work.
 
 Start with 'ctx challenges' for what each one pays for, then 'ctx status' to
 see whether a host can score right now. A challenge that cannot score answers
@@ -77,6 +79,21 @@ enum Cmd {
     Bounty {
         #[command(subcommand)]
         cmd: BountyCmd,
+    },
+    /// Relearn (off): no emission. Local-stack submit only.
+    Relearn {
+        #[command(subcommand)]
+        cmd: off::OffCmd,
+    },
+    /// Relearn Image (off): no emission. Local-stack submit only.
+    Image {
+        #[command(subcommand)]
+        cmd: off::ImageCmd,
+    },
+    /// Relearn Agent (off): no emission. Local-stack submit only.
+    Agent {
+        #[command(subcommand)]
+        cmd: off::OffCmd,
     },
 }
 
@@ -214,6 +231,9 @@ async fn run(cli: Cli) -> Result<(), String> {
         Cmd::Weights => catalog::print_weights(&client, cli.json).await,
         Cmd::Proof { cmd } => run_proof(&client, cmd, cli.json).await,
         Cmd::Bounty { cmd } => run_bounty(&client, cmd, cli.json).await,
+        Cmd::Relearn { cmd } => off::run(&client, "relearn", cmd, cli.json).await,
+        Cmd::Image { cmd } => off::run_image(&client, cmd, cli.json).await,
+        Cmd::Agent { cmd } => off::run(&client, "relearn-agent", cmd, cli.json).await,
     }
 }
 
@@ -323,10 +343,43 @@ mod tests {
     }
 
     #[test]
-    fn relearn_commands_are_not_on_the_cli() {
-        assert!(Cli::try_parse_from(["ctx", "relearn", "status"]).is_err());
-        assert!(Cli::try_parse_from(["ctx", "image", "status"]).is_err());
-        assert!(Cli::try_parse_from(["ctx", "agent", "status"]).is_err());
+    fn off_commands_parse_but_are_not_live() {
+        assert!(Cli::try_parse_from(["ctx", "relearn", "status"]).is_ok());
+        assert!(Cli::try_parse_from(["ctx", "image", "prompts"]).is_ok());
+        assert!(Cli::try_parse_from(["ctx", "agent", "status"]).is_ok());
+        assert!(Cli::try_parse_from(["ctx", "relearn", "prompts"]).is_err());
+        assert!(catalog::find("relearn").is_none());
+        assert_eq!(
+            catalog::find_off("relearn").map(|c| c.emission_bps),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn off_submit_parses_repeatable_manifest_flags() {
+        let cli = Cli::try_parse_from([
+            "ctx",
+            "relearn",
+            "submit",
+            "--hotkey",
+            &"ab".repeat(32),
+            "--artifact-digest",
+            &"cd".repeat(32),
+            "--train-id",
+            "1",
+            "--train-dataset",
+            "my-mix",
+        ])
+        .expect("parse");
+        match cli.cmd {
+            Cmd::Relearn {
+                cmd: off::OffCmd::Submit(args),
+            } => {
+                assert_eq!(args.train_ids, vec![1]);
+                assert_eq!(args.train_datasets, vec!["my-mix".to_owned()]);
+            }
+            other => panic!("wrong command: {other:?}"),
+        }
     }
 
     #[test]

--- a/bins/ctx/src/off.rs
+++ b/bins/ctx/src/off.rs
@@ -1,0 +1,441 @@
+//! Off challenges: `relearn`, `relearn-image`, `relearn-agent`.
+//!
+//! Commands still talk to a local stack (`--gateway`) so those services stay
+//! exercisable. They are not live: no trust-root row, no emission.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::{Args, Subcommand};
+use serde_json::{json, Value};
+
+use crate::api::{challenge_path, Client};
+use crate::catalog::{compact, find_off, Challenge};
+
+const TERMINAL_STATES: [&str; 3] = ["awaiting_admin", "rejected", "champion"];
+const POLL_SECS: u64 = 20;
+const IMAGE_BASE: &str = "nvidia/Cosmos3-Super-Text2Image";
+const IMAGE_BASE_LICENSE: &str = "OpenMDW-1.1";
+
+/// Shared submit / show / status group for Relearn and Relearn Agent.
+#[derive(Debug, Subcommand)]
+pub enum OffCmd {
+    /// Submit an artifact digest plus the training manifest.
+    Submit(Box<SubmitArgs>),
+    /// Show one submission.
+    Show {
+        /// Submission id returned by submit.
+        id: String,
+        /// Keep polling until the submission stops moving.
+        #[arg(long)]
+        wait: bool,
+    },
+    /// Show this (off) challenge's status.
+    Status,
+}
+
+/// Relearn Image: submit / show / status / public prompts.
+#[derive(Debug, Subcommand)]
+pub enum ImageCmd {
+    /// Submit an artifact digest plus the training manifest.
+    Submit(Box<SubmitArgs>),
+    /// Show one submission.
+    Show {
+        /// Submission id returned by submit.
+        id: String,
+        /// Keep polling until the submission stops moving.
+        #[arg(long)]
+        wait: bool,
+    },
+    /// Show this (off) challenge's status.
+    Status,
+    /// Show the frozen public prompt split and its seeds.
+    Prompts,
+}
+
+/// Artifact and manifest arguments for a Relearn-family submit.
+#[derive(Debug, Args)]
+pub struct SubmitArgs {
+    /// 64-hex miner hotkey.
+    #[arg(long, value_name = "HEX64")]
+    pub hotkey: String,
+    /// SHA-256 hex of the artifact you are submitting.
+    #[arg(long, value_name = "SHA256")]
+    pub artifact_digest: String,
+    /// Optional locator for the artifact.
+    #[arg(long, value_name = "URL")]
+    pub artifact_uri: Option<String>,
+    /// Full manifest JSON file, used verbatim.
+    #[arg(long, value_name = "PATH")]
+    pub manifest_file: Option<PathBuf>,
+    /// Public item, prompt, or episode id. Repeatable.
+    #[arg(long = "train-id", value_name = "ID")]
+    pub train_ids: Vec<u32>,
+    /// Image or observation hash. Repeatable.
+    #[arg(long = "train-hash", value_name = "SHA256")]
+    pub train_hashes: Vec<String>,
+    /// Dataset, corpus, or environment id. Repeatable.
+    #[arg(long = "train-dataset", value_name = "ID")]
+    pub train_datasets: Vec<String>,
+    /// Declared base checkpoint. Relearn Image only.
+    #[arg(long, value_name = "MODEL")]
+    pub base: Option<String>,
+    /// Declared base license. Relearn Image only.
+    #[arg(long, value_name = "LICENSE")]
+    pub base_license: Option<String>,
+    /// Seed-replay claim as cell=sha256. Relearn Image only.
+    #[arg(long = "claimed-output", value_name = "CELL=SHA256")]
+    pub claimed_outputs: Vec<String>,
+    /// Poll the submission until it stops moving.
+    #[arg(long)]
+    pub wait: bool,
+}
+
+/// Run `ctx relearn|agent …`.
+pub async fn run(client: &Client, id: &str, cmd: OffCmd, json: bool) -> Result<(), String> {
+    let challenge = off(id)?;
+    warn_off(challenge);
+    match cmd {
+        OffCmd::Submit(args) => submit(client, challenge, &args, json).await,
+        OffCmd::Show { id, wait } => show(client, challenge, &id, wait, json).await,
+        OffCmd::Status => print_one_status(client, challenge, json).await,
+    }
+}
+
+/// Run `ctx image …`.
+pub async fn run_image(client: &Client, cmd: ImageCmd, json: bool) -> Result<(), String> {
+    let challenge = off("relearn-image")?;
+    warn_off(challenge);
+    match cmd {
+        ImageCmd::Submit(args) => submit(client, challenge, &args, json).await,
+        ImageCmd::Show { id, wait } => show(client, challenge, &id, wait, json).await,
+        ImageCmd::Status => print_one_status(client, challenge, json).await,
+        ImageCmd::Prompts => print_prompts(client, json).await,
+    }
+}
+
+fn off(id: &str) -> Result<&'static Challenge, String> {
+    find_off(id).ok_or_else(|| format!("{id} is not an off Relearn challenge"))
+}
+
+fn warn_off(challenge: &Challenge) {
+    eprintln!(
+        "ctx: {} is off — no trust-root row, no emission. Live work is bounty and proof.",
+        challenge.id
+    );
+}
+
+async fn submit(
+    client: &Client,
+    challenge: &Challenge,
+    input: &SubmitArgs,
+    json_out: bool,
+) -> Result<(), String> {
+    let hotkey = normalize_hex64(&input.hotkey, "hotkey")?;
+    let digest = normalize_hex64(&input.artifact_digest, "artifact-digest")?;
+    let manifest = build_manifest(challenge.id, input)?;
+    let mut body = json!({
+        "miner_hotkey": hotkey,
+        "artifact_digest": digest,
+        "manifest": manifest,
+    });
+    if let Some(uri) = &input.artifact_uri {
+        body["artifact_uri"] = Value::String(uri.clone());
+    }
+    let reply = client
+        .post(&challenge_path(challenge.id, "/v1/submissions"), &body)
+        .await?;
+    if json_out {
+        println!("{}", reply.body);
+    }
+    if !reply.ok() {
+        return Err(explain_failure(challenge, reply.status, &reply.message()));
+    }
+    let id = reply
+        .body
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    if !json_out {
+        println!(
+            "{} submission accepted (off: earns nothing)",
+            challenge.label
+        );
+        print_fields(&reply.body);
+        println!();
+        println!("Track it: ctx {} show {id}", challenge.command);
+    }
+    if input.wait && !id.is_empty() {
+        println!();
+        poll(client, challenge, &id, true, json_out).await?;
+    }
+    Ok(())
+}
+
+async fn show(
+    client: &Client,
+    challenge: &Challenge,
+    id: &str,
+    wait: bool,
+    json_out: bool,
+) -> Result<(), String> {
+    poll(client, challenge, id, wait, json_out).await
+}
+
+async fn poll(
+    client: &Client,
+    challenge: &Challenge,
+    id: &str,
+    wait: bool,
+    json_out: bool,
+) -> Result<(), String> {
+    loop {
+        let reply = client
+            .get(&challenge_path(
+                challenge.id,
+                &format!("/v1/submissions/{id}"),
+            ))
+            .await?;
+        if !reply.ok() {
+            return Err(explain_failure(challenge, reply.status, &reply.message()));
+        }
+        let state = reply
+            .body
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_owned();
+        if json_out {
+            println!("{}", reply.body);
+        } else {
+            println!("{} {id}: {state}", challenge.label);
+            print_fields(&reply.body);
+        }
+        if !wait || TERMINAL_STATES.contains(&state.as_str()) {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(POLL_SECS)).await;
+    }
+}
+
+async fn print_one_status(
+    client: &Client,
+    challenge: &Challenge,
+    json: bool,
+) -> Result<(), String> {
+    let body = crate::catalog::fetch_status(client, challenge.id).await?;
+    if json {
+        println!("{body}");
+    } else {
+        println!("{} ({}) — OFF", challenge.label, challenge.id);
+        if let Some(map) = body.as_object() {
+            for (k, v) in map {
+                println!("  {k}: {}", compact(v));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn print_prompts(client: &Client, json: bool) -> Result<(), String> {
+    let reply = client.get("/challenge/relearn-image/v1/prompts").await?;
+    if json {
+        println!("{}", reply.body);
+        return Ok(());
+    }
+    if !reply.ok() {
+        return Err(format!("HTTP {}: {}", reply.status, reply.message()));
+    }
+    let cells = reply
+        .body
+        .get("public")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    println!("public cells: {cells}");
+    if let Some(v) = reply.body.get("dataset") {
+        println!("dataset: {}", compact(v));
+    }
+    if let Some(v) = reply.body.get("holdout") {
+        println!("holdout commitment: {v}");
+    }
+    println!("Full cells: ctx image prompts --json");
+    Ok(())
+}
+
+fn print_fields(body: &Value) {
+    for field in [
+        "id",
+        "state",
+        "submission_digest",
+        "eval_backend",
+        "judge_backend",
+        "eligible",
+        "error",
+    ] {
+        if let Some(v) = body.get(field) {
+            println!("  {field}: {}", compact(v));
+        }
+    }
+}
+
+fn build_manifest(challenge_id: &str, input: &SubmitArgs) -> Result<Value, String> {
+    if let Some(path) = &input.manifest_file {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| format!("read manifest {}: {e}", path.display()))?;
+        return serde_json::from_str::<Value>(&raw)
+            .map_err(|e| format!("manifest {} is not valid JSON: {e}", path.display()));
+    }
+    let declared = input.train_ids.len() + input.train_hashes.len() + input.train_datasets.len();
+    if declared == 0 {
+        return Err(missing_evidence_help(challenge_id));
+    }
+    match challenge_id {
+        "relearn" => Ok(json!({
+            "train_item_ids": input.train_ids,
+            "train_image_hashes": input.train_hashes,
+            "train_dataset_ids": input.train_datasets,
+        })),
+        "relearn-agent" => Ok(json!({
+            "train_episode_ids": input.train_ids,
+            "train_observation_hashes": input.train_hashes,
+            "train_environment_ids": input.train_datasets,
+        })),
+        "relearn-image" => Ok(json!({
+            "base": input.base.clone().unwrap_or_else(|| IMAGE_BASE.to_owned()),
+            "base_license": input
+                .base_license
+                .clone()
+                .unwrap_or_else(|| IMAGE_BASE_LICENSE.to_owned()),
+            "train_prompt_ids": input.train_ids,
+            "train_dataset_ids": input.train_datasets,
+            "claimed_output_hashes": parse_claimed(&input.claimed_outputs)?,
+        })),
+        other => Err(format!("{other} does not take a Relearn manifest")),
+    }
+}
+
+fn parse_claimed(pairs: &[String]) -> Result<BTreeMap<String, String>, String> {
+    let mut out = BTreeMap::new();
+    for pair in pairs {
+        let Some((cell, digest)) = pair.split_once('=') else {
+            return Err(format!(
+                "--claimed-output wants cell=sha256, got {pair:?} (cells look like p1#v0)"
+            ));
+        };
+        out.insert(
+            cell.trim().to_owned(),
+            normalize_hex64(digest, "claimed output hash")?,
+        );
+    }
+    Ok(out)
+}
+
+fn missing_evidence_help(challenge_id: &str) -> String {
+    let flags = match challenge_id {
+        "relearn" => "--train-id, --train-hash, or --train-dataset",
+        "relearn-agent" => {
+            "--train-id (episode), --train-hash (observation), or --train-dataset (environment)"
+        }
+        _ => "--train-id (bench prompt) or --train-dataset",
+    };
+    format!(
+        "contamination_evidence_missing: declare what you trained on ({flags}, or --manifest-file). \
+         An empty manifest is not a clean check."
+    )
+}
+
+fn explain_failure(challenge: &Challenge, status: u16, message: &str) -> String {
+    let hint = match status {
+        400 => "rejected before scoring. Check 64-hex hotkey/digest and a declared manifest.",
+        503 => {
+            "the host cannot score. Nothing was stored and nothing was spent. This challenge is off."
+        }
+        _ => "unexpected reply from the challenge service.",
+    };
+    format!(
+        "{} HTTP {status}: {message}\n  {hint}\n  guide: {}",
+        challenge.label, challenge.guide
+    )
+}
+
+fn normalize_hex64(raw: &str, field: &str) -> Result<String, String> {
+    let t = raw.trim().trim_start_matches("0x");
+    if t.len() != 64 || !t.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!("{field} must be 64 hex characters"));
+    }
+    Ok(t.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_dataset() -> SubmitArgs {
+        SubmitArgs {
+            hotkey: String::new(),
+            artifact_digest: String::new(),
+            artifact_uri: None,
+            manifest_file: None,
+            train_ids: Vec::new(),
+            train_hashes: Vec::new(),
+            train_datasets: vec!["my-sft-mix-v3".into()],
+            base: None,
+            base_license: None,
+            claimed_outputs: Vec::new(),
+            wait: false,
+        }
+    }
+
+    #[test]
+    fn relearn_manifest_uses_item_ids() {
+        let mut input = with_dataset();
+        input.train_ids = vec![1, 2];
+        let m = build_manifest("relearn", &input).expect("manifest");
+        assert_eq!(m["train_item_ids"], json!([1, 2]));
+    }
+
+    #[test]
+    fn agent_manifest_uses_episode_ids() {
+        let m = build_manifest("relearn-agent", &with_dataset()).expect("manifest");
+        assert!(m.get("train_episode_ids").is_some());
+        assert!(m.get("train_item_ids").is_none());
+    }
+
+    #[test]
+    fn image_manifest_defaults_to_the_pinned_base() {
+        let m = build_manifest("relearn-image", &with_dataset()).expect("manifest");
+        assert_eq!(m["base"], json!(IMAGE_BASE));
+        assert_eq!(m["base_license"], json!(IMAGE_BASE_LICENSE));
+    }
+
+    #[test]
+    fn empty_manifest_is_refused_locally() {
+        let err = build_manifest(
+            "relearn",
+            &SubmitArgs {
+                hotkey: String::new(),
+                artifact_digest: String::new(),
+                artifact_uri: None,
+                manifest_file: None,
+                train_ids: Vec::new(),
+                train_hashes: Vec::new(),
+                train_datasets: Vec::new(),
+                base: None,
+                base_license: None,
+                claimed_outputs: Vec::new(),
+                wait: false,
+            },
+        )
+        .expect_err("must refuse");
+        assert!(err.contains("contamination_evidence_missing"), "{err}");
+    }
+
+    #[test]
+    fn claimed_outputs_need_cell_and_digest() {
+        assert!(parse_claimed(&["p1#v0".into()]).is_err());
+        let ok = parse_claimed(&["p1#v0=".to_owned() + &"ab".repeat(32)]).expect("pairs");
+        assert_eq!(ok.len(), 1);
+    }
+}

--- a/docs/COMPLETENESS.md
+++ b/docs/COMPLETENESS.md
@@ -115,7 +115,7 @@ Removed as **live products**. Shared rails (`prism-lium*`, `prism-competition` p
 |-----------|--------|-------|
 | Crates (`crates/bounty-*`) | **done** | task (pairing), score (precision × severity, triage-noise canary off the lattice), store, http (fail-closed ingest + quotas), challenge (backend public **consumer** + fail-closed leaf emitter; the two public routes are re-read until they agree, and `/leaderboard` `valid_count` must match the `valid` reports, so a mid-publish pair or a stable A+B mix is never signed as one snapshot). |
 | Binary (`bins/bounty-challenge`) | **done** | Internal HTTP on `:8096` plus the emitter (backend feed → exact-`E` leaves → gateway `POST /v1/weights/raw`, `BOUNTY_EMIT_POLL_SECS`). Does **not** serve `/v1/public/*`. No feed (or an unreadable one) pays nobody: `E` is covered with `NoScore(ChallengeInternal)` so D24 holds and the share burns to uid 0. A scored epoch is never downgraded to a burn mid-epoch. |
-| Miner CLI (`bins/ctx`) | **done** | `ctx bounty pair|report|show|status`. `bins/cortex-bounty` deprecates to `ctx bounty pair`. |
+| Miner CLI (`bins/ctx`) | **done** | `ctx bounty pair|report|show|status`. `bins/cortex-bounty` deprecates to `ctx bounty pair`. `ctx relearn|image|agent` remain for a local stack; those challenges are off. |
 | Compose / images | **done** | Default compose + `images.yml` target `bounty-challenge`. |
 | Emission | **7000 bps** | Payable share while Proof's eval digest is empty (sum `10000`). |
 | Spec | live | [`BOUNTY.md`](BOUNTY.md). |

--- a/docs/external-miner/relearn-agent.md
+++ b/docs/external-miner/relearn-agent.md
@@ -62,6 +62,18 @@ model here.
 
 ## Submit
 
+The CLI still speaks this challenge for a local stack (`ctx agent submit
+--gateway …`). It is **not** live work.
+
+```bash
+ctx agent submit \
+  --hotkey <64-hex hotkey> \
+  --artifact-digest <sha256 of your artifact> \
+  --train-dataset your-training-environment-id
+```
+
+The same thing with `curl`:
+
 ```bash
 curl -sS -X POST https://network.cortex.foundation/challenge/relearn-agent/v1/submissions \
   -H 'content-type: application/json' \

--- a/docs/external-miner/relearn-image.md
+++ b/docs/external-miner/relearn-image.md
@@ -81,6 +81,18 @@ Promotion needs all of this, not just a higher total:
 The manifest is the license attestation. `base` and `base_license` must name the
 pinned checkpoint; anything else is a `400`.
 
+The CLI still speaks this challenge for a local stack (`ctx image submit
+--gateway …`). It is **not** live work.
+
+```bash
+ctx image submit \
+  --hotkey <64-hex hotkey> \
+  --artifact-digest <sha256 of your artifact> \
+  --train-dataset your-training-corpus-id
+```
+
+The same thing with `curl`:
+
 ```bash
 curl -sS -X POST https://network.cortex.foundation/challenge/relearn-image/v1/submissions \
   -H 'content-type: application/json' \

--- a/docs/external-miner/relearn-seed/README.md
+++ b/docs/external-miner/relearn-seed/README.md
@@ -26,6 +26,13 @@ See [docs/](./docs/) and the control-plane mirror
 [`docs/external-miner/relearn.md`](https://github.com/CortexLM/cortex/blob/main/docs/external-miner/relearn.md).
 
 ```bash
+curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
+ctx --help
+```
+
+This challenge is **off**. Live work is Bounty and Proof.
+
+```bash
 curl -sS -X POST https://network.cortex.foundation/challenge/relearn/v1/submissions \
   -H 'content-type: application/json' \
   -H "X-Lium-Api-Key: $LIUM_API_KEY" \

--- a/docs/external-miner/relearn.md
+++ b/docs/external-miner/relearn.md
@@ -44,6 +44,18 @@ shuffle control on a vision family the champion measured is rejected
 
 ## Submit
 
+The CLI still speaks this challenge for a local stack (`ctx relearn submit
+--gateway …`). It is **not** live work.
+
+```bash
+ctx relearn submit \
+  --hotkey <64-hex hotkey> \
+  --artifact-digest <sha256 of your artifact> \
+  --train-dataset my-sft-mix-v3
+```
+
+The same thing with `curl`:
+
 ```bash
 curl -sS -X POST https://network.cortex.foundation/challenge/relearn/v1/submissions \
   -H 'content-type: application/json' \

--- a/docs/external-miner/troubleshoot.md
+++ b/docs/external-miner/troubleshoot.md
@@ -41,5 +41,7 @@ Install `ctx` from [README](./README.md). Proof miners pay Lium
 
 `relearn`, `relearn-image`, `relearn-agent`, `relearn-mm`, `design`, and
 `prism` have no trust-root row. Submitting to them earns nothing.
+`ctx relearn|image|agent` still talk to a local stack (`--gateway`); they are
+not live work.
 
 Never paste `LIUM_API_KEY`, challenge secrets, or mnemonics into tickets or git.

--- a/xtask/src/external_docs_check.rs
+++ b/xtask/src/external_docs_check.rs
@@ -36,6 +36,36 @@ const EXTERNAL_MINER_PINS: &[(&str, &str)] = &[
     ("relearn_mm_off", "relearn-mm"),
 ];
 
+/// Every miner page must name the real gateway host, not a placeholder.
+///
+/// The value is read from `bins/ctx`, so the docs and the binary's default
+/// cannot drift apart.
+const GATEWAY_CONST_FILE: &str = "bins/ctx/src/api.rs";
+
+/// Const declaration the host is parsed out of.
+const GATEWAY_CONST_PREFIX: &str = "pub const DEFAULT_GATEWAY: &str =";
+
+/// Pages a miner reads. They must resolve every host and never hand a miner an
+/// operator env var to set. `validators.md` is exempt: a validator does set
+/// `BASE_GATEWAY_ENDPOINT` on its own process.
+const MINER_PAGES: &[&str] = &[
+    "README.md",
+    "bounty.md",
+    "proof.md",
+    "troubleshoot.md",
+    "relearn.md",
+    "relearn-image.md",
+    "relearn-agent.md",
+    "relearn-mm.md",
+];
+
+/// Strings that turn a miner guide into an operator runbook.
+const MINER_FORBIDDEN_ENV: &[&str] = &[
+    "BOUNTY_CHAT_COMMAND",
+    "BOUNTY_BACKEND_PUBLIC_URL",
+    "BASE_GATEWAY_",
+];
+
 /// Per-page pins. A challenge product rule that is not in the miner's own guide
 /// is not a rule they will follow.
 const PAGE_PINS: &[(&str, &[&str])] = &[
@@ -117,13 +147,15 @@ pub fn run(workspace_root: &Path) -> Result<(), String> {
     let mut failures = Vec::new();
 
     let protocol_version = read_bundle_protocol_version(workspace_root)?;
+    let gateway = read_ctx_default_gateway(workspace_root)?;
     check_external_miner_docs(workspace_root, protocol_version, &mut failures)?;
+    check_gateway_host(workspace_root, &gateway, &mut failures)?;
     check_threat_model_d19(workspace_root, &mut failures)?;
     check_threat_model_supporting_pins(workspace_root, &mut failures)?;
 
     if failures.is_empty() {
         println!(
-            "external-docs-check OK (protocol_version={protocol_version}, bounty + proof HTTP, D19 verbatim match)"
+            "external-docs-check OK (protocol_version={protocol_version}, gateway={gateway}, bounty + proof HTTP, D19 verbatim match)"
         );
         Ok(())
     } else {
@@ -163,6 +195,103 @@ fn read_bundle_protocol_version(workspace_root: &Path) -> Result<u16, String> {
         "PROTOCOL_VERSION const not found in {}",
         types_rs.display()
     ))
+}
+
+/// Every `.md` under a directory, recursively.
+fn markdown_files(dir: &Path) -> Result<Vec<std::path::PathBuf>, String> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(next) = stack.pop() {
+        for entry in fs::read_dir(&next).map_err(|e| format!("read_dir {}: {e}", next.display()))? {
+            let path = entry.map_err(|e| format!("dirent: {e}"))?.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|s| s.to_str()) == Some("md") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Read `DEFAULT_GATEWAY` out of the `ctx` CLI so docs cannot name a different
+/// host than the binary miners install.
+fn read_ctx_default_gateway(workspace_root: &Path) -> Result<String, String> {
+    let path = workspace_root.join(GATEWAY_CONST_FILE);
+    let body = fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    for line in body.lines() {
+        let t = line.trim();
+        if let Some(rest) = t.strip_prefix(GATEWAY_CONST_PREFIX) {
+            let host = rest.trim().trim_end_matches(';').trim().trim_matches('"');
+            if host.starts_with("https://") && !host.ends_with('/') {
+                return Ok(host.to_owned());
+            }
+            return Err(format!(
+                "{GATEWAY_CONST_FILE}: DEFAULT_GATEWAY must be an https URL without a trailing slash, got {host:?}"
+            ));
+        }
+    }
+    Err(format!(
+        "{GATEWAY_CONST_FILE} has no `{GATEWAY_CONST_PREFIX} \"…\"` line"
+    ))
+}
+
+/// Miner docs must resolve every host, and must not hand a miner operator env.
+fn check_gateway_host(
+    workspace_root: &Path,
+    gateway: &str,
+    failures: &mut Vec<String>,
+) -> Result<(), String> {
+    let dir = workspace_root.join("docs/external-miner");
+    if !dir.is_dir() {
+        return Ok(());
+    }
+
+    for path in markdown_files(&dir)? {
+        let rel = path
+            .strip_prefix(workspace_root)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        let body = fs::read_to_string(&path).map_err(|e| format!("read {rel}: {e}"))?;
+        for placeholder in ["<gateway>", "<GATEWAY>", "<host>"] {
+            if body.contains(placeholder) {
+                failures.push(format!(
+                    "{rel} still has the {placeholder:?} placeholder; write {gateway} instead"
+                ));
+            }
+        }
+    }
+
+    for page in MINER_PAGES {
+        let path = dir.join(page);
+        let Ok(body) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if !body.contains(gateway) {
+            failures.push(format!(
+                "docs/external-miner/{page} never names the gateway {gateway}"
+            ));
+        }
+        for banned in MINER_FORBIDDEN_ENV {
+            if body.contains(banned) {
+                failures.push(format!(
+                    "docs/external-miner/{page} tells a miner about operator env {banned:?}; \
+                     use a ctx command or a concrete URL"
+                ));
+            }
+        }
+    }
+
+    let root_readme = workspace_root.join("README.md");
+    let body = fs::read_to_string(&root_readme).map_err(|e| format!("read README.md: {e}"))?;
+    for needle in [gateway, "scripts/install-ctx.sh", "ctx challenges"] {
+        if !body.contains(needle) {
+            failures.push(format!("README.md missing miner pin {needle:?}"));
+        }
+    }
+    Ok(())
 }
 
 fn check_external_miner_docs(
@@ -420,6 +549,48 @@ mod tests {
         assert!(EXTERNAL_MINER_PINS
             .iter()
             .any(|(n, v)| *n == "gateway_host" && *v == "network.cortex.foundation"));
+        assert!(EXTERNAL_MINER_PINS
+            .iter()
+            .any(|(n, v)| *n == "two_live" && *v == "Two live challenges"));
+    }
+
+    #[test]
+    fn the_index_does_not_pin_operator_env_names() {
+        for (_, value) in EXTERNAL_MINER_PINS {
+            assert!(
+                !MINER_FORBIDDEN_ENV.iter().any(|b| value.contains(b)),
+                "pin {value:?} names operator env"
+            );
+        }
+    }
+
+    #[test]
+    fn miner_pages_must_not_hand_out_operator_env() {
+        for banned in ["BOUNTY_CHAT_COMMAND", "BOUNTY_BACKEND_PUBLIC_URL"] {
+            assert!(MINER_FORBIDDEN_ENV.contains(&banned), "missing {banned}");
+        }
+        assert!(!MINER_PAGES.contains(&"validators.md"));
+        assert!(MINER_PAGES.contains(&"proof.md"));
+        assert!(MINER_PAGES.contains(&"bounty.md"));
+    }
+
+    #[test]
+    fn the_ctx_default_gateway_is_the_documented_host() {
+        let root = workspace_root();
+        let gateway = read_ctx_default_gateway(&root).expect("ctx gateway const");
+        assert_eq!(gateway, "https://network.cortex.foundation");
+    }
+
+    #[test]
+    fn gate_passes_on_this_workspace() {
+        super::run(&workspace_root()).expect("external-docs-check should pass");
+    }
+
+    fn workspace_root() -> std::path::PathBuf {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest
+            .parent()
+            .map_or_else(std::path::PathBuf::new, Path::to_path_buf)
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebase of [#207](https://github.com/CortexLM/cortex/pull/207) onto current `main` (post [#210](https://github.com/CortexLM/cortex/pull/210) Proof+Bounty-only and [#211](https://github.com/CortexLM/cortex/pull/211) security hotfix).

`#210` already landed the miner CLI for the two live challenges. This PR keeps that catalog and ports the leftover #207 work without putting Relearn/Prism back on the trust root:

- **Live catalog stays `bounty` (7000 bps) + `proof` (3000 bps).** `ctx challenges` / `ctx status` only list those two.
- **`ctx relearn|image|agent` remain** for a local stack (`--gateway`). Every invocation prints that the challenge is **off** (no trust-root row, no emission). Empty manifests are still refused locally (`contamination_evidence_missing`).
- **Docs gate:** `xtask external-docs-check` reads `DEFAULT_GATEWAY` from `bins/ctx/src/api.rs`, requires miner pages to name that host, walks `docs/external-miner/` recursively for `<gateway>` / `<host>` placeholders, and refuses `BOUNTY_CHAT_COMMAND` / `BOUNTY_BACKEND_PUBLIC_URL` / `BASE_GATEWAY_*` on miner pages (`validators.md` is exempt).
- Root `README.md` gains a Mine section with the install one-liner, `ctx challenges`, and the public gateway host.

Does **not** reintroduce Relearn/Prism as live. Does not weaken the #211 HTTP API-key refusal or rust-toolchain pin.

Supersedes #207 (that branch still treats Relearn as live and conflicts with `main`).

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [ ] Greptile has reviewed this PR; findings are fixed or answered
- [x] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `cargo test --workspace --locked` — green locally
- [x] `cargo test -p ctx` — 37 passed (off-command parse + live catalog still bounty+proof)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- loc-cap` (`bins/ctx` 1481 / 1500)
- [x] `cargo run -p xtask -- consensus-lint` / `spec-check` / `design-check` / `external-docs-check`
- [x] GitHub CI `fmt · clippy · test · deny · xtask` — green
- [ ] Greptile review

## Risk

Docs + miner CLI only. No challenge scoring, emission, model pin, or deploy path is touched. Off commands can still POST to a local Relearn service; they cannot earn weight without a trust-root row.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e85593db-ccc8-49d3-b72b-d5e14ed6581e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e85593db-ccc8-49d3-b72b-d5e14ed6581e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

