### PR TITLE
fix(eval): install host C compiler for Triton on scoring image

### DIFF
--- a/.github/workflows/publish-proof-eval-image.yml
+++ b/.github/workflows/publish-proof-eval-image.yml
@@ -125,6 +125,8 @@ jobs:
             'test ! -L /usr/bin/proof-eval'
           docker run --rm --entrypoint /bin/sh "${ref}" -c \
             'env -i PATH=/usr/bin:/bin /usr/bin/proof-eval score --help'
+          docker run --rm --entrypoint /bin/sh "${ref}" -c \
+            'test -x /usr/bin/gcc && test -x /usr/bin/g++ && test "$CC" = gcc && test "$CXX" = g++'
           docker run --rm --entrypoint /opt/proof-eval-venv/bin/python "${ref}" \
             -c 'import torch, transformers'
           docker run --rm --entrypoint /opt/proof-eval-venv/bin/python "${ref}" \

--- a/eval/Dockerfile.scoring
+++ b/eval/Dockerfile.scoring
@@ -2,11 +2,23 @@
 #
 # Scoring image. This is the digest the control plane pins.
 #
-# CUDA Ubuntu base — the live pod is a GPU machine. `/usr/bin/proof-eval` is
-# a regular file (COPY), not a symlink. The image ships no HF bake
-# (`baked_proxies.json` is empty) and enforces the 12.5 Gbit/s / no-IB /
-# no-NVLink / no-NCCL-fast-fabric cap. Harvest stages local weights at
-# `PROOF_PROXY_MODEL_DIR` and holdout shards at `PROOF_HOLDOUT_STORE`.
+# CUDA Ubuntu *runtime* base — the live pod is a GPU machine.
+# `/usr/bin/proof-eval` is a regular file (COPY), not a symlink. The image
+# ships no HF bake (`baked_proxies.json` is empty) and enforces the
+# 12.5 Gbit/s / no-IB / no-NVLink / no-NCCL-fast-fabric cap. Harvest stages
+# local weights at `PROOF_PROXY_MODEL_DIR` and holdout shards at
+# `PROOF_HOLDOUT_STORE`.
+#
+# Triton (pulled in via torch) JIT-compiles CUDA kernels on the first GPU
+# forward after proxy weights load (Qwen SDPA/flash). That needs a host C
+# compiler. We stay on the runtime tag and install `build-essential`
+# (~200MB: gcc/g++) rather than switching to
+# `nvidia/cuda:12.8.1-devel-ubuntu24.04` (several GB: nvcc + CUDA headers).
+# Triton's LLVM backend does not need nvcc for this stack. The live
+# failure on pin `ff21fd98` was "Failed to find C compiler" / exit 1
+# after weight load — not a missing `cuda.h`. If a later kernel compile
+# fails on missing CUDA headers, switch BASE_IMAGE to the matching devel
+# digest (do not invent a sha256).
 #
 #   docker build -f eval/Dockerfile.scoring -t proof-eval:scoring .
 #
@@ -28,6 +40,9 @@ ENV PYTHONUNBUFFERED=1 \
     HF_HUB_DISABLE_TELEMETRY=1 \
     TRANSFORMERS_VERBOSITY=error \
     TOKENIZERS_PARALLELISM=false \
+    CC=gcc \
+    CXX=g++ \
+    CUDAHOSTCXX=g++ \
     PROOF_GIT_SHA=${PROOF_GIT_SHA} \
     PROOF_SELFTEST_REQUIRE_RUNTIME=1
 
@@ -35,6 +50,7 @@ RUN set -eux; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates curl openssh-server iproute2 \
+        build-essential \
         python3 python3-pip python3-venv; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tini \
         || curl -fsSL -o /usr/bin/tini \
@@ -47,7 +63,9 @@ RUN set -eux; \
     mkdir -p /run/sshd /root/.ssh /opt/proof-eval/baselines; \
     chmod 700 /root/.ssh; \
     test -x /usr/bin/python3; \
-    test -x /usr/bin/tini
+    test -x /usr/bin/tini; \
+    test -x /usr/bin/gcc; \
+    test -x /usr/bin/g++
 
 WORKDIR /opt/proof-eval
 COPY eval/pyproject.toml ./
@@ -80,6 +98,7 @@ RUN set -eux; \
     test -f /usr/bin/proof-eval; \
     test ! -L /usr/bin/proof-eval; \
     test -x /usr/bin/proof-eval; \
+    env -i PATH=/usr/bin:/bin /usr/bin/gcc --version >/dev/null; \
     env -i PATH=/usr/bin:/bin /usr/bin/proof-eval --help >/dev/null; \
     env -i PATH=/usr/bin:/bin /usr/bin/proof-eval score --help >/dev/null; \
     env -i PATH=/usr/bin:/bin HOME=/root PROOF_SELFTEST_REQUIRE_RUNTIME=1 \

--- a/eval/README.md
+++ b/eval/README.md
@@ -13,11 +13,15 @@ Harvest wrappers print `PROOF_METRICS=<document>` and `PROOF_EVAL_OK`.
 non-zero with no marker.
 
 Pin the **scoring** image (`eval/Dockerfile.scoring`, CUDA + torch), never
-the contract-only digest. The RLM **judge** is the live `InferenceOffer`
-(OpenAI-compatible HTTP). Auth is `teacher.env` (`OPENAI_API_KEY` /
-`PROOF_INFERENCE_API_KEY`) staged by harvest — never request.json, never
-git. No HF bake into the judge path. Fabric: no InfiniBand, no NVLink, no
-NCCL fast path, 12.5 Gbit/s cap.
+the contract-only digest. The scoring image installs a host C compiler
+(`build-essential`, `CC=gcc`). Torch/Triton JIT-compiles CUDA kernels on
+the first GPU forward after measurement weights load; without gcc the
+process exits 1 and harvest never prints `PROOF_EVAL_OK` (control plane
+503). The RLM **judge** is the live `InferenceOffer` (OpenAI-compatible
+HTTP). Auth is `teacher.env` (`OPENAI_API_KEY` / `PROOF_INFERENCE_API_KEY`)
+staged by harvest — never request.json, never git. No HF bake into the
+judge path. Fabric: no InfiniBand, no NVLink, no NCCL fast path,
+12.5 Gbit/s cap.
 
 No secrets, holdout text, teacher hosts, or Modal references are baked in.
 The pin ships **no HF bake** and this image does not download a default

--- a/eval/src/proof_eval/harness.py
+++ b/eval/src/proof_eval/harness.py
@@ -19,6 +19,22 @@ from .request import HarvestRequest
 SCORED_SPLITS = ("web_ood", "code_ood", "math_ood", "longctx", "multilingual_ood")
 
 
+def _ensure_host_cc() -> None:
+    """Point Triton at gcc when harvest SSH dropped Docker ENV.
+
+    First CUDA kernel compile (SDPA / flash after Qwen weight load) needs a
+    host C compiler. The scoring image installs `build-essential`. This only
+    sets `CC`/`CXX`/`CUDAHOSTCXX` when unset — scores are unchanged. Do not
+    disable flash/SDPA here: that would change tokens/sec and possibly NLL.
+    """
+    if not os.environ.get("CC"):
+        os.environ["CC"] = "gcc"
+    if not os.environ.get("CXX"):
+        os.environ["CXX"] = "g++"
+    if not os.environ.get("CUDAHOSTCXX"):
+        os.environ["CUDAHOSTCXX"] = "g++"
+
+
 def require_runtime() -> None:
     try:
         import torch  # noqa: F401
@@ -70,6 +86,7 @@ def measure(request: HarvestRequest, artifact_dir: str | None) -> dict[str, Any]
     The pin ships no HF bake: weights must already be a local directory.
     """
     require_runtime()
+    _ensure_host_cc()
     import torch
     from transformers import AutoModelForCausalLM, AutoTokenizer
 

--- a/eval/tests/test_contract.py
+++ b/eval/tests/test_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from threading import Thread
@@ -12,7 +13,7 @@ import pytest
 from proof_eval.baked import baked_proxies, require_baked
 from proof_eval.contract import DEFAULT_PROXY, METRICS_MARKER, OK_MARKER
 from proof_eval.fabric import DT_NO_IB_GBPS, enforce
-from proof_eval.harness import _shard_text, require_local_model_dir
+from proof_eval.harness import _ensure_host_cc, _shard_text, require_local_model_dir
 from proof_eval.judge import call_judge, load_judge_api_key, require_judge
 from proof_eval.request import Constraints, HarvestRequest, canonical_json, holdout_commitment
 
@@ -32,6 +33,26 @@ def test_no_hf_default_proxy() -> None:
 def test_unknown_proxy_is_refused() -> None:
     with pytest.raises(Exception, match="not baked"):
         require_baked("Qwen/Qwen3-0.6B")
+
+
+def test_ensure_host_cc_sets_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CC", raising=False)
+    monkeypatch.delenv("CXX", raising=False)
+    monkeypatch.delenv("CUDAHOSTCXX", raising=False)
+    _ensure_host_cc()
+    assert os.environ["CC"] == "gcc"
+    assert os.environ["CXX"] == "g++"
+    assert os.environ["CUDAHOSTCXX"] == "g++"
+
+
+def test_ensure_host_cc_does_not_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CC", "clang")
+    monkeypatch.setenv("CXX", "clang++")
+    monkeypatch.setenv("CUDAHOSTCXX", "clang++")
+    _ensure_host_cc()
+    assert os.environ["CC"] == "clang"
+    assert os.environ["CXX"] == "clang++"
+    assert os.environ["CUDAHOSTCXX"] == "clang++"
 
 
 def test_local_model_dir_is_required() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Live Proof eval on a 1× B200 Lium pod (pin prefix `ff21fd98`) loaded Qwen proxy weights then died:

```
error: Failed to find C compiler. Please specify via CC environment variable or set triton.knobs.build.impl.
exit=1
```

`PROOF_EVAL_OK` never printed, so the control plane stayed **503**.

`eval/Dockerfile.scoring` used `nvidia/cuda:12.8.1-runtime-ubuntu24.04` and only installed `ca-certificates curl openssh-server iproute2 python3 python3-pip python3-venv` (+ tini). No `gcc`/`g++`. Torch pulls Triton; Triton's first CUDA kernel compile (Qwen SDPA/flash after weight load) needs a host C compiler.

The failure was missing **CC**, not missing `nvcc` / `cuda.h`. Triton's LLVM backend compiles the GPU kernel itself; gcc is only for the host launcher.

## What changed

- **`eval/Dockerfile.scoring`:** keep the **runtime** CUDA base (smaller). Install `build-essential`. Set `ENV CC=gcc CXX=g++ CUDAHOSTCXX=g++`. Build-time `test -x /usr/bin/gcc` and `gcc --version` on a clean `PATH`.
  - Size tradeoff: `build-essential` is ~200MB vs switching to `nvidia/cuda:12.8.1-devel-ubuntu24.04` (several GB of nvcc + CUDA headers). If a later kernel compile fails on missing `cuda.h`, switch `BASE_IMAGE` to the matching **devel** digest — do not invent a sha256.
- **`eval/src/proof_eval/harness.py`:** score-neutral belt-and-suspenders: set `CC`/`CXX`/`CUDAHOSTCXX` when unset (harvest SSH may drop Docker ENV). Does **not** disable flash/SDPA or `torch.compile` — that would change tokens/sec and possibly NLL.
- **`eval/README.md`:** scoring image requires a C compiler for Triton.
- **`publish-proof-eval-image`:** after pull, assert `gcc`/`g++` exist and `CC=gcc`.
- `baked_proxies.json` stays `[]`. No HF bake, secrets, or holdouts. Fabric selftest / `proof-eval` entrypoint unchanged.

## Operator: republish + re-pin

This PR does **not** bump `config/proof-pin.toml`. Do not invent a digest.

1. Merge (or let `publish-proof-eval-image` run on this `cursor/**` branch — it builds `eval/Dockerfile.scoring`).
2. Wait for [publish-proof-eval-image](https://github.com/CortexLM/cortex/actions/workflows/publish-proof-eval-image.yml) to finish green.
3. Copy the scoring digest from the job summary (`eval_image_digest = "sha256:…"`).
4. Bump `eval_image_digest` (and the pin comment / `proof_git_sha`) in `config/proof-pin.toml` to **that** published digest.
5. Until the pin moves, live harvest still boots the old image without gcc.

Empty digest stays fail-closed (503). A pin + `can_score` is not proof of scientific reproduction.

## Test plan

- [x] `pytest eval/tests` (contract + new CC helper tests)
- [ ] `publish-proof-eval-image` on this branch: digest pull, gcc present, `CC=gcc`, empty `baked_proxies`, `proof-eval selftest`
- [ ] After merge + pin bump: live 1× GPU score prints `PROOF_EVAL_OK`

Rust fmt/clippy/xtask gates are not in scope (eval image + workflow only).

## Risk

Live Proof scoring image only. No `BASE_*` rename, no emission/consensus change, no invented sha256. Next live rent still 503 until operators republish and re-pin.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths, GHCR package names, or `base-*-v1` cryptographic domain tags.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a84151d7-283e-4a8c-8b73-f669e2d3bb1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a84151d7-283e-4a8c-8b73-f669e2d3bb1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

