### PR TITLE
fix(proof-vm-agent): install rustls provider at boot, drop aws-lc-rs (Architecte follow-up 1/4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "asn1_der"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +558,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,7 +575,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -538,6 +583,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1306,7 +1360,7 @@ dependencies = [
  "log",
  "p256 0.14.0",
  "parity-scale-codec",
- "pem",
+ "pem 3.0.6",
  "reqwest 0.13.4",
  "ring",
  "rustls-pki-types",
@@ -1379,6 +1433,20 @@ dependencies = [
  "der_derive",
  "flagset",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2869,6 +2937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +2985,16 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2990,6 +3074,15 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3127,6 +3220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -3752,6 +3855,8 @@ dependencies = [
  "proof-fc-host",
  "proof-vm-agent",
  "proof-vm-proto",
+ "rcgen",
+ "rustls",
  "telemetry",
  "tokio",
  "tracing",
@@ -3776,7 +3881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.5",
@@ -4015,6 +4120,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
+dependencies = [
+ "pem 4.0.0",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,6 +4335,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,6 +4363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6324,6 +6453,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
@@ -6342,6 +6489,16 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "twox-hash",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/bins/proof-vm-orchestrator/Cargo.toml
+++ b/bins/proof-vm-orchestrator/Cargo.toml
@@ -14,14 +14,24 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
-axum-server = { version = "0.8", features = ["tls-rustls"] }
+# `tls-rustls-no-provider`, not `tls-rustls`: the latter pulls rustls's
+# `aws-lc-rs` feature, while every other workspace crate (reqwest) enables
+# `ring`. A workspace-wide build then unified both and rustls could not pick a
+# CryptoProvider at boot (panic). The binary installs `ring` explicitly in
+# main.rs, so boot no longer depends on how the workspace was built.
+axum-server = { version = "0.8", default-features = false, features = ["tls-rustls-no-provider"] }
 clap = { version = "4", features = ["derive", "env"] }
 proof-fc-host = { path = "../../crates/proof-fc-host" }
 proof-vm-agent = { path = "../../crates/proof-vm-agent" }
 proof-vm-proto = { path = "../../crates/proof-vm-proto" }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 telemetry = { path = "../../crates/telemetry" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal"] }
 tracing = "0.1"
+
+[dev-dependencies]
+# Self-signed certificate for the boot smoke test (never shipped).
+rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem", "ring"] }
 
 [lints]
 workspace = true

--- a/bins/proof-vm-orchestrator/src/main.rs
+++ b/bins/proof-vm-orchestrator/src/main.rs
@@ -15,11 +15,17 @@
 //! non-loopback bind without a TLS certificate + key exits 1. A missing bearer
 //! file does not stop the process — every request is refused until it exists
 //! (the file is re-read per request, so rotation needs no restart).
+//!
+//! TLS boots the same way however the binary was built: the rustls
+//! [`CryptoProvider`](rustls::crypto::CryptoProvider) is installed explicitly
+//! ([`install_crypto_provider`]) before any TLS config exists, so a
+//! workspace-wide build that unified rustls's `ring` and `aws-lc-rs` features
+//! no longer panics at the first HTTPS listener.
 
 #![forbid(unsafe_code)]
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
@@ -197,8 +203,48 @@ fn tls_required(
     }
 }
 
+/// Name of the rustls provider this binary runs on.
+const CRYPTO_PROVIDER: &str = "ring";
+
+/// Select the process-level rustls [`CryptoProvider`](rustls::crypto::CryptoProvider)
+/// **once**, before any TLS config is built.
+///
+/// rustls only picks a provider on its own when exactly one of its `ring` /
+/// `aws-lc-rs` features is enabled. Cargo unifies features across every
+/// package selected for a build, so `cargo build --workspace` or `cargo build
+/// --bin proof-vm-orchestrator` from the workspace root used to enable both
+/// (reqwest → `ring`, axum-server's `tls-rustls` → `aws-lc-rs`) and
+/// `RustlsConfig::from_pem_file` panicked at boot with "Could not
+/// automatically determine the process-level `CryptoProvider`". Installing
+/// `ring` here makes boot independent of the build shape; the manifest also
+/// drops `aws-lc-rs` from this binary's own graph so a package-scoped build
+/// needs no cmake / C toolchain beyond what `ring` wants.
+///
+/// Returns `true` when this call installed the provider, `false` when one was
+/// already in place (a second call, or a test harness) — both are fine, and
+/// neither panics.
+fn install_crypto_provider() -> bool {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_ok()
+}
+
+/// Load the certificate chain + private key into a server config. Requires
+/// [`install_crypto_provider`] to have run (or exactly one provider feature).
+async fn tls_config(cert: &Path, key: &Path) -> Result<RustlsConfig, String> {
+    RustlsConfig::from_pem_file(cert, key)
+        .await
+        .map_err(|e| format!("tls {} / {}: {e}", cert.display(), key.display()))
+}
+
 fn main() -> ExitCode {
     let _ = telemetry::init_tracing();
+    let installed = install_crypto_provider();
+    tracing::info!(
+        provider = CRYPTO_PROVIDER,
+        installed_here = installed,
+        "rustls crypto provider selected"
+    );
     let cli = Cli::parse();
     let rt = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -252,9 +298,7 @@ async fn run(cli: &Cli) -> Result<(), String> {
         shutdown.graceful_shutdown(Some(Duration::from_secs(10)));
     });
     if let Some((cert, key)) = tls {
-        let config = RustlsConfig::from_pem_file(&cert, &key)
-            .await
-            .map_err(|e| format!("tls {} / {}: {e}", cert.display(), key.display()))?;
+        let config = tls_config(&cert, &key).await?;
         tracing::info!(bind = %cli.bind, "proof-vm-orchestrator listening (https)");
         return axum_server::bind_rustls(cli.bind, config)
             .handle(handle)
@@ -322,5 +366,45 @@ mod tests {
             .is_some());
         assert!(tls_required(public, Some(&cert), None).is_err());
         assert_eq!(cli(&[]).bind, public);
+    }
+
+    /// Boot smoke: the provider is installed exactly once (a repeat is a
+    /// no-op, never a panic) and a certificate + key load into a server
+    /// config afterwards — the step that panicked on the workspace-built
+    /// binary. The certificate is self-signed at test time; nothing on disk.
+    #[tokio::test]
+    async fn crypto_provider_installs_once_and_tls_boots_from_pem() {
+        let first = install_crypto_provider();
+        let second = install_crypto_provider();
+        assert!(!second, "a second install is a no-op");
+        // `first` may be false when another test in this process got there
+        // earlier; what matters is that a provider is now in force.
+        let _ = first;
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "a process-level provider is installed"
+        );
+        // ServerConfig::builder() is where an undecidable provider panics.
+        let _builder = rustls::ServerConfig::builder();
+
+        let key = rcgen::KeyPair::generate().expect("keypair");
+        let cert = rcgen::CertificateParams::new(vec!["kvm.example.invalid".to_owned()])
+            .expect("params")
+            .self_signed(&key)
+            .expect("self-signed");
+        let dir = std::env::temp_dir().join(format!("proof-vm-tls-smoke-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("dir");
+        let cert_path = dir.join("tls.crt");
+        let key_path = dir.join("tls.key");
+        std::fs::write(&cert_path, cert.pem()).expect("cert");
+        std::fs::write(&key_path, key.serialize_pem()).expect("key");
+        tls_config(&cert_path, &key_path)
+            .await
+            .expect("pem cert + key load into a rustls server config");
+        let err = tls_config(&dir.join("missing.crt"), &key_path)
+            .await
+            .expect_err("missing cert");
+        assert!(err.contains("missing.crt"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/docs/runbooks/proof-vm-orchestrator.md
+++ b/docs/runbooks/proof-vm-orchestrator.md
@@ -88,6 +88,60 @@ frames are 4-byte big-endian length + JSON, `api_version: 1`). The RLM guest
 asks for a sister by connecting to host port `5001` with a `SisterRequest`
 carrying the artefact tarball it already fetched and inspected.
 
+## Build
+
+The agent is a host binary (systemd unit), not a compose image. Build it on
+a box with the pinned toolchain (`rust-toolchain.toml`) and copy the file to
+the KVM host:
+
+```bash
+# glibc (matches the DO Ubuntu droplet's libc; simplest)
+cargo build --release -p proof-vm-orchestrator-bin
+ls -l target/release/proof-vm-orchestrator
+
+# static musl (one file, no libc dependency on the host)
+rustup target add x86_64-unknown-linux-musl          # plus `apt install musl-tools` for the C shim
+CC_x86_64_unknown_linux_musl=musl-gcc \
+  cargo build --release -p proof-vm-orchestrator-bin --target x86_64-unknown-linux-musl
+ls -l target/x86_64-unknown-linux-musl/release/proof-vm-orchestrator   # static-pie, ~8 MiB unstripped
+```
+
+(`ring` compiles its C with the target's compiler; Debian/Ubuntu ship it as
+`musl-gcc`, hence the `CC_…` variable — without it the build stops at
+`failed to find tool "x86_64-linux-musl-gcc"`.)
+
+Either shape boots. The binary selects its rustls `CryptoProvider` (`ring`)
+explicitly at start-up — boot log `rustls crypto provider selected
+provider=ring` — so a build that unified rustls's `ring` and `aws-lc-rs`
+features (`cargo build --workspace`, or `--bin proof-vm-orchestrator` from
+the workspace root, which resolves features over every member) no longer
+panics at the first HTTPS listener with `Could not automatically determine
+the process-level CryptoProvider`. That panic is what forced staging to keep
+a previously built binary; that workaround is retired — rebuild from `main`
+and install. The package-scoped command above is still the one to use: it
+also keeps `aws-lc-rs` (cmake + a C toolchain) out of the graph, which is
+what makes the musl build a plain `cargo build`.
+
+Smoke the file before installing it — no `/dev/kvm`, no images needed; it
+must **listen**, not panic (health answers `ready: false` naming the missing
+firecracker, which is the expected answer off the KVM host):
+
+```bash
+d=$(mktemp -d) && openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+  -keyout $d/k.pem -out $d/c.pem -subj /CN=smoke -addext subjectAltName=IP:127.0.0.1 -days 1 2>/dev/null
+echo smoke > $d/token
+timeout 3 target/release/proof-vm-orchestrator --bind 127.0.0.1:18200 --token-file $d/token \
+  --tls-cert $d/c.pem --tls-key $d/k.pem \
+  --kernel-digest sha256:$(printf 'a%.0s' {1..64}) --sister-image-digest sha256:$(printf 'b%.0s' {1..64}) \
+  2>&1 | grep -E 'crypto provider selected|listening \(https\)|panicked'
+# want: "rustls crypto provider selected" then "proof-vm-orchestrator listening (https)"; never "panicked"
+rm -rf $d
+```
+
+The same check runs in CI as the binary's unit test
+(`crypto_provider_installs_once_and_tls_boots_from_pem`: install twice, load
+a self-signed PEM pair into the server config).
+
 ## Install
 
 ```bash
@@ -102,9 +156,11 @@ systemctl daemon-reload && systemctl enable --now proof-vm-orchestrator
 journalctl -u proof-vm-orchestrator -n 50
 ```
 
-Boot log must show `firecracker + jailer + /dev/kvm present; agent ready` and
-`bearer token file present (contents not logged)`. A malformed pin exits 1; a
-non-loopback bind without TLS exits 1.
+Boot log must show `rustls crypto provider selected provider=ring`,
+`firecracker + jailer + /dev/kvm present; agent ready` and `bearer token file
+present (contents not logged)`. A malformed pin exits 1; a non-loopback bind
+without TLS exits 1; a `panicked` line anywhere at boot is a bug, never
+something to work around by keeping an older binary.
 
 Verify from the host (the bearer is required even for health):
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Architecte / Owner follow-up **1 of 4** (CryptoProvider — agent boot stable) before Proof FC wires on prod. Fixes the `proof-vm-orchestrator` boot panic that forced staging to keep a previously built binary; that workaround is retired.

**Root cause (reproduced locally, not guessed).** rustls only auto-selects a `CryptoProvider` when exactly one of its `ring` / `aws-lc-rs` features is on. Cargo unifies features across every package selected for a build, so `cargo build --workspace` **or** `cargo build --bin proof-vm-orchestrator` from the workspace root (which resolves features over all members) compiled rustls with **both**: reqwest → `ring`, `axum-server`'s `tls-rustls` → `aws-lc-rs`. `RustlsConfig::from_pem_file` then panicked at the first HTTPS listener:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point …
```

Only a package-scoped `cargo build -p proof-vm-orchestrator-bin` happened to work.

**Fix (`bins/proof-vm-orchestrator`)**
- `install_crypto_provider()`: install `ring` explicitly as the process-level provider before any TLS config exists; a repeat / pre-existing provider is a no-op, never a panic. Logged at boot: `rustls crypto provider selected provider=ring installed_here=…`.
- `axum-server` → `tls-rustls-no-provider` + a direct `rustls` dep on `ring`. `aws-lc-rs` / `aws-lc-sys` (cmake + C toolchain) leave the binary's graph entirely, so every build shape now unifies to the same single provider and the musl build is a plain `cargo build`.
- `tls_config()` split out so the PEM → server-config step is unit-testable.
- Smoke test `crypto_provider_installs_once_and_tls_boots_from_pem`: install twice, `ServerConfig::builder()` (the panic site), then load a self-signed PEM pair (`rcgen`, dev-dep only) into the server config.

**Docs (`docs/runbooks/proof-vm-orchestrator.md`)** — new § Build: exact flags for glibc and static musl (`CC_x86_64_unknown_linux_musl=musl-gcc`, because `ring` looks for `x86_64-linux-musl-gcc`), a no-KVM listen smoke to run before `install`, and the boot-log lines to expect; "a `panicked` line is a bug, never something to work around by keeping an older binary".

No wire / protocol / env change. No digest anywhere. Lockfile: `rcgen` + its closure (dev-only); `aws-lc-rs` is no longer in any built graph (`cargo tree --workspace -i aws-lc-rs` → none).

## How to verify

```bash
# 1. the exact staging shape that panicked, now boots
cargo build --release --bin proof-vm-orchestrator          # from the workspace root
d=$(mktemp -d) && openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
  -keyout $d/k.pem -out $d/c.pem -subj /CN=smoke -addext subjectAltName=IP:127.0.0.1 -days 1 2>/dev/null
echo smoke > $d/token
timeout 3 target/release/proof-vm-orchestrator --bind 127.0.0.1:18200 --token-file $d/token \
  --tls-cert $d/c.pem --tls-key $d/k.pem \
  --kernel-digest sha256:$(printf 'a%.0s' {1..64}) --sister-image-digest sha256:$(printf 'b%.0s' {1..64}) \
  2>&1 | grep -E 'crypto provider selected|listening \(https\)|panicked'
# → "rustls crypto provider selected" + "proof-vm-orchestrator listening (https)"; no "panicked"

# 2. package-scoped and musl shapes
cargo build --release -p proof-vm-orchestrator-bin
CC_x86_64_unknown_linux_musl=musl-gcc cargo build --release -p proof-vm-orchestrator-bin --target x86_64-unknown-linux-musl

# 3. unit smoke
cargo test -p proof-vm-orchestrator-bin
```

Verified here: the root `--bin` build reproduced the panic on `main` and boots HTTPS on this branch (curl health → 200 with bearer, 401 without); glibc release and static-pie musl release both boot.

## Greptile

- [ ] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, `cargo deny check`, xtask `loc-cap` / `consensus-lint` / `spec-check` / `design-check` / `external-docs-check` (compose-matrix assertion needs docker; not touched by this PR)

## Risk

Deploy only: the host-installed agent binary. No miner CVM measurement, signature domain, or emission impact. TLS behaviour is unchanged except that boot no longer panics; the provider (`ring`) is the one every other workspace binary already uses.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44f9c018-5822-4254-9aad-1cc9733baa11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44f9c018-5822-4254-9aad-1cc9733baa11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

