### PR TITLE
fix(prism-lium): abort rent when rent_gpu_count > 1

### DIFF
--- a/crates/prism-lium-types/src/types.rs
+++ b/crates/prism-lium-types/src/types.rs
@@ -185,8 +185,8 @@ impl Offer {
     /// Accepts an exact-width host, a larger host when `requested > 1`, or a
     /// multi-GPU host that advertises (or omits-min) GPU splitting. A 1-GPU
     /// pin never takes a non-split 8× pack. NCU is whole-host only, so
-    /// `rent_count` may exceed the pin; the client aborts before POST when
-    /// that happens. 8×5090 is never a silent fallback.
+    /// `rent_count` may exceed the pin; the client skips that offer before
+    /// POST and tries later split-capable rows. 8×5090 is never posted.
     #[must_use]
     pub fn matches_gpu_count(&self, requested: u32) -> bool {
         if self.allows_split_for(requested) {

--- a/crates/prism-lium-types/src/types.rs
+++ b/crates/prism-lium-types/src/types.rs
@@ -184,9 +184,9 @@ impl Offer {
     ///
     /// Accepts an exact-width host, a larger host when `requested > 1`, or a
     /// multi-GPU host that advertises (or omits-min) GPU splitting. A 1-GPU
-    /// pin never takes a non-split 8× pack — except NCU, which is whole-host
-    /// only and is the live B200 champion path. 8×5090 is never a silent
-    /// fallback.
+    /// pin never takes a non-split 8× pack. NCU is whole-host only, so
+    /// `rent_count` may exceed the pin; the client aborts before POST when
+    /// that happens. 8×5090 is never a silent fallback.
     #[must_use]
     pub fn matches_gpu_count(&self, requested: u32) -> bool {
         if self.allows_split_for(requested) {

--- a/crates/prism-lium/src/client.rs
+++ b/crates/prism-lium/src/client.rs
@@ -815,9 +815,12 @@ impl EvalJobBackend for LiumClient {
                 prism_lium_types::effective_gpu_count(selected.gpu_count, &selected.gpu_type);
             // Split hosts: requested width. NCU / non-split: whole host.
             let rent_gpu_count = selected.rent_count(spec.gpu_count);
-            if pref.matches_pin("RTX 5090") && rent_gpu_count >= 8 && spec.gpu_count < 8 {
+            // Proof harvest default is 1× (`HarvestLimits.gpu_count`). Never POST
+            // an 8× B200 whole-host / NCU upsell, and keep the 5090 8× abort.
+            if rent_gpu_count > spec.gpu_count {
                 return Err(LiumError::Api(format!(
-                    "abort: refusing {rent_gpu_count}× 5090 rent (no 8×5090 fallback)"
+                    "abort: refusing {rent_gpu_count}× {} rent (requested {}; no whole-host upsell)",
+                    selected.gpu_type, spec.gpu_count
                 )));
             }
             loop {
@@ -1557,7 +1560,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provision_rents_whole_host_on_ncu_2x_b200() {
+    async fn provision_refuses_ncu_2x_b200_when_requesting_one() {
         let server = MockServer::start().await;
         mount_common(
             &server,
@@ -1578,21 +1581,53 @@ mod tests {
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "pod-ncu"})),
             )
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path("/pods/pod-ncu"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"id": "pod-ncu", "status": "RUNNING"})),
-            )
+            .expect(0)
             .mount(&server)
             .await;
         let c = LiumClient::with_base_url("test-key", server.uri()).unwrap();
-        // HarvestLimits.gpu_count stays 1; rent_count upsizes NCU to 2.
-        let inst = c.provision(&provision_spec()).await.unwrap();
-        assert_eq!(inst.id, "pod-ncu");
+        // HarvestLimits.gpu_count stays 1; rent_count would upsize NCU to 2.
+        let err = c.provision(&provision_spec()).await.unwrap_err();
+        assert!(
+            err.to_string().contains("abort:") && err.to_string().contains("requested 1"),
+            "got {err}"
+        );
         assert_eq!(provision_spec().gpu_count, 1);
+    }
+
+    #[tokio::test]
+    async fn provision_refuses_8x_b200_when_requesting_one() {
+        let server = MockServer::start().await;
+        mount_common(
+            &server,
+            serde_json::json!([{
+                "id": "eight-b200",
+                "machine_name": "NVIDIA B200",
+                "gpu_count": 8,
+                "available_gpu_count": 8,
+                "min_gpu_count_for_rental": 1,
+                "ncu_profiling_enabled": true,
+                "price_per_gpu": 6.52
+            }]),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path("/executors/eight-b200/rent"))
+            .and(body_partial_json(serde_json::json!({"gpu_count": 8})))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "pod-8x"})),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+        let c = LiumClient::with_base_url("test-key", server.uri()).unwrap();
+        assert_eq!(provision_spec().gpu_count, 1);
+        let err = c.provision(&provision_spec()).await.unwrap_err();
+        assert!(
+            err.to_string().contains("abort:")
+                && err.to_string().contains("requested 1")
+                && (err.to_string().contains("8×") || err.to_string().contains("8x")),
+            "got {err}"
+        );
     }
 
     #[tokio::test]
@@ -1683,9 +1718,13 @@ mod tests {
         spec.gpu_count = 4;
         let err = c.provision(&spec).await.unwrap_err();
         assert!(
-            err.to_string().contains("8×5090")
-                || err.to_string().contains("8x5090")
-                || err.to_string().contains("no 8"),
+            err.to_string().contains("abort:")
+                && err.to_string().contains("requested 4")
+                && (err.to_string().contains("8×")
+                    || err.to_string().contains("8x")
+                    || err.to_string().contains("8×5090")
+                    || err.to_string().contains("8x5090")
+                    || err.to_string().contains("no 8")),
             "got {err}"
         );
     }

--- a/crates/prism-lium/src/client.rs
+++ b/crates/prism-lium/src/client.rs
@@ -815,13 +815,14 @@ impl EvalJobBackend for LiumClient {
                 prism_lium_types::effective_gpu_count(selected.gpu_count, &selected.gpu_type);
             // Split hosts: requested width. NCU / non-split: whole host.
             let rent_gpu_count = selected.rent_count(spec.gpu_count);
-            // Proof harvest default is 1× (`HarvestLimits.gpu_count`). Never POST
-            // an 8× B200 whole-host / NCU upsell, and keep the 5090 8× abort.
+            // Never POST more GPUs than requested (Proof harvest default 1×).
+            // Skip this candidate — a later split 8× B200 can still rent 1×.
             if rent_gpu_count > spec.gpu_count {
-                return Err(LiumError::Api(format!(
+                last_err = format!(
                     "abort: refusing {rent_gpu_count}× {} rent (requested {}; no whole-host upsell)",
                     selected.gpu_type, spec.gpu_count
-                )));
+                );
+                continue 'offers;
             }
             loop {
                 info!(
@@ -1628,6 +1629,70 @@ mod tests {
                 && (err.to_string().contains("8×") || err.to_string().contains("8x")),
             "got {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn provision_skips_ncu_upsell_and_rents_split_1x() {
+        let server = MockServer::start().await;
+        mount_common(
+            &server,
+            serde_json::json!([
+                {
+                    "id": "ncu-2x",
+                    "machine_name": "NVIDIA B200",
+                    "gpu_count": 2,
+                    "available_gpu_count": 2,
+                    "min_gpu_count_for_rental": 1,
+                    "ncu_profiling_enabled": true,
+                    "price_per_gpu": 5.5
+                },
+                {
+                    "id": "eight-b200-idle",
+                    "machine_name": "NVIDIA B200",
+                    "gpu_count": 8,
+                    "available_gpu_count": 8,
+                    "price_per_gpu": 6.52
+                }
+            ]),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path("/executors/ncu-2x/rent"))
+            .and(body_partial_json(serde_json::json!({"gpu_count": 2})))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "pod-ncu"})),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/executors/eight-b200-idle/rent"))
+            .and(body_partial_json(serde_json::json!({"gpu_count": 8})))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "pod-8x"})),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/executors/eight-b200-idle/rent"))
+            .and(body_partial_json(serde_json::json!({"gpu_count": 1})))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "pod-split-1"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/pods/pod-split-1"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id": "pod-split-1", "status": "RUNNING"})),
+            )
+            .mount(&server)
+            .await;
+        let c = LiumClient::with_base_url("test-key", server.uri()).unwrap();
+        let inst = c.provision(&provision_spec()).await.unwrap();
+        assert_eq!(inst.id, "pod-split-1");
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hard-abort Lium `POST /rent` when `rent_gpu_count` exceeds the requested width (`InstanceSpec.gpu_count` / Proof `HarvestLimits.gpu_count`, default 1).

Prod 2026-09-08 rented an 8× NVIDIA B200 (`rent_gpu_count=8`) then hit `CREATION_FAILED`. The previous abort only covered 8× **5090**. NCU / whole-host B200 `rent_count(1)→8` was still posted.

- Skip (do not POST) any candidate with `rent_gpu_count > spec.gpu_count`, then continue so a later split 8× B200 can still rent 1×.
- Solo oversize inventory still errors with the abort message; no HTTP rent body with `gpu_count=8`.
- Idle split 8× B200 with `available_gpu_count` still rents **1×**.
- `provision_refuses_8x_b200_when_requesting_one` proves the 8× NCU path is refused.
- `provision_skips_ncu_upsell_and_rents_split_1x` covers Greptile P1 (2× NCU + split 8× → rent 1×).

Did not invent digests, touch `FORCE_SIM`/StubWin, or change prod pins.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [x] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `cargo test -p prism-lium -p prism-lium-types`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p prism-lium -p prism-lium-types --all-targets -- -D warnings`

## Risk

Proof harvest will not POST NCU / whole-host upsells that exceed the requested GPU count. A later split-capable offer in the same candidate set can still rent 1×. No deploy pin or emission change.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b84e1574-cad4-4641-adba-4aa5038d0ecd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b84e1574-cad4-4641-adba-4aa5038d0ecd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

