### PR TITLE
fix(proof-harvest): log stdout_tail on PROOF_EVAL_OK refuse

### DIFF
--- a/crates/proof-harvest/src/lib.rs
+++ b/crates/proof-harvest/src/lib.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use harvest_pod::{harvest_template_name, EvalPod, PodProgram};
+use harvest_pod::{harvest_template_name, truncate_tail, EvalPod, PodProgram};
 use prism_lium_types::InstanceSpec;
 use proof_eval::{
     secret_backed_base_url, EvalError, LiveScorer, ProofEvalDocument, PROOF_METRICS_SCHEMA,
@@ -32,6 +32,9 @@ pub const METRICS_MARKER: &str = "PROOF_METRICS=";
 
 /// Marker the eval image prints on a completed run.
 pub const OK_MARKER: &str = "PROOF_EVAL_OK";
+
+/// Bytes of pod stdout retained on a missing [`OK_MARKER`] refuse.
+const STDOUT_TAIL_BYTES: usize = 8 * 1024;
 
 /// Directory the request and metrics sidecar live in, on the pod.
 pub const POD_WORKDIR: &str = "/tmp/proof_eval";
@@ -272,7 +275,12 @@ impl LiveScorer for LiumProofHarvest {
         }
         let stdout = run.map_err(EvalError::Backend)?;
         if !PROGRAM.ran_to_completion(&stdout) {
-            tracing::warn!(instance, "eval image did not print {OK_MARKER}; refusing");
+            let stdout_tail = truncate_tail(&stdout, STDOUT_TAIL_BYTES);
+            tracing::warn!(
+                instance,
+                stdout_tail = %stdout_tail,
+                "eval image did not print {OK_MARKER}; refusing"
+            );
             return Err(EvalError::Backend(format!(
                 "eval image did not print {OK_MARKER}"
             )));
@@ -558,5 +566,80 @@ mod tests {
             .expect_err("spoof");
         assert!(err.to_string().contains("committed judge origin"), "{err}");
         assert!(!*pod.booted.lock().expect("booted"));
+    }
+
+    #[test]
+    fn stdout_tail_keeps_the_last_8kib() {
+        let fatal = "refused: no model: Qwen/Qwen3.8-0.6B";
+        let stdout = format!("{}{fatal}", "x".repeat(10 * 1024));
+        let tail = truncate_tail(&stdout, STDOUT_TAIL_BYTES);
+        assert!(tail.starts_with('…'), "{tail}");
+        assert!(tail.ends_with(fatal), "{tail}");
+        assert!(tail.len() <= STDOUT_TAIL_BYTES + '…'.len_utf8());
+    }
+
+    struct StdoutPod {
+        stdout: String,
+        booted: std::sync::Mutex<bool>,
+    }
+
+    impl StdoutPod {
+        fn new(stdout: impl Into<String>) -> Arc<Self> {
+            Arc::new(Self {
+                stdout: stdout.into(),
+                booted: std::sync::Mutex::new(false),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl EvalPod for StdoutPod {
+        async fn boot(&self, _spec: &InstanceSpec) -> Result<String, String> {
+            *self.booted.lock().expect("boot") = true;
+            Ok("pod-1".into())
+        }
+
+        async fn run(
+            &self,
+            _instance_id: &str,
+            _request: &[u8],
+            _env_file: &[u8],
+        ) -> Result<String, String> {
+            Ok(self.stdout.clone())
+        }
+
+        async fn shutdown(&self, _instance_id: &str) -> Result<bool, String> {
+            Ok(true)
+        }
+    }
+
+    #[tokio::test]
+    async fn harvest_refuses_stdout_without_ok_marker() {
+        let recs = synthetic_holdout(STRATUM_SIZE, 1);
+        let topic = harvest_topic(&recs);
+        let pod = StdoutPod::new("refused: no model: Qwen/Qwen3.8-0.6B\nexit=2\n");
+        let harvest = LiumProofHarvest::new(
+            pod.clone(),
+            HarvestLimits::default(),
+            vec!["ssh-ed25519 AAAAtest proof".into()],
+        )
+        .with_judge_api_key(Some("sk-live-not-a-real-secret".into()));
+        let err = harvest
+            .score(
+                &harvest_pin(),
+                &topic,
+                &harvest_offer(),
+                "digest-abcdef",
+                "artifact",
+                &recs,
+                "claim",
+            )
+            .await
+            .expect_err("no ok");
+        assert!(
+            matches!(err, EvalError::Backend(ref m) if m.contains(OK_MARKER)),
+            "{err}"
+        );
+        assert!(*pod.booted.lock().expect("booted"));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Live Proof harvest discarded pod stdout when the eval image omitted `PROOF_EVAL_OK`, so operators only saw a blind refuse (`eval image did not print PROOF_EVAL_OK`) and had to re-rent to diagnose. Prod E2E 2026-09-08 hit this: a B200 came up, then harvest refused ~5s after RUNNING because score exited 2 on an invalid HF id (`Qwen/Qwen3.8-0.6B`).

This PR logs a truncated **stdout tail (8 KiB)** on that refuse via `harvest_pod::truncate_tail` (re-export of `prism_lium::truncate_tail`). The returned `EvalError` is unchanged.

## What

- On missing `PROOF_EVAL_OK`, `tracing::warn!` now includes `stdout_tail` (last 8 KiB, UTF-8 safe).
- Unit tests: 8 KiB retain, and harvest still refuses a non-OK stdout path.

## Out of scope

- Proxy / HF model id (`DEFAULT_PROXY`, `PROOF_PROXY_MODEL_DIR`).
- `PROOF_HOLDOUT_STORE`.
- Re-rent / harvest wiring.
- Staging/prod hosts.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [ ] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `cargo test -p proof-harvest`
- [x] `cargo fmt` on the touched crate
- [x] `cargo clippy -p proof-harvest --all-targets -- -D warnings`

## Risk

Operator logs only. No scoring, emission, pin, or miner CVM change. Stdout may contain eval diagnostics (the point of this PR); the 8 KiB cap matches the pod `tail -c 8192 run.log` already appended to harvest stdout.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c091197b-eaf6-47d8-9704-79f73e8edc64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c091197b-eaf6-47d8-9704-79f73e8edc64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

