### PR TITLE
fix(bounty): set User-Agent on backend public feed fetch

### DIFF
--- a/crates/bounty-challenge/src/backend.rs
+++ b/crates/bounty-challenge/src/backend.rs
@@ -30,9 +30,12 @@ pub enum BackendError {
     /// `BOUNTY_BACKEND_PUBLIC_URL` unset — this host cannot score.
     #[error("BOUNTY_BACKEND_PUBLIC_URL unset")]
     Unset,
-    /// HTTP transport or status.
+    /// HTTP transport failure (no status available).
     #[error("backend public fetch failed")]
     Fetch,
+    /// HTTP non-2xx from the public feed. Status only — no host, URL, or body.
+    #[error("backend public fetch failed: HTTP {0}")]
+    FetchStatus(u16),
     /// JSON did not match the public DTO.
     #[error("backend public json: {0}")]
     Json(String),
@@ -65,7 +68,8 @@ pub fn public_path(base: &str, tail: &str) -> String {
 ///
 /// # Errors
 /// [`BackendError::Unset`] when neither the argument nor the env carries a
-/// base URL, [`BackendError::Fetch`] on transport or non-2xx,
+/// base URL, [`BackendError::Fetch`] on transport failure,
+/// [`BackendError::FetchStatus`] on non-2xx,
 /// [`BackendError::Json`] when a body does not match the public DTO,
 /// [`BackendError::Mismatched`] when the two routes describe different
 /// publications, and [`BackendError::Inconsistent`] when the feed never held
@@ -75,10 +79,7 @@ pub async fn fetch_public_snapshot(base: Option<&str>) -> Result<PublicSnapshot,
         Some(u) if !u.trim().is_empty() => u.trim().to_owned(),
         _ => backend_public_url().ok_or(BackendError::Unset)?,
     };
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(20))
-        .build()
-        .map_err(|_| BackendError::Fetch)?;
+    let client = public_feed_client()?;
     let mut prev = read_pair(&client, &url).await?;
     for _ in 1..MAX_PAIR_READS {
         let next = read_pair(&client, &url).await?;
@@ -94,6 +95,19 @@ pub async fn fetch_public_snapshot(base: Option<&str>) -> Result<PublicSnapshot,
         prev = next;
     }
     Err(BackendError::Inconsistent)
+}
+
+/// Identify this process on outbound GETs.
+const PUBLIC_FEED_USER_AGENT: &str = concat!("cortex-bounty-challenge/", env!("CARGO_PKG_VERSION"));
+
+fn public_feed_client() -> Result<reqwest::Client, BackendError> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        // CloudFront/WAF rejects an empty User-Agent (curl's default works;
+        // reqwest `default-features = false` does not send one).
+        .user_agent(PUBLIC_FEED_USER_AGENT)
+        .build()
+        .map_err(|_| BackendError::Fetch)
 }
 
 /// One GET-pair, plus any publication token the backend put on each route.
@@ -159,7 +173,7 @@ async fn get_text(
         .await
         .map_err(|_| BackendError::Fetch)?;
     if !resp.status().is_success() {
-        return Err(BackendError::Fetch);
+        return Err(BackendError::FetchStatus(resp.status().as_u16()));
     }
     let etag = resp
         .headers()
@@ -249,5 +263,36 @@ mod tests {
             .await
             .expect_err("unreachable");
         assert!(matches!(err, BackendError::Fetch), "{err}");
+    }
+
+    #[test]
+    fn public_feed_client_sets_a_nonempty_user_agent() {
+        let client = public_feed_client().expect("client");
+        let req = client.get("http://127.0.0.1/").build().expect("request");
+        let ua = req
+            .headers()
+            .get(reqwest::header::USER_AGENT)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(!ua.is_empty(), "{ua:?}");
+        assert!(ua.starts_with("cortex-bounty-challenge/"), "{ua}");
+    }
+
+    #[tokio::test]
+    async fn a_non_2xx_feed_is_a_fetch_status_error() {
+        let listener =
+            tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let app = axum::Router::new().fallback(|| async { axum::http::StatusCode::FORBIDDEN });
+            let _ = axum::serve(listener, app).await;
+        });
+        let err = fetch_public_snapshot(Some(&format!("http://{addr}")))
+            .await
+            .expect_err("403");
+        assert!(matches!(err, BackendError::FetchStatus(403)), "{err}");
+        assert_eq!(err.to_string(), "backend public fetch failed: HTTP 403");
     }
 }

--- a/crates/bounty-challenge/src/backend.rs
+++ b/crates/bounty-challenge/src/backend.rs
@@ -265,28 +265,26 @@ mod tests {
         assert!(matches!(err, BackendError::Fetch), "{err}");
     }
 
-    #[test]
-    fn public_feed_client_sets_a_nonempty_user_agent() {
-        let client = public_feed_client().expect("client");
-        let req = client.get("http://127.0.0.1/").build().expect("request");
-        let ua = req
-            .headers()
-            .get(reqwest::header::USER_AGENT)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        assert!(!ua.is_empty(), "{ua:?}");
-        assert!(ua.starts_with("cortex-bounty-challenge/"), "{ua}");
-    }
-
     #[tokio::test]
     async fn a_non_2xx_feed_is_a_fetch_status_error() {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+        let seen_h = std::sync::Arc::clone(&seen);
         let listener =
             tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
                 .await
                 .expect("bind");
         let addr = listener.local_addr().expect("addr");
         tokio::spawn(async move {
-            let app = axum::Router::new().fallback(|| async { axum::http::StatusCode::FORBIDDEN });
+            let app = axum::Router::new().fallback(move |headers: axum::http::HeaderMap| {
+                let seen_h = std::sync::Arc::clone(&seen_h);
+                async move {
+                    *seen_h.lock().expect("lock") = headers
+                        .get(axum::http::header::USER_AGENT)
+                        .and_then(|v| v.to_str().ok())
+                        .map(ToOwned::to_owned);
+                    axum::http::StatusCode::FORBIDDEN
+                }
+            });
             let _ = axum::serve(listener, app).await;
         });
         let err = fetch_public_snapshot(Some(&format!("http://{addr}")))
@@ -294,5 +292,9 @@ mod tests {
             .expect_err("403");
         assert!(matches!(err, BackendError::FetchStatus(403)), "{err}");
         assert_eq!(err.to_string(), "backend public fetch failed: HTTP 403");
+        // reqwest applies Client default headers at send time, not RequestBuilder::build.
+        let ua = seen.lock().expect("lock").clone().unwrap_or_default();
+        assert!(!ua.is_empty(), "{ua:?}");
+        assert!(ua.starts_with("cortex-bounty-challenge/"), "{ua}");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bounty scoring reads the CortexLM/backend public feed (`{BOUNTY_BACKEND_PUBLIC_URL}/v1/bounty/public/leaderboard` and `…/reports`). On prod metal (`cortex-metal` / `base-bounty-challenge-1`) that fetch logged `backend public fetch failed` even though the URL and paths were correct.

**Root cause:** CloudFront/WAF on `api.cortex.foundation` rejects an empty `User-Agent` with HTTP 403 HTML.

**Evidence (verified on the host):**

- `curl https://api.cortex.foundation/v1/bounty/public/leaderboard` (default UA) → HTTP 200 JSON
- `curl -A ""` (empty UA) → HTTP 403 HTML from CloudFront/WAF
- `reqwest` built with `default-features = false, features = ["json", "rustls-tls"]` does not set a User-Agent → same 403
- `backend.rs` mapped every non-2xx to opaque `BackendError::Fetch` (`"backend public fetch failed"`), matching live logs

**Fix:**

- Set `User-Agent: cortex-bounty-challenge/<crate version>` on the public-feed client (same pattern as `ctx` / `proof-vm-fc`)
- Surface non-2xx as `BackendError::FetchStatus(u16)` with Display `backend public fetch failed: HTTP 403` — status only, no host/URL/body/secrets
- Transport failures stay `BackendError::Fetch`

Scoring logic, public paths, and emit cadence are unchanged. No deploy/env/WAF changes.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [ ] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] Unit tests: existing unset/unreachable cases plus UA header and HTTP 403 → `FetchStatus(403)`
- [x] `cargo test -p bounty-challenge` (lib + `emit_fail_closed`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p bounty-challenge --all-targets -- -D warnings`

## Risk

Low. Outbound identification header only. Fail-closed scoring is unchanged: an unreadable feed still pays nobody and covers `E` with `NoScore(ChallengeInternal)`. Display stays free of hosts and secrets.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ceb88223-e49d-475e-b4e6-32d95caf22af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceb88223-e49d-475e-b4e6-32d95caf22af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

