### PR TITLE
fix(challenges): boot when sk/session placeholders are empty

### DIFF
--- a/bins/bounty-challenge/src/main.rs
+++ b/bins/bounty-challenge/src/main.rs
@@ -93,10 +93,7 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: &Cli) -> Result<(), String> {
-    let sk = match &cli.challenge_sk_file {
-        Some(p) => Some(load_challenge_secret(p).map_err(|e| format!("challenge sk: {e}"))?),
-        None => None,
-    };
+    let sk = load_optional_sk(cli.challenge_sk_file.as_deref());
     let admin_hashes = load_admin_hashes(cli.admin_tokens_file.as_deref());
     let session_secret = load_session_secret(cli.session_secret_file.as_deref())?;
     // The CLI flag and the env var are the same knob; `resolve_scoring_backend`
@@ -193,6 +190,23 @@ fn build_emitter(
     ))))
 }
 
+fn load_optional_sk(path: Option<&std::path::Path>) -> Option<[u8; 32]> {
+    let p = path?;
+    match load_challenge_secret(p) {
+        Ok(k) => Some(k),
+        Err(e) => {
+            // Compose always sets BASE_CHALLENGE_SK_FILE; remote-deploy may
+            // materialize an empty placeholder so Docker does not create a
+            // directory. That must not take /health down.
+            tracing::warn!(
+                "challenge sk: {e}; bounty cannot sign leaves, so nothing will be emitted \
+                 and POST /v1/admin/seal will answer 409 while bounty holds a paid trust-root row"
+            );
+            None
+        }
+    }
+}
+
 fn load_admin_hashes(path: Option<&std::path::Path>) -> Vec<String> {
     let Some(p) = path else {
         return Vec::new();
@@ -209,13 +223,20 @@ fn load_admin_hashes(path: Option<&std::path::Path>) -> Vec<String> {
 
 fn load_session_secret(path: Option<&std::path::Path>) -> Result<Vec<u8>, String> {
     if let Some(p) = path {
-        let bytes = std::fs::read(p).map_err(|e| format!("session secret: {e}"))?;
-        if bytes.is_empty() {
-            return Err("session secret file is empty".into());
+        match std::fs::read(p) {
+            Ok(bytes) if !bytes.is_empty() => return Ok(bytes),
+            Ok(_) => tracing::warn!(
+                "BOUNTY_SESSION_SECRET_FILE is empty; using an ephemeral secret \
+                 (pairing sessions will not survive restart)"
+            ),
+            Err(e) => tracing::warn!(
+                "session secret: {e}; using an ephemeral secret \
+                 (pairing sessions will not survive restart)"
+            ),
         }
-        return Ok(bytes);
     }
-    // Dev / CI: ephemeral secret. Production should set BOUNTY_SESSION_SECRET_FILE.
+    // Dev / CI / empty host placeholder. Production should persist a
+    // non-empty BOUNTY_SESSION_SECRET_FILE so pairing survives restart.
     let mut out = vec![0u8; 32];
     getrandom_fill(&mut out)?;
     Ok(out)
@@ -296,5 +317,55 @@ mod tests {
         assert!(legacy_sim_opt_in_present());
         assert_eq!(resolve_scoring_backend(), ScoringBackend::Unconfigured);
         std::env::remove_var("BOUNTY_FORCE_SIM");
+    }
+
+    /// Compose always sets `BASE_CHALLENGE_SK_FILE`. remote-deploy may leave an
+    /// empty placeholder so Docker does not create a directory at that path.
+    /// That must not exit 1 — `/health` has to come up so routing smoke works.
+    #[test]
+    fn an_empty_or_missing_challenge_sk_file_does_not_abort_boot() {
+        let dir = std::env::temp_dir().join(format!(
+            "bounty-sk-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("dir");
+        let empty = dir.join("sk");
+        std::fs::write(&empty, []).expect("write");
+        assert!(load_optional_sk(Some(&empty)).is_none());
+        assert!(load_optional_sk(Some(&dir.join("missing"))).is_none());
+        assert!(load_optional_sk(None).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Same placeholder footgun for `BOUNTY_SESSION_SECRET_FILE`: empty or
+    /// missing must yield an ephemeral secret so pair HMAC still has bytes.
+    #[test]
+    fn an_empty_or_missing_session_secret_file_falls_back_to_ephemeral() {
+        let dir = std::env::temp_dir().join(format!(
+            "bounty-sess-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("dir");
+        let empty = dir.join("session_secret");
+        std::fs::write(&empty, []).expect("write");
+        let a = load_session_secret(Some(&empty)).expect("empty file");
+        let b = load_session_secret(Some(&dir.join("missing"))).expect("missing file");
+        let c = load_session_secret(None).expect("unset");
+        assert_eq!(a.len(), 32);
+        assert_eq!(b.len(), 32);
+        assert_eq!(c.len(), 32);
+        let present = dir.join("real");
+        std::fs::write(&present, b"persisted-session-secret").expect("write");
+        assert_eq!(
+            load_session_secret(Some(&present)).expect("present"),
+            b"persisted-session-secret"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/bins/proof-challenge/src/main.rs
+++ b/bins/proof-challenge/src/main.rs
@@ -87,7 +87,15 @@ fn main() -> ExitCode {
 
 fn run(cli: &Cli) -> Result<(), String> {
     if let Some(p) = &cli.challenge_sk_file {
-        let _sk = load_challenge_secret(p).map_err(|e| format!("challenge sk: {e}"))?;
+        if let Err(e) = load_challenge_secret(p) {
+            // Compose always sets BASE_CHALLENGE_SK_FILE; remote-deploy may
+            // materialize an empty placeholder so Docker does not create a
+            // directory. Missing/invalid key must not take /health down.
+            tracing::warn!(
+                "challenge sk: {e}; leaf signing unavailable until BASE_CHALLENGE_SK_FILE is a \
+                 32-byte mini-secret (or 64 hex chars)"
+            );
+        }
     }
     let pin = load_pin(cli.pin_file.as_deref())?;
     let backend = if cli.force_sim {
@@ -448,4 +456,51 @@ mod tests {
     }
 
     static LIUM_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Compose always points `PROOF_PIN_FILE` at the committed pin. Empty
+    /// `[inference].model` / `base_url` is pre-launch fail-closed (503), not a
+    /// boot reject — same as an empty eval digest.
+    #[test]
+    fn committed_pin_boots_with_empty_inference_model() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../config/proof-pin.toml");
+        let pin = load_pin(Some(&path)).expect("committed pin must boot");
+        assert!(
+            pin.inference.model.trim().is_empty(),
+            "empty model is pre-launch 503"
+        );
+        assert!(
+            pin.inference.base_url.trim().is_empty(),
+            "url is secret-backed"
+        );
+        assert!(pin.proxy_model.trim().is_empty());
+    }
+
+    /// Compose sets `PROOF_INFERENCE_OFFER_FILE`. A missing/closed offer is
+    /// `can_score=false` / submit 503 — it must not `exit 1`.
+    #[test]
+    fn compose_inference_offer_env_parses_and_a_missing_file_is_not_a_boot_error() {
+        let _guard = OFFER_ENV
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::env::set_var(
+            "PROOF_INFERENCE_OFFER_FILE",
+            "/run/base/proof/inference_offer.json",
+        );
+        let cli = Cli::try_parse_from(["proof-challenge"])
+            .unwrap_or_else(|e| panic!("PROOF_INFERENCE_OFFER_FILE broke parsing: {e}"));
+        assert_eq!(
+            cli.inference_offer_file.as_deref(),
+            Some(Path::new("/run/base/proof/inference_offer.json"))
+        );
+        let pin = load_pin(None).expect("default pin");
+        let err = load_offer(&pin, cli.inference_offer_file.as_deref())
+            .expect_err("missing offer is unavailable, not a panic");
+        assert!(
+            err.contains("read") || err.contains("PROOF_INFERENCE_OFFER_FILE"),
+            "{err}"
+        );
+        std::env::remove_var("PROOF_INFERENCE_OFFER_FILE");
+    }
+
+    static OFFER_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
 }

--- a/deploy/scripts/remote-deploy.sh
+++ b/deploy/scripts/remote-deploy.sh
@@ -186,9 +186,11 @@ rsync -az --delete \
 # directory with real files: compose would otherwise create directories where
 # the container expects files.
 # Same footgun for file mounts: if bounty_sk/proof_sk is missing, Docker
-# creates *directories* at those paths and the challenge bin fails with
-# "Is a directory" / "secret file missing". Materialize empty files when
-# absent; if a directory already poisoned the path, replace it with a file.
+# creates *directories* at those paths. Materialize empty files when absent
+# (the bins warn and still serve /health; they must not exit 1). If a
+# directory already poisoned the path, replace it with a file.
+# session_secret must be non-empty bytes — an empty placeholder used to
+# crash bounty-challenge at boot. Fill from urandom when missing or 0-length.
 ssh_h "mkdir -p '$REMOTE_DIR/deploy/env' '$REMOTE_DIR/deploy/secrets/lium' \
   '$REMOTE_DIR/deploy/secrets/bounty' \
   '$REMOTE_DIR/deploy/secrets/proof' \
@@ -198,7 +200,9 @@ ssh_h "mkdir -p '$REMOTE_DIR/deploy/env' '$REMOTE_DIR/deploy/secrets/lium' \
        [ -e '$REMOTE_DIR/deploy/secrets/lium/'\$f ] || : > '$REMOTE_DIR/deploy/secrets/lium/'\$f; \
      done \
   && [ -e '$REMOTE_DIR/deploy/secrets/bounty/admin_tokens' ] || : > '$REMOTE_DIR/deploy/secrets/bounty/admin_tokens' \
-  && [ -e '$REMOTE_DIR/deploy/secrets/bounty/session_secret' ] || : > '$REMOTE_DIR/deploy/secrets/bounty/session_secret' \
+  && if [ ! -s '$REMOTE_DIR/deploy/secrets/bounty/session_secret' ]; then \
+       dd if=/dev/urandom bs=32 count=1 status=none of='$REMOTE_DIR/deploy/secrets/bounty/session_secret'; \
+     fi \
   && [ -e '$REMOTE_DIR/deploy/secrets/proof/admin_tokens' ] || : > '$REMOTE_DIR/deploy/secrets/proof/admin_tokens' \
   && [ -e '$REMOTE_DIR/deploy/secrets/proof/topics.json' ] || echo '[]' > '$REMOTE_DIR/deploy/secrets/proof/topics.json' \
   && [ -e '$REMOTE_DIR/deploy/secrets/proof/holdouts.json' ] || echo '{}' > '$REMOTE_DIR/deploy/secrets/proof/holdouts.json' \

--- a/deploy/secrets/README.md
+++ b/deploy/secrets/README.md
@@ -39,7 +39,7 @@ chmod 0400 deploy/secrets/gateway_admin_token
 | `proof/inference_api_key` | proof-challenge | Provider API key for the eval image. **Never commit, never log.** Mode **0400**, uid **65532** |
 | `proof/inference_base_url` | proof-challenge | Optional secret-backed origin (`PROOF_INFERENCE_BASE_URL_FILE`) when pin `[inference].base_url` and the topic omit one. **Never commit, never log.** Mode **0400**, uid **65532** |
 | `bounty/admin_tokens` | bounty-challenge | Operator bearer for `POST /v1/admin/adjudicate` |
-| `bounty/session_secret` | bounty-challenge | Pairing session HMAC secret |
+| `bounty/session_secret` | bounty-challenge | Pairing session HMAC secret. Empty/missing no longer crashes boot (`/health` stays up; pairing will not survive restart). `remote-deploy.sh` fills a 32-byte value from urandom when the file is missing or 0-length. |
 
 ## Other
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Staging master has been crash-looping `bounty-challenge` and `proof-challenge` (exit 1 → `Restarting`) since well before #223. GHA [33952922508](https://github.com/CortexLM/cortex/actions/runs/33952922508) is the same pattern as #224 / #222 / #210: gateway `/healthz` is fine, `/challenge/{bounty,proof}/health` stays 502/503 because the processes never listen.

**Root cause is not InferenceOffer.** #223 already treats a missing/closed offer as warn + `can_score=false` / submit 503. `ProofPin::validate` accepts the committed pin with empty `[inference].model` / `base_url`. Compose `PROOF_INFERENCE_OFFER_FILE=/run/base/proof/inference_offer.json` is a file *inside* the existing `deploy/secrets/proof` directory mount — a missing file is ENOENT, not a Docker bind-mount poison.

The hard boot errors are the compose-always-set secret *files*:

| Env | Host path | What remote-deploy does if missing | Previous bin behavior |
|-----|-----------|-----------------------------------|------------------------|
| `BASE_CHALLENGE_SK_FILE` | `deploy/secrets/bounty_sk`, `proof_sk` | `: >` empty file (so Docker does not create a **directory** at a file mount) | `load_challenge_secret` → `Err` → **exit 1** |
| `BOUNTY_SESSION_SECRET_FILE` | `deploy/secrets/bounty/session_secret` | same empty placeholder | empty file → **exit 1** |

Both services therefore die before `/health`. The 502/503 oscillation is the gateway proxy hitting a restarting backend, not a failed backend registry (reseed returned 201).

This PR:

- bounty: invalid/empty `BASE_CHALLENGE_SK_FILE` → warn, skip emitter (same as unset)
- bounty: empty/unreadable `BOUNTY_SESSION_SECRET_FILE` → warn, ephemeral 32 bytes
- proof: invalid/empty `BASE_CHALLENGE_SK_FILE` → warn, keep serving `/health`
- `remote-deploy.sh`: fill `session_secret` from urandom when missing or 0-length (matches `local-e2e.sh`)

**Not invented:** no InferenceOffer JSON, no judge provider URL/key. Missing offer stays fail-closed on submit.

**Host files that must still exist for real weight (not for boot):**

- `deploy/secrets/bounty_sk` and `deploy/secrets/proof_sk` — 32 raw bytes or 64 hex, pubs matching the staging trust root (`#215` ceremony). Empty placeholders keep `/health` up but cannot sign leaves (bounty seal will 409 D24 until a real mini-secret is installed).
- `deploy/secrets/bounty/session_secret` — non-empty for pairing that survives restart (remote-deploy now generates one).
- `deploy/secrets/proof/inference_offer.json` and `inference_api_key` — **optional**. Missing → warn, `can_score=false`, submit 503. Do not invent a provider.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [ ] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot is silent, I commented `@greptileai review`

## Test plan

- [x] `cargo test -p bounty-challenge-bin -p proof-challenge-bin`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p bounty-challenge-bin -p proof-challenge-bin --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- loc-cap` (bins still well under cap)

## Risk

No emission / scoring / consensus change. Staging `/health` should come up without a live judge offer. Operators still need real `bounty_sk` / `proof_sk` before a seal can include signed leaves.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f0c9ecf-390f-4b48-99aa-b3c0c4c1f403?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f0c9ecf-390f-4b48-99aa-b3c0c4c1f403&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

