### PR TITLE
ops(compose): set staging BASE_GATEWAY_REQUIRE_OWNER=0

### DIFF
--- a/deploy/compose/env-staging.yml
+++ b/deploy/compose/env-staging.yml
@@ -1,9 +1,5 @@
 # Staging environment — Bittensor testnet (Finney), netuid 541.
 #
-# Netuid 541 is owned on testnet by the `base-owner` hotkey
-# (5CfjVGG7DaagMUuABNnqQJygLV2xtn3AQ7LnPeFoc5gVK9xo), so the gateway's
-# subnet-owner check passes here for real.
-#
 # Cleartext/IP e2e (no TLS).
 services:
   validator:
@@ -34,8 +30,11 @@ services:
       BASE_DOMAIN: staging.api.joinbase.ai
       BT_WALLETS_PATH: /run/base/wallets
       BASE_GATEWAY_WALLET: base-owner
-      # We do own netuid 541 on testnet, so the owner check can be strict here.
-      BASE_GATEWAY_REQUIRE_OWNER: "1"
+      # Staging netuid 541 SubnetOwnerHotkey does not match the mainnet owner
+      # wallet (5ExuWpCM…); keep REQUIRE_OWNER=0 until a dedicated netuid-541
+      # owner wallet is installed under deploy/secrets/wallets. Do not install
+      # mainnet owner as a fake 541 owner.
+      BASE_GATEWAY_REQUIRE_OWNER: "0"
       # Required with REQUIRE_OWNER=1 — gates /v1/admin/*.
       BASE_GATEWAY_ADMIN_TOKEN_FILE: /run/secrets/gateway_admin_token
     # Serve the public hostname without forcing clients onto :8080.

--- a/docs/COMPLETENESS.md
+++ b/docs/COMPLETENESS.md
@@ -40,7 +40,7 @@ Honest per-component status as of `main` HEAD. Updated as phases land.
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Master check (`SubnetOwnerHotkey`) | done | Read from the live chain. Advisory by default; `BASE_GATEWAY_REQUIRE_OWNER=1` makes it fail-closed (set in staging). |
+| Master check (`SubnetOwnerHotkey`) | done | Read from the live chain. Advisory by default; `BASE_GATEWAY_REQUIRE_OWNER=1` makes it fail-closed. Staging stays at `0` until a dedicated netuid-541 owner wallet is installed (do not install the mainnet owner as a fake 541 owner). |
 | Registry + proxy | done | |
 | Bundle seal (`POST /v1/weights/raw` → `GET /v1/weights/latest`) | done | Unsealed: fail-closed burn (`sealed: false`, uid 0 = 100%) instead of 404. |
 | Chain backend | done | Live only. `fake_owner` was removed from `bins/gateway`. |

--- a/docs/runbooks/local-testnet-e2e.md
+++ b/docs/runbooks/local-testnet-e2e.md
@@ -160,7 +160,7 @@ rm -f deploy/env/local-tunnel.env
 - `assert-compose-matrix.sh` still validates staging/prod role×env; local overlay must not introduce `fake_owner` / `BASE_CHAIN_BACKEND`.
 - `docker-compose.e2e.yml` (`fake_owner`) is legacy cleartext harness — not the testnet path.
 - Agent-v1 / Phala CVM miner overlays are removed; miners submit over HTTP (see [`../external-miner/`](../external-miner/)).
-- `env-staging` sets `BASE_GATEWAY_REQUIRE_OWNER=1`; `env-local` overrides via `LOCAL_REQUIRE_OWNER` (smoke defaults to `0`).
+- `env-staging` sets `BASE_GATEWAY_REQUIRE_OWNER=0` (541 SubnetOwnerHotkey ≠ mainnet owner wallet; dedicated 541 wallet not installed). `env-local` overrides via `LOCAL_REQUIRE_OWNER` (smoke defaults to `0`; `--live` sets `1`).
 - Host probe ports default to `2808x` (not role-master `1808x`) to avoid staging SSH tunnels.
 - `BASE_DOCKER_BUILD_FROM=prebuilt` copies host `target/release/*` into a Debian bookworm image. Binaries built on a newer glibc host (e.g. needing `GLIBC_2.39`) will crash in-container — use `BASE_DOCKER_BUILD_FROM=source` or rebuild on bookworm. `local-e2e.sh` may treat prism/design health as soft-fail so gateway+validator smoke can still complete while deploy-wiring finishes.
 - Rebuild gateway/validator from **current** `main` before `--live`: stale `target/release/gateway` may still contain the removed `fake_owner` path and will not exercise real testnet owner checks.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #216 (prod-only). Staging netuid 541 `SubnetOwnerHotkey` does **not** match the mainnet owner wallet (`5ExuWpCM…`). Flip `BASE_GATEWAY_REQUIRE_OWNER` from `"1"` to `"0"` in `deploy/compose/env-staging.yml` so the gateway’s master-only identity check stays advisory until a dedicated netuid-541 owner wallet is installed under `deploy/secrets/wallets`.

Do **not** install the mainnet owner as a fake 541 owner.

`env-prod.yml` is unchanged in this PR.

Removed the stale header that claimed `base-owner` (`5CfjVGG7…`) owns 541 and that the owner check could be strict.

Greptile P2: aligned `docs/COMPLETENESS.md` and `docs/runbooks/local-testnet-e2e.md` so they no longer claim staging fail-closes the owner check. Local `--live` still sets `LOCAL_REQUIRE_OWNER=1`.

**After merge:** recreate the gateway on staging droplets so the new env is picked up. Gateway will continue to bind without a matching 541 owner wallet.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [x] Greptile has reviewed this PR; findings are fixed or answered
- [x] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] Compose-only change plus two operator-doc lines
- [x] CI green on the docs-follow-up commit
- [x] Confirm `env-prod.yml` is untouched
- [ ] After deploy: recreate gateway on staging; confirm bind succeeds with advisory owner check

## Risk

**Deploy:** staging gateway currently has `REQUIRE_OWNER=1`. If the on-disk `base-owner` hotkey does not match live 541 `SubnetOwnerHotkey`, the gateway refuses to bind (exit 2). This PR restores the advisory setting so staging can boot without a dedicated 541 owner wallet.

No miner CVM measurement, signature domain, or emission impact.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70efb698-83e8-40de-9d13-8e226f248cc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70efb698-83e8-40de-9d13-8e226f248cc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

