### PR TITLE
fix(eval): bake python3-dev so Triton can find Python.h

### DIFF
--- a/.github/workflows/publish-proof-eval-image.yml
+++ b/.github/workflows/publish-proof-eval-image.yml
@@ -127,6 +127,8 @@ jobs:
             'env -i PATH=/usr/bin:/bin /usr/bin/proof-eval score --help'
           docker run --rm --entrypoint /bin/sh "${ref}" -c \
             'test -x /usr/bin/gcc && test -x /usr/bin/g++ && test "$CC" = gcc && test "$CXX" = g++'
+          docker run --rm --entrypoint /bin/sh "${ref}" -c \
+            'inc=$(/opt/proof-eval-venv/bin/python -c "import sysconfig; print(sysconfig.get_path(\"include\"))"); test -f "$inc/Python.h" && echo "#include <Python.h>" | gcc -E -I"$inc" - >/dev/null'
           docker run --rm --entrypoint /opt/proof-eval-venv/bin/python "${ref}" \
             -c 'import torch, transformers'
           docker run --rm --entrypoint /opt/proof-eval-venv/bin/python "${ref}" \
@@ -161,8 +163,9 @@ jobs:
             echo "### proof-eval (scoring image, CUDA base)"
             echo
             echo "Pulled this digest after push, ran the harvest-PATH check,"
-            echo "proved \`import torch, transformers\`, empty baked_proxies (no HF bake),"
-            echo "and ran \`proof-eval selftest\` (fabric 12.5 Gbit/s / no IB-NVLink-NCCL)."
+            echo "proved gcc/g++ + \`Python.h\` (Triton driver.c), \`import torch, transformers\`,"
+            echo "empty baked_proxies (no HF bake), and ran \`proof-eval selftest\`"
+            echo "(fabric 12.5 Gbit/s / no IB-NVLink-NCCL)."
             echo "Live score requires harvest-staged \`PROOF_PROXY_MODEL_DIR\` +"
             echo "\`PROOF_HOLDOUT_STORE\`. Paste into the control plane's"
             echo "\`config/proof-pin.toml\` (keep proxy_model empty):"

--- a/eval/Dockerfile.scoring
+++ b/eval/Dockerfile.scoring
@@ -11,14 +11,17 @@
 #
 # Triton (pulled in via torch) JIT-compiles CUDA kernels on the first GPU
 # forward after proxy weights load (Qwen SDPA/flash). That needs a host C
-# compiler. We stay on the runtime tag and install `build-essential`
-# (~200MB: gcc/g++) rather than switching to
+# compiler *and* CPython headers. We stay on the runtime tag and install
+# `build-essential` (~200MB: gcc/g++) plus `python3-dev` (Python.h for
+# the venv's 3.12) rather than switching to
 # `nvidia/cuda:12.8.1-devel-ubuntu24.04` (several GB: nvcc + CUDA headers).
 # Triton's LLVM backend does not need nvcc for this stack. The live
 # failure on pin `ff21fd98` was "Failed to find C compiler" / exit 1
-# after weight load — not a missing `cuda.h`. If a later kernel compile
-# fails on missing CUDA headers, switch BASE_IMAGE to the matching devel
-# digest (do not invent a sha256).
+# after weight load — not a missing `cuda.h`. After gcc landed
+# (`sha256:996cb5f4…`), the next live refuse was Triton's
+# `backends/nvidia/driver.c` failing `#include <Python.h>` (no python3-dev).
+# If a later kernel compile fails on missing CUDA headers, switch
+# BASE_IMAGE to the matching devel digest (do not invent a sha256).
 #
 #   docker build -f eval/Dockerfile.scoring -t proof-eval:scoring .
 #
@@ -51,7 +54,7 @@ RUN set -eux; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates curl openssh-server iproute2 \
         build-essential \
-        python3 python3-pip python3-venv; \
+        python3 python3-dev python3-pip python3-venv; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tini \
         || curl -fsSL -o /usr/bin/tini \
             https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd64; \
@@ -65,7 +68,8 @@ RUN set -eux; \
     test -x /usr/bin/python3; \
     test -x /usr/bin/tini; \
     test -x /usr/bin/gcc; \
-    test -x /usr/bin/g++
+    test -x /usr/bin/g++; \
+    test -f "$(python3 -c 'import sysconfig; print(sysconfig.get_path("include"))')/Python.h"
 
 WORKDIR /opt/proof-eval
 COPY eval/pyproject.toml ./
@@ -99,6 +103,9 @@ RUN set -eux; \
     test ! -L /usr/bin/proof-eval; \
     test -x /usr/bin/proof-eval; \
     env -i PATH=/usr/bin:/bin /usr/bin/gcc --version >/dev/null; \
+    inc="$(/opt/proof-eval-venv/bin/python -c 'import sysconfig; print(sysconfig.get_path("include"))')"; \
+    test -f "${inc}/Python.h"; \
+    echo '#include <Python.h>' | gcc -E -I"${inc}" - >/dev/null; \
     env -i PATH=/usr/bin:/bin /usr/bin/proof-eval --help >/dev/null; \
     env -i PATH=/usr/bin:/bin /usr/bin/proof-eval score --help >/dev/null; \
     env -i PATH=/usr/bin:/bin HOME=/root PROOF_SELFTEST_REQUIRE_RUNTIME=1 \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Live 1× BYOK harvest on prod **failed again** after [#239](https://github.com/CortexLM/cortex/pull/239) (`424fb12a`, pin `sha256:996cb5f4…`). `gcc` is present now, but Triton still dies compiling `backends/nvidia/driver.c`:

```
/opt/proof-eval-venv/lib/python3.12/site-packages/triton/backends/nvidia/driver.c:9:10: fatal error: Python.h: No such file or directory
#include <Python.h>
```

`PROOF_EVAL_OK` never printed, so the control plane stayed **503**.

`eval/Dockerfile.scoring` installed `build-essential` + `python3` / `python3-pip` / `python3-venv` but not `python3-dev`. The venv is CPython 3.12; Triton's host launcher compile needs `Python.h` from that version.

## What changed

- **`eval/Dockerfile.scoring`:** keep `build-essential` and `CC`/`CXX`/`CUDAHOSTCXX=gcc`/`g++` from #239. Add `python3-dev` (Ubuntu 24.04 → 3.12 headers matching the venv). Bake-time checks: `Python.h` exists via `sysconfig.get_path("include")`, and `gcc -E` can preprocess `#include <Python.h>` against that path.
- **`publish-proof-eval-image`:** after the existing gcc check, assert `Python.h` is findable the same way (venv include path, not a hardcoded 3.12).
- No harness / harvest / BYOK / miner-autonomy change. Empty `baked_proxies.json`. No invented sha256.

## Operator: republish + re-pin

This PR does **not** bump `config/proof-pin.toml`. Do not invent a digest.

Branch `publish-proof-eval-image` already built and pulled a scoring digest (run [34214757296](https://github.com/CortexLM/cortex/actions/runs/34214757296)): bake found `/usr/include/python3.12/Python.h`, `gcc -E` preprocess passed, harvest-PATH / gcc / `Python.h` / empty `baked_proxies` / `selftest` all green.

```
eval_image_digest = "sha256:d32676bf27a63cd721aa5572c8aa110c81652b10e8820e9d48928ed21d3ac1ce"
```

`PROOF_GIT_SHA` is a build-arg, so a merge-to-main republish will mint a **new** digest. Pin the digest from the **post-merge** job summary, not this branch one, unless you intentionally pin the branch image.

1. Merge (or let `publish-proof-eval-image` run on this `cursor/**` branch — it builds `eval/Dockerfile.scoring`).
2. Wait for [publish-proof-eval-image](https://github.com/CortexLM/cortex/actions/workflows/publish-proof-eval-image.yml) on `main` to finish green.
3. Copy the scoring digest from the job summary (`eval_image_digest = "sha256:…"`).
4. Bump `eval_image_digest` (and the pin comment / `proof_git_sha`) in `config/proof-pin.toml` to **that** published digest.
5. Until the pin moves, live harvest still boots `sha256:996cb5f4…` (gcc, no `Python.h`).

Empty digest stays fail-closed (503). A pin + `can_score` is not proof of scientific reproduction.

## Greptile

- [x] Greptile has reviewed this PR; findings are fixed or answered (5/5, no issues; T-Rex built the scoring image and confirmed `Python.h` preprocess)
- [x] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `publish-proof-eval-image` on this branch: digest pull, gcc present, `CC=gcc`, `Python.h` preprocess via venv include path (`/usr/include/python3.12/Python.h`), empty `baked_proxies`, `proof-eval selftest`
- [ ] After merge + pin bump: live 1× GPU score prints `PROOF_EVAL_OK`

Rust fmt/clippy/xtask gates are not in scope (Dockerfile + workflow only).

## Risk

Live Proof scoring image only. No `BASE_*` rename, no emission/consensus change, no invented sha256. Next live rent still 503 until operators republish and re-pin.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths, GHCR package names, or `base-*-v1` cryptographic domain tags.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6f39dd-c498-4813-9840-d564832ed65e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6f39dd-c498-4813-9840-d564832ed65e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

