### PR TITLE
fix(gateway): pin SN100 defaults to gateway.cortex.foundation

### DIFF
--- a/.github/workflows/release-ctx.yml
+++ b/.github/workflows/release-ctx.yml
@@ -140,4 +140,4 @@ jobs:
             ctx status
             ```
 
-            Default gateway: https://network.cortex.foundation
+            Default gateway: https://gateway.cortex.foundation

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ deployment is ready.
 
 ## Get started
 
-The public gateway is [https://network.cortex.foundation](https://network.cortex.foundation).
+The public gateway is [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 
 Install the `ctx` command-line tool using
 [`scripts/install-ctx.sh`](scripts/install-ctx.sh):

--- a/bins/ctx/src/api.rs
+++ b/bins/ctx/src/api.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 ///
 /// Docs, `--help`, and `scripts/install-ctx.sh` all name this host. Override
 /// with `--gateway` only when you run your own stack.
-pub const DEFAULT_GATEWAY: &str = "https://network.cortex.foundation";
+pub const DEFAULT_GATEWAY: &str = "https://gateway.cortex.foundation";
 
 /// Per-request timeout. Submits rent nothing synchronously, so this is short.
 const TIMEOUT_SECS: u64 = 60;
@@ -156,23 +156,23 @@ mod tests {
 
     #[test]
     fn default_gateway_is_the_public_host() {
-        assert_eq!(DEFAULT_GATEWAY, "https://network.cortex.foundation");
+        assert_eq!(DEFAULT_GATEWAY, "https://gateway.cortex.foundation");
         assert!(!DEFAULT_GATEWAY.ends_with('/'));
     }
 
     #[test]
     fn trailing_slash_does_not_double_up() {
-        let c = Client::new("https://network.cortex.foundation/", None).expect("client");
-        assert_eq!(c.gateway(), "https://network.cortex.foundation");
+        let c = Client::new("https://gateway.cortex.foundation/", None).expect("client");
+        assert_eq!(c.gateway(), "https://gateway.cortex.foundation");
         assert_eq!(
             c.url("/v1/weights/latest"),
-            "https://network.cortex.foundation/v1/weights/latest"
+            "https://gateway.cortex.foundation/v1/weights/latest"
         );
     }
 
     #[test]
     fn non_http_gateway_is_rejected() {
-        assert!(Client::new("network.cortex.foundation", None).is_err());
+        assert!(Client::new("gateway.cortex.foundation", None).is_err());
     }
 
     #[test]

--- a/bins/ctx/src/main.rs
+++ b/bins/ctx/src/main.rs
@@ -27,7 +27,7 @@ use proof::SubmitInput;
     name = "ctx",
     version,
     about = "Cortex subnet CLI: challenge status, Proof submits, and Bounty reports",
-    long_about = "ctx talks to the public Cortex gateway at https://network.cortex.foundation.
+    long_about = "ctx talks to the public Cortex gateway at https://gateway.cortex.foundation.
 
 Live challenges: bounty (2000 bps) and proof (8000 bps). relearn*, design, and
 prism are off and earn nothing.
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn default_gateway_matches_the_docs_host() {
-        assert_eq!(DEFAULT_GATEWAY, "https://network.cortex.foundation");
+        assert_eq!(DEFAULT_GATEWAY, "https://gateway.cortex.foundation");
     }
 
     #[test]
@@ -363,7 +363,7 @@ mod tests {
             .map(ToString::to_string)
             .unwrap_or_default();
         assert!(
-            long_about.contains("https://network.cortex.foundation"),
+            long_about.contains("https://gateway.cortex.foundation"),
             "{long_about}"
         );
         assert!(!long_about.contains("<gateway>"), "{long_about}");

--- a/crates/proof-http/tests/live_submit_e2e.rs
+++ b/crates/proof-http/tests/live_submit_e2e.rs
@@ -20,10 +20,37 @@ fn base_url() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Production hosts the live probe must never touch. Compared as a parsed,
+/// lower-cased hostname (DNS is case-insensitive); a mixed-case spelling of
+/// the same host is still production.
+const PROD_HOSTS: &[&str] = &[
+    "gateway.cortex.foundation",
+    "network.cortex.foundation",
+    "chain.joinbase.ai",
+];
+
+/// Host part of `url`, lower-cased, trailing-dot stripped. Bare hosts (no
+/// scheme) are parsed as HTTPS so `GATEWAY.CORTEX.FOUNDATION` still matches.
+fn url_hostname(url: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(url)
+        .ok()
+        .or_else(|| reqwest::Url::parse(&format!("https://{url}")).ok())?;
+    let host = parsed.host_str()?.trim_end_matches('.');
+    if host.is_empty() {
+        return None;
+    }
+    Some(host.to_ascii_lowercase())
+}
+
+fn host_is_listed(host: &str, listed: &str) -> bool {
+    host == listed
+        || (host.len() > listed.len()
+            && host.ends_with(listed)
+            && host.as_bytes()[host.len() - listed.len() - 1] == b'.')
+}
+
 fn is_prod_host(base: &str) -> bool {
-    base.contains("gateway.cortex.foundation")
-        || base.contains("network.cortex.foundation")
-        || base.contains("chain.joinbase.ai")
+    url_hostname(base).is_some_and(|host| PROD_HOSTS.iter().any(|p| host_is_listed(&host, p)))
 }
 
 fn hex64(label: &str) -> String {
@@ -184,4 +211,116 @@ async fn live_host_submit_scores_or_fails_closed() {
             );
         }
     }
+}
+
+#[test]
+fn mixed_case_and_lowercase_production_hosts_are_refused() {
+    for url in [
+        "https://gateway.cortex.foundation/challenge/proof",
+        "https://GATEWAY.CORTEX.FOUNDATION/challenge/proof",
+        "https://Gateway.Cortex.Foundation/challenge/proof",
+        "http://user@Chain.JoinBase.AI:8080/challenge/proof",
+        "https://NETWORK.CORTEX.FOUNDATION./v1",
+        "https://sub.gateway.cortex.foundation:443/challenge/proof",
+        "GATEWAY.CORTEX.FOUNDATION/challenge/proof",
+    ] {
+        assert!(is_prod_host(url), "{url} must be refused as production");
+    }
+}
+
+#[test]
+fn staging_loopback_and_path_lookalikes_are_not_production() {
+    for url in [
+        "http://127.0.0.1:28100",
+        "http://localhost:8100/challenge/proof",
+        "http://staging.api.joinbase.ai/challenge/proof",
+        "http://159.223.159.205/challenge/proof",
+        "https://example.com/gateway.cortex.foundation",
+    ] {
+        assert!(
+            !is_prod_host(url),
+            "{url} must not be refused as production"
+        );
+    }
+}
+
+/// The shell `--probe` path must refuse mixed-case production hosts before
+/// any HTTP client runs. A fake `curl` first on PATH fails the test if the
+/// guard is bypassed.
+#[test]
+fn proof_submit_e2e_script_refuses_mixed_case_production_hosts() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root");
+    let bin =
+        std::env::temp_dir().join(format!("proof-submit-e2e-fake-curl-{}", std::process::id()));
+    std::fs::create_dir_all(&bin).expect("fake curl dir");
+    let curl = bin.join("curl");
+    std::fs::write(&curl, "#!/bin/sh\necho UNEXPECTED_CURL >&2\nexit 99\n").expect("fake curl");
+    let mut perm = std::fs::metadata(&curl).expect("stat").permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(&curl, perm).expect("chmod");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    for url in [
+        "https://GATEWAY.CORTEX.FOUNDATION/challenge/proof",
+        "https://gateway.cortex.foundation/challenge/proof",
+        "http://Chain.JoinBase.AI/challenge/proof",
+        "https://NETWORK.CORTEX.FOUNDATION/challenge/proof",
+    ] {
+        let out = Command::new("bash")
+            .arg(root.join("deploy/scripts/proof-submit-e2e.sh"))
+            .args(["--probe", url])
+            .env("PATH", &path)
+            .current_dir(&root)
+            .output()
+            .expect("run proof-submit-e2e.sh");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            out.status.code().unwrap_or(-1),
+            2,
+            "{url} must exit 2:\n{text}"
+        );
+        assert!(text.contains("refusing production host"), "{url}: {text}");
+        assert!(
+            !text.contains("UNEXPECTED_CURL"),
+            "{url}: curl must not run:\n{text}"
+        );
+    }
+
+    let staging = Command::new("bash")
+        .arg(root.join("deploy/scripts/proof-submit-e2e.sh"))
+        .args(["--probe", "http://staging.api.joinbase.ai/challenge/proof"])
+        .env("PATH", &path)
+        .current_dir(&root)
+        .output()
+        .expect("run proof-submit-e2e.sh staging");
+    let staging_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&staging.stdout),
+        String::from_utf8_lossy(&staging.stderr)
+    );
+    assert_ne!(
+        staging.status.code().unwrap_or(-1),
+        2,
+        "staging must not be refused as production:\n{staging_text}"
+    );
+    assert!(
+        !staging_text.contains("refusing production host"),
+        "staging must not be refused as production:\n{staging_text}"
+    );
+
+    let _ = std::fs::remove_dir_all(bin);
 }

--- a/crates/proof-http/tests/live_submit_e2e.rs
+++ b/crates/proof-http/tests/live_submit_e2e.rs
@@ -21,7 +21,9 @@ fn base_url() -> Option<String> {
 }
 
 fn is_prod_host(base: &str) -> bool {
-    base.contains("network.cortex.foundation") || base.contains("chain.joinbase.ai")
+    base.contains("gateway.cortex.foundation")
+        || base.contains("network.cortex.foundation")
+        || base.contains("chain.joinbase.ai")
 }
 
 fn hex64(label: &str) -> String {

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -172,7 +172,7 @@ Manual one-shot (from an operator host with secrets) is still:
 
 ```bash
 cargo run -q --release -p weights-smoke -- \
-  --gateway https://chain.joinbase.ai --burn
+  --gateway https://gateway.cortex.foundation --burn
 ```
 
 A seal older than ~256 blocks can never be verified by the validator (public RPC prunes state) — if `GET /v1/weights/latest` shows `metagraph_block` lagging tip by thousands of blocks, check `systemctl status base-burn-seal.timer` and `/var/log/base-burn-seal.log` on the master.
@@ -203,7 +203,7 @@ Validator logs should show `Match epoch=` then `Match → submit_intent` / `subm
 
 **Sole on-chain submitter (mainnet hotkey `5Gzi…`):** Rust `base-validator-1` on **`base-prod-validator` (`192.81.218.11`) only**. `role-master.yml` profiles the validator under `never`; `remote-deploy.sh --role master` force-removes any leftover container. Do **not** run a second validator (or Python weight submitter) with the same wallet — dual submitters fight `WeightsSetRateLimit` and can leave CRV4 commits stuck while incentive still shows a prior monopoly UID.
 
-**Legacy Python agents (mainnet):** `validator-5gzi` (`95.133.252.120`) may point `master_url` / `weights_url` / `registry_url` at `https://chain.joinbase.ai` with **`submit_on_chain_enabled: false`**. Coordination shims live in `gateway-compat` (`/v1/validators/*`, `/v1/registry`, empty assignments). `GET /v1/weights/latest` refreshes `computed_at` / `expires_at` at serve time so Python pydantic clients accept sealed vectors older than 720s. Do **not** start `base-weight-submitter-5gzi` on `validator-root` unless CR ownership is moved off Rust.
+**Legacy Python agents (mainnet):** `validator-5gzi` (`95.133.252.120`) may point `master_url` / `weights_url` / `registry_url` at `https://gateway.cortex.foundation` with **`submit_on_chain_enabled: false`**. Coordination shims live in `gateway-compat` (`/v1/validators/*`, `/v1/registry`, empty assignments). `GET /v1/weights/latest` refreshes `computed_at` / `expires_at` at serve time so Python pydantic clients accept sealed vectors older than 720s. Do **not** start `base-weight-submitter-5gzi` on `validator-root` unless CR ownership is moved off Rust.
 
 **Challenge verification:** on **master** only (validator has **no challenge exec**). Bounty: pair, report, probe quota/auth/fail-closed paths, then verify feed-driven leaves. Proof: submit against a signed `topic_id`, probe rejected and unavailable-evaluation paths, and distinguish library tests from the unwired live emitter. Verify leaf → seal → `GET /v1/weights/latest` **`sealed: true`** where the full path is available. Follow the root [verification contract](../AGENTS.md#challenge-verification-mandatory-path-coverage); do not use retired Design run/winner endpoints. **Never host Sim in staging/prod** (`BASE_ALLOW_HOST_SIM` / host `SimSandbox` are CI/local only). Healthz alone is insufficient.
 
@@ -239,6 +239,6 @@ Ladder: CI → GHCR digests → `deploy/pins/staging.json` (committed by `images
 
 - DO Spaces backup credentials — set in GitHub (repo + `production` env): `BASE_BACKUP_ENDPOINT`, `SPACES_ACCESS_KEY_ID`, `SPACES_SECRET_ACCESS_KEY`, `BASE_BACKUP_BUCKET` (bucket `base-intelligence-backups` in nyc3; name `base-backups` was globally taken). Prod promote dumps Postgres over SSH then uploads from the runner (`deploy-prod.yml`).
 - GitHub `production` environment required reviewers / `main` branch protection
-- Gateway in-process TLS ACME (task 42 / `rustls-acme`) — **interim:** prod `chain.joinbase.ai` HTTPS via host Caddy on `:443` (TLS-ALPN-01) → `127.0.0.1:8080`; cleartext `:80` still docker→gateway
+- Gateway in-process TLS ACME (task 42 / `rustls-acme`) — **interim:** prod `gateway.cortex.foundation` HTTPS via host Caddy on `:443` (TLS-ALPN-01) → `127.0.0.1:8080`; cleartext `:80` still docker→gateway
 - Terraform remote state backend (recommended, not blocking app deploy)
 - Bootstrap of age/secrets on brand-new droplets (OOB)

--- a/deploy/compose/env-prod.yml
+++ b/deploy/compose/env-prod.yml
@@ -18,11 +18,11 @@ services:
       # for 60s and tries the next in order.
       BASE_CHAIN_ENDPOINTS: "wss://bittensor-finney.api.onfinality.io/public-ws,wss://entrypoint-finney.opentensor.ai:443"
       BASE_COORDINATION_INTERVAL_SECS: "10"
-      # Public sealed-weights API (same gateway as Caddy). Validators verify
+      # Public metal gateway (gateway.cortex.foundation). Validators verify
       # `GET /v1/weights/latest` + `GET /v1/bundle/{epoch}` here — not the
       # VPC bind. Do not fall back to role-validator.yml (that default is
       # the staging master VPC IP / netuid 541).
-      BASE_GATEWAY_ENDPOINT: "https://chain.joinbase.ai"
+      BASE_GATEWAY_ENDPOINT: "https://gateway.cortex.foundation"
       BT_WALLETS_PATH: /run/base/wallets
       BASE_VALIDATOR_WALLET: base-validator
     volumes:
@@ -34,8 +34,8 @@ services:
       BASE_CHAIN_ENDPOINT: "wss://entrypoint-finney.opentensor.ai:443"
       # Same ordered failover list as the validator (see note above).
       BASE_CHAIN_ENDPOINTS: "wss://bittensor-finney.api.onfinality.io/public-ws,wss://entrypoint-finney.opentensor.ai:443"
-      # Public API hostname (cleartext on :80/:8080 until ACME).
-      BASE_DOMAIN: chain.joinbase.ai
+      # Public API hostname (Caddy TLS → this process on :8080).
+      BASE_DOMAIN: gateway.cortex.foundation
       BT_WALLETS_PATH: /run/base/wallets
       BASE_GATEWAY_WALLET: base-owner
       BASE_GATEWAY_WALLET_HOTKEY: default
@@ -43,7 +43,7 @@ services:
       BASE_GATEWAY_REQUIRE_OWNER: "1"
       # Required whenever REQUIRE_OWNER=1 — gates /v1/admin/* (seal, backends, …).
       BASE_GATEWAY_ADMIN_TOKEN_FILE: /run/secrets/gateway_admin_token
-    # Serve chain.joinbase.ai without forcing clients onto :8080 (8080 is VPC-only).
+    # Serve gateway.cortex.foundation without forcing clients onto :8080 (8080 is VPC-only).
     # Note: cleartext :80 publishes the full gateway surface; pair with host Caddy
     # path filters / DOCKER-USER drops until ACME owns :80. Prefer HTTPS clients.
     ports:

--- a/deploy/compose/role-validator.yml
+++ b/deploy/compose/role-validator.yml
@@ -1,6 +1,6 @@
 # Validator role — NO gateway, NO owner hotkey, NO challenge execution.
 # Points at the master gateway (staging VPC default; env-prod.yml pins
-# https://chain.joinbase.ai). Used with:
+# https://gateway.cortex.foundation). Used with:
 # docker compose -f docker-compose.yml -f deploy/compose/role-validator.yml
 services:
   validator:

--- a/deploy/scripts/proof-submit-e2e.sh
+++ b/deploy/scripts/proof-submit-e2e.sh
@@ -24,7 +24,7 @@ RED() { printf '\033[31m%s\033[0m\n' "$*"; }
 GRN() { printf '\033[32m%s\033[0m\n' "$*"; }
 LOG() { printf '[proof-e2e] %s\n' "$*"; }
 
-PROD_HOSTS='network.cortex.foundation|chain.joinbase.ai'
+PROD_HOSTS='gateway.cortex.foundation|network.cortex.foundation|chain.joinbase.ai'
 STAGING_TOPICS=(dt-no-ib-v0 muon-vs-adamw-10m-v0)
 
 refuse_prod() {

--- a/deploy/scripts/proof-submit-e2e.sh
+++ b/deploy/scripts/proof-submit-e2e.sh
@@ -24,12 +24,25 @@ RED() { printf '\033[31m%s\033[0m\n' "$*"; }
 GRN() { printf '\033[32m%s\033[0m\n' "$*"; }
 LOG() { printf '[proof-e2e] %s\n' "$*"; }
 
-PROD_HOSTS='gateway.cortex.foundation|network.cortex.foundation|chain.joinbase.ai'
+PROD_HOSTS='gateway\.cortex\.foundation|network\.cortex\.foundation|chain\.joinbase\.ai'
 STAGING_TOPICS=(dt-no-ib-v0 muon-vs-adamw-10m-v0)
 
+# url_host URL → the host part, lower-cased (no scheme, userinfo, port, path,
+# query; a trailing dot dropped; IPv6 literal kept bracketed).
+url_host() {
+  local h="$1"
+  h="${h#*://}"; h="${h%%/*}"; h="${h%%\?*}"; h="${h%%\#*}"; h="${h##*@}"
+  if [[ "$h" == \[* ]]; then h="${h%%]*}]"; else h="${h%%:*}"; fi
+  h="${h%.}"
+  printf '%s' "$h" | tr '[:upper:]' '[:lower:]'
+}
+# Refuse a production origin however it is spelled: the parsed host (or any
+# subdomain of a protected host) is compared lower-cased. DNS is
+# case-insensitive; the guard must be too.
 refuse_prod() {
-  local url="${1:-}"
-  if echo "$url" | grep -Eq "$PROD_HOSTS"; then
+  local url="${1:-}" host
+  host="$(url_host "$url")"
+  if printf '%s\n' "$host" | grep -Eq "^(.*\.)?(${PROD_HOSTS})$"; then
     RED "refusing production host: $url"
     exit 2
   fi

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -107,8 +107,9 @@ not the product name.
 
 ## On-chain and public hostnames
 
-- Live gateway hostname `chain.joinbase.ai` is operator DNS, not a GitHub
-  brand string. Do not retarget it from a docs-only PR.
+- Live gateway hostname `gateway.cortex.foundation` is operator DNS, not a GitHub
+  brand string. `chain.joinbase.ai` is the retired prod host. Do not retarget
+  the live host from a docs-only PR.
 - Subnet netuid and on-chain names stay whatever the chain already uses.
 
 ## Public miner repos (other GitHub repositories)

--- a/docs/external-miner/README.md
+++ b/docs/external-miner/README.md
@@ -32,7 +32,7 @@ ctx challenges
 ctx status
 ```
 
-Default gateway is [https://network.cortex.foundation](https://network.cortex.foundation).
+Default gateway is [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 `--gateway` overrides it for a local stack. `LIUM_API_KEY` is forwarded as
 `X-Lium-Api-Key` and never printed.
 
@@ -51,21 +51,24 @@ Neither live challenge pays for a published split you can grind:
 
 - Proof scores operator-published topics against a **private per-topic holdout**.
   You submit a claim + reproducible recipe + `declared_flops` vs `topic_id`.
-  The pin has no catalog; `GET /v1/proof/topics` is the live list (operators
-  inject topics at any time). The canary stays **off the number you are paid on**.
-  Paid score is the **sum of per-topic** masses (`wta` or `discovery`).
-  Empty `eval_image_digest` still **503**; the live pin is
+  The pin has no catalog; `GET /challenge/proof/v1/proof/topics` is the live
+  list (operators inject topics at any time). The canary stays **off the
+  number you are paid on**. Paid score is the **sum of per-topic** masses
+  (`wta` or `discovery`). Empty `eval_image_digest` still **503**; the live
+  pin is
   `sha256:78b614a1f51ce5dd80076c4e343a2b31b85d6c36025e02836cb83929867e7009`.
 - Bounty pays precision times severity. The triage-noise ratio stays off the
   visible score. An unpriced `valid` row is not creditable.
 - **Missing evidence fails closed.** An empty training manifest is not a clean
   contamination check, and a host that cannot score answers `503` instead of
-  inventing a verdict. Check `GET /v1/status` → `can_score` (or `ctx status`)
-  before you spend anything.
+  inventing a verdict. Check `GET /challenge/proof/v1/status` (or
+  `GET /challenge/bounty/v1/status`, or `ctx status`) before you spend
+  anything. Bare `GET /v1/status` on the public gateway is not the Proof
+  status path.
 
 ```text
-https://network.cortex.foundation/challenge/bounty/...
-https://network.cortex.foundation/challenge/proof/...
+https://gateway.cortex.foundation/challenge/bounty/...
+https://gateway.cortex.foundation/challenge/proof/...
 ```
 
 Never put mnemonics or challenge signing keys in miner clients.

--- a/docs/external-miner/README.md
+++ b/docs/external-miner/README.md
@@ -52,10 +52,10 @@ Neither live challenge pays for a published split you can grind:
 - Proof scores operator-published topics against a **private per-topic holdout**.
   You submit a claim + reproducible recipe + `declared_flops` vs `topic_id`.
   The pin has no catalog; `GET /challenge/proof/v1/proof/topics` is the live
-  list (operators inject topics at any time). The canary stays **off the
-  number you are paid on**. Paid score is the **sum of per-topic** masses
-  (`wta` or `discovery`). Empty `eval_image_digest` still **503**; the live
-  pin is
+  list (operators inject topics at any time). The canary stays
+  **off the number you are paid on**. Paid score is the **sum of per-topic**
+  masses (`wta` or `discovery`). Empty `eval_image_digest` still **503**;
+  the live pin is
   `sha256:78b614a1f51ce5dd80076c4e343a2b31b85d6c36025e02836cb83929867e7009`.
 - Bounty pays precision times severity. The triage-noise ratio stays off the
   visible score. An unpriced `valid` row is not creditable.

--- a/docs/external-miner/bounty.md
+++ b/docs/external-miner/bounty.md
@@ -7,7 +7,7 @@ Challenge id is `bounty`. One of two live challenges (`bounty` **2000 bps**,
 unique reports earn subnet weight. Every report is tagged with your Bittensor
 hotkey so operators can patch in real time and pay (or penalize) the right miner.
 
-**Gateway:** `https://network.cortex.foundation`  
+**Gateway:** `https://gateway.cortex.foundation`  
 **CLI:** `ctx bounty status`, then `ctx bounty pair`, then `ctx bounty report`
 (install: [README](./README.md))
 
@@ -21,9 +21,9 @@ Validators do **not** re-run your reports. They verify the sealed weight
 bundle. Ingest goes through the gateway:
 
 ```text
-https://network.cortex.foundation/challenge/bounty/v1/pair
-https://network.cortex.foundation/challenge/bounty/v1/reports
-https://network.cortex.foundation/challenge/bounty/v1/status
+https://gateway.cortex.foundation/challenge/bounty/v1/pair
+https://gateway.cortex.foundation/challenge/bounty/v1/reports
+https://gateway.cortex.foundation/challenge/bounty/v1/status
 ```
 
 ## Dedicated account (required)
@@ -101,7 +101,7 @@ rate-limit window.
 The same thing with `curl` (the Lium header is optional and never logged):
 
 ```bash
-curl -sS -X POST https://network.cortex.foundation/challenge/bounty/v1/reports \
+curl -sS -X POST https://gateway.cortex.foundation/challenge/bounty/v1/reports \
   -H 'content-type: application/json' \
   -H "X-Lium-Api-Key: $LIUM_API_KEY" \
   -d '{

--- a/docs/external-miner/proof.md
+++ b/docs/external-miner/proof.md
@@ -12,7 +12,7 @@ research-to-payment path. Read the
 [paper-to-code comparison](../WHITEPAPER.md#proposal-versus-current-code) and
 confirm deployment support with the operator first.
 
-**Gateway:** [https://network.cortex.foundation](https://network.cortex.foundation)  
+**Gateway:** [https://gateway.cortex.foundation](https://gateway.cortex.foundation)  
 **CLI:** `ctx proof topics`, then `ctx proof submit` (install:
 [README](./README.md))  
 **Pin:** [`config/proof-pin.toml`](../../config/proof-pin.toml)  
@@ -69,7 +69,7 @@ that topic. Zero open topics → the host cannot score (`503`), not a paid 0.
 ```bash
 ctx proof status
 # same as:
-curl -sS https://network.cortex.foundation/challenge/proof/v1/status
+curl -sS https://gateway.cortex.foundation/challenge/proof/v1/status
 ```
 
 `GET /challenge/proof/v1/status` shows `can_score`, `eval_backend`,
@@ -102,8 +102,8 @@ rented.
 
 ```bash
 ctx proof topics
-curl -sS https://network.cortex.foundation/challenge/proof/v1/proof/topics
-curl -sS https://network.cortex.foundation/challenge/proof/v1/proof/topics/dt-no-ib-v0
+curl -sS https://gateway.cortex.foundation/challenge/proof/v1/proof/topics
+curl -sS https://gateway.cortex.foundation/challenge/proof/v1/proof/topics/dt-no-ib-v0
 ```
 
 Topics are **operator-published** and can be **injected at any time** (operator
@@ -195,7 +195,7 @@ ctx proof submit \
 The same submit with `curl`:
 
 ```bash
-curl -sS -X POST https://network.cortex.foundation/challenge/proof/v1/submissions \
+curl -sS -X POST https://gateway.cortex.foundation/challenge/proof/v1/submissions \
   -H 'content-type: application/json' \
   -H "X-Lium-Api-Key: $LIUM_API_KEY" \
   -d '{
@@ -220,7 +220,7 @@ judge config, no open sealed topic), submissions answer **503**.
 
 ### Required POST JSON
 
-`POST https://network.cortex.foundation/challenge/proof/v1/submissions`
+`POST https://gateway.cortex.foundation/challenge/proof/v1/submissions`
 
 | Field | Required | Shape |
 |-------|----------|-------|
@@ -242,7 +242,7 @@ contamination check. It is `contamination_evidence_missing`: the row is
 ```bash
 ctx proof show <id>
 # same as:
-curl -sS https://network.cortex.foundation/challenge/proof/v1/submissions/<id>
+curl -sS https://gateway.cortex.foundation/challenge/proof/v1/submissions/<id>
 ```
 
 | `state` | Meaning |

--- a/docs/external-miner/relearn-agent.md
+++ b/docs/external-miner/relearn-agent.md
@@ -5,7 +5,7 @@
 > **This challenge is off.** `relearn-agent` has no row in
 > [`config/challenges.toml`](../../config/challenges.toml), so it has
 > **no emission**. Live work is [Bounty](./bounty.md) and [Proof](./proof.md)
-> at [https://network.cortex.foundation](https://network.cortex.foundation).
+> at [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 
 The Relearn Agent control-plane and compose services have been removed from
 this repo. Historical links land here so they do not 404.

--- a/docs/external-miner/relearn-image.md
+++ b/docs/external-miner/relearn-image.md
@@ -5,7 +5,7 @@
 > **This challenge is off.** `relearn-image` has no row in
 > [`config/challenges.toml`](../../config/challenges.toml), so it has
 > **no emission**. Live work is [Bounty](./bounty.md) and [Proof](./proof.md)
-> at [https://network.cortex.foundation](https://network.cortex.foundation).
+> at [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 
 The Relearn Image control-plane and compose services have been removed from
 this repo. Historical links land here so they do not 404.

--- a/docs/external-miner/relearn-mm.md
+++ b/docs/external-miner/relearn-mm.md
@@ -5,7 +5,7 @@
 > **This challenge is off.** `relearn-mm` has no row in
 > [`config/challenges.toml`](../../config/challenges.toml), so it has
 > **no emission**. Live work is [Bounty](./bounty.md) and [Proof](./proof.md)
-> at [https://network.cortex.foundation](https://network.cortex.foundation).
+> at [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 
 The Relearn Multimodal control-plane and compose services have been removed
 from this repo. Historical links land here so they do not 404.

--- a/docs/external-miner/relearn.md
+++ b/docs/external-miner/relearn.md
@@ -6,7 +6,7 @@
 > [`config/challenges.toml`](../../config/challenges.toml), so it has
 > **no emission** and no leaf signed by its key can verify. Submitting to it
 > earns nothing. Live work is [Bounty](./bounty.md) and [Proof](./proof.md)
-> at [https://network.cortex.foundation](https://network.cortex.foundation).
+> at [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 
 The Relearn control-plane and compose services have been removed from this
 repo. Historical links land here so they do not 404.

--- a/docs/external-miner/troubleshoot.md
+++ b/docs/external-miner/troubleshoot.md
@@ -2,7 +2,7 @@
 
 # External miner — troubleshoot (HTTP)
 
-**Path:** HTTP submit through [https://network.cortex.foundation](https://network.cortex.foundation).
+**Path:** HTTP submit through [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 Install `ctx` from [README](./README.md). Proof miners pay Lium
 (`LIUM_API_KEY` / `X-Lium-Api-Key`).
 
@@ -11,7 +11,7 @@ Install `ctx` from [README](./README.md). Proof miners pay Lium
 | Symptom | Likely cause | What to check |
 |---------|--------------|---------------|
 | `install-ctx` aborts on checksum | Missing or mismatched `SHA256SUMS.txt` | The installer refuses an unverified binary. Wait for a `v*.*.*` release, or build `ctx` from this repo |
-| `request to … failed` | Gateway not reachable | `ctx status --gateway https://network.cortex.foundation`. A local stack needs `--gateway http://127.0.0.1:8080` |
+| `request to … failed` | Gateway not reachable | `ctx status --gateway https://gateway.cortex.foundation`. A local stack needs `--gateway http://127.0.0.1:8080` |
 | `can_score: NO` / HTTP 503 | The host cannot score right now | Nothing was stored and nothing was rented. Read the error; do not retry-spend |
 
 ## Bounty

--- a/docs/external-miner/validators.md
+++ b/docs/external-miner/validators.md
@@ -13,7 +13,7 @@ trust-root check, which is the point.
 ## Job
 
 1. Pull `GET /v1/weights/latest` from the master gateway.
-   - Prod: `https://chain.joinbase.ai/v1/weights/latest`
+   - Prod: `https://gateway.cortex.foundation/v1/weights/latest`
    - Staging / VPC: `$BASE_GATEWAY_ENDPOINT/v1/weights/latest` (compose default `http://10.116.0.2:8080`)
 2. Verify the sealed bundle: signatures, D24 completeness (every declared participant has a leaf), owner trust root on **local disk** (`config/challenges.toml`, `config/measurements.toml`), no forged leaves.
 3. `set_weights` on-chain.
@@ -44,7 +44,7 @@ Env: [`deploy/env/validator.env.example`](../../deploy/env/validator.env.example
 
 ```bash
 # required: BASE_ROLE=validator, BASE_NETUID, database URL, BASE_CHAIN_ENDPOINT
-# BASE_GATEWAY_ENDPOINT = master gateway (prod pin: https://chain.joinbase.ai)
+# BASE_GATEWAY_ENDPOINT = master gateway (prod pin: https://gateway.cortex.foundation)
 # wallet: BASE_VALIDATOR_WALLET or BASE_VALIDATOR_MNEMONIC_FILE (for set_weights)
 
 ./deploy/scripts/materialize-env.sh

--- a/docs/runbooks/proof-submit-e2e.md
+++ b/docs/runbooks/proof-submit-e2e.md
@@ -49,8 +49,8 @@ missing `error`, missing `verdict` after 201, or holdout leak.
 
 ## Probe a running host (local compose or staging)
 
-Do **not** point this at `https://network.cortex.foundation` or
-`https://chain.joinbase.ai`.
+Do **not** point this at `https://gateway.cortex.foundation`,
+`https://network.cortex.foundation`, or `https://chain.joinbase.ai`.
 
 ```bash
 # Auto-detect first healthy origin among loopback + documented staging URLs:

--- a/scripts/install-ctx.sh
+++ b/scripts/install-ctx.sh
@@ -14,7 +14,7 @@
 set -eu
 
 REPO="CortexLM/cortex"
-GATEWAY="https://network.cortex.foundation"
+GATEWAY="https://gateway.cortex.foundation"
 VERSION="${CTX_VERSION:-latest}"
 INSTALL_DIR="${CTX_INSTALL_DIR:-$HOME/.local/bin}"
 

--- a/xtask/src/external_docs_check.rs
+++ b/xtask/src/external_docs_check.rs
@@ -25,7 +25,7 @@ const EXTERNAL_MINER_PINS: &[(&str, &str)] = &[
     ("fail_closed", "fails closed"),
     ("bounty_backend_consumer", "CortexLM/backend"),
     ("ctx_cli", "ctx"),
-    ("gateway_host", "network.cortex.foundation"),
+    ("gateway_host", "gateway.cortex.foundation"),
     ("two_live", "Two live challenges"),
     ("emission_bounty", "2000 bps"),
     ("emission_proof", "8000 bps"),
@@ -535,7 +535,7 @@ mod tests {
             .any(|(n, v)| *n == "ctx_cli" && *v == "ctx"));
         assert!(EXTERNAL_MINER_PINS
             .iter()
-            .any(|(n, v)| *n == "gateway_host" && *v == "network.cortex.foundation"));
+            .any(|(n, v)| *n == "gateway_host" && *v == "gateway.cortex.foundation"));
         assert!(EXTERNAL_MINER_PINS
             .iter()
             .any(|(n, v)| *n == "two_live" && *v == "Two live challenges"));
@@ -565,7 +565,7 @@ mod tests {
     fn the_ctx_default_gateway_is_the_documented_host() {
         let root = workspace_root();
         let gateway = read_ctx_default_gateway(&root).expect("ctx gateway const");
-        assert_eq!(gateway, "https://network.cortex.foundation");
+        assert_eq!(gateway, "https://gateway.cortex.foundation");
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pin SN100 validators, `ctx`, and miner-facing docs onto the live Cortex metal gateway at `https://gateway.cortex.foundation`.

`https://chain.joinbase.ai` is the legacy prod weights host. `https://network.cortex.foundation` is still Vercel DNS (Arcade), not the metal source of truth. Validators and `ctx` must read the metal gateway.

## What changed

- Prod compose: `BASE_GATEWAY_ENDPOINT` / `BASE_DOMAIN` → `gateway.cortex.foundation` (netuid 100 / Finney endpoints unchanged).
- `ctx` `DEFAULT_GATEWAY`, help text, installer, and release notes.
- Miner/validator docs: public host + Proof paths under `/challenge/proof/v1/...` (status, topics, submissions). Bare `GET /v1/status` on the public gateway is not the Proof status path. Bounty stays `/challenge/bounty/v1/...`.
- xtask `external-docs-check` pin follows the new host.
- E2E refuse-lists now also treat the metal host as production.
- **Greptile P1:** Proof E2E production-host guards parse the URL and compare a lower-cased hostname, so mixed-case spellings (`GATEWAY.CORTEX.FOUNDATION`) cannot bypass the probe refuse path. Covered in `live_submit_e2e` (Rust predicate + shell `--probe` with a fake `curl`).
- **Greptile P2:** operator/naming guidance (`deploy/AGENTS.md`, `docs/NAMING.md`, `role-validator.yml`) now names `gateway.cortex.foundation` as the live production host.

Staging (`env-staging.yml`, joinbase staging hosts) is unchanged. No topic reseal, baseline, n=15, emission bps, or burn/aggregate logic changes.

## Burn

With zero miners, `GET https://gateway.cortex.foundation/v1/weights/latest` remains fail-closed uid0=100% (`sealed: true` when a seal exists; unsealed latest is still a burn vector). The validator still skips owner-burn on-chain submit. Unchanged.

## Path note

Caddy for `gateway.cortex.foundation` reverse-proxies **base-gateway :8080** (not proof :8100). Proof is reached via `/challenge/proof/v1/...`. Bare `GET /v1/status` on that host is 404.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [x] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `cargo test -p ctx` (33 passed)
- [x] `cargo test -p xtask -- gate_passes_on_this_workspace`
- [x] `cargo run -p xtask -- external-docs-check` (gateway=`https://gateway.cortex.foundation`)
- [x] `cargo test -p proof-http --test live_submit_e2e` (mixed-case + lowercase prod hosts refused; staging/loopback not refused; shell `--probe` exits 2 before curl)

## Risk

URL/docs pin only. No metal runtime change from this PR. No `BASE_*` rename.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fe377ee-5aa9-420c-b50a-d8868eff1c8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fe377ee-5aa9-420c-b50a-d8868eff1c8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

