### PR TITLE
ops(compose): set prod BASE_GATEWAY_REQUIRE_OWNER=1

### DIFF
--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -1,10 +1,8 @@
 # Production environment — Bittensor mainnet (Finney), netuid 100.
 #
-# Wallet on disk (`base-owner` → 5GziQCc…) is NOT the current on-chain
-# SubnetOwnerHotkey (as of 2026-08-10: 5HdSGJgs… / f623c6…). With
-# REQUIRE_OWNER=1 the gateway refuses to bind (exit 2) and Caddy serves 502.
-# Keep advisory (0) until the live owner wallet is installed under
-# deploy/secrets/wallets/base-owner, then flip to "1".
+# Owner wallet on disk matches SubnetOwnerHotkey (5ExuWpCM…), so
+# REQUIRE_OWNER=1. gateway_admin_token is required (gates /v1/admin/*).
+# Recreate the gateway on droplets after this lands.
 #
 # Conservative intervals, no evil-gateway, no e2e overrides.
 services:
@@ -41,8 +39,8 @@ services:
       BT_WALLETS_PATH: /run/base/wallets
       BASE_GATEWAY_WALLET: base-owner
       BASE_GATEWAY_WALLET_HOTKEY: default
-      # Advisory until wallet matches live SubnetOwnerHotkey (see header).
-      BASE_GATEWAY_REQUIRE_OWNER: "0"
+      # REQUIRE_OWNER=1 now that owner wallet is on disk; gateway_admin_token required.
+      BASE_GATEWAY_REQUIRE_OWNER: "1"
       # Required whenever REQUIRE_OWNER=1 — gates /v1/admin/* (seal, backends, …).
       BASE_GATEWAY_ADMIN_TOKEN_FILE: /run/secrets/gateway_admin_token
     # Serve chain.joinbase.ai without forcing clients onto :8080 (8080 is VPC-only).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production owner wallet now matches SubnetOwnerHotkey (`5ExuWpCM…`). Flip `BASE_GATEWAY_REQUIRE_OWNER` from `"0"` to `"1"` in `deploy/compose/env-prod.yml` so the gateway’s master-only identity check is fail-closed, matching staging.

Comments that described the old ops gap (leave at 0 until the live owner wallet is on disk) now say `REQUIRE_OWNER=1` with `gateway_admin_token` required for `/v1/admin/*`.

No other compose settings changed.

**After merge:** recreate the gateway on prod droplets so the new env is picked up. Ceremony `gateway_admin_token` is already installed on hosts.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [x] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

**P1 (deploy preflight/rollback):** answered, out of scope — staging already runs `REQUIRE_OWNER=1` with the same `remote-deploy.sh` replace path; operators recreate the gateway after this lands. Fail-closed bind refusal on a wallet/token mismatch is the intended behavior.

**P2 (stale completeness row):** fixed — `docs/COMPLETENESS.md` / `deploy/AGENTS.md` now record prod `REQUIRE_OWNER=1`.

## Test plan

- [x] Compose-only change; no crate/Rust surface
- [x] CI green on the compose commit (`feccb001`)
- [ ] After deploy: recreate gateway on prod droplets; confirm bind succeeds with owner check
- [ ] Confirm `/v1/admin/*` still requires bearer `gateway_admin_token`

## Risk

**Deploy:** gateway will refuse to bind (exit 2) if the on-disk `base-owner` hotkey does not match live `SubnetOwnerHotkey`, and Caddy would serve 502. Operator confirmed the wallet now matches. `REQUIRE_OWNER=1` also requires `gateway_admin_token` (already installed). Existing compose env is not live until operators recreate the gateway container.

No miner CVM measurement, signature domain, or emission impact.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8af3340-4598-4897-9da0-0c091412b5c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8af3340-4598-4897-9da0-0c091412b5c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

