### PR TITLE
ci(release-ctx): build ctx from a build ref, attach to the release tag

### DIFF
--- a/.github/workflows/release-ctx.yml
+++ b/.github/workflows/release-ctx.yml
@@ -1,9 +1,36 @@
 name: release-ctx
 
-# Builds the miner CLI for every platform miners actually run and attaches the
-# archives (plus SHA256SUMS.txt) to the GitHub Release for the tag.
+# Builds the miner CLI (`ctx`) for every platform miners actually run and
+# attaches the archives (plus SHA256SUMS.txt) to a GitHub Release.
 # scripts/install-ctx.sh downloads from that release and verifies the checksum,
 # so a release without the sums file installs nothing.
+#
+# Build ref vs release tag — two different things:
+#
+#   * The **build ref** is the commit `ctx` is compiled from. On a tag push it
+#     is the tagged commit. On workflow_dispatch it is `build_ref`, default
+#     `main` (the tip of the working branch at run time).
+#   * The **release tag** is the GitHub Release the archives are attached to.
+#     On a tag push it is the pushed tag. On workflow_dispatch it is `tag`,
+#     which must already exist: the operator cuts the tag / Release first, and
+#     a typo can never mint a new release.
+#
+# So the release tag is a publishing label — `v*.*.*` numbering follows the
+# network's prod tags (deploy/README.md § Prod release flow) — while the `ctx`
+# sources come from the tip of `main`. A dispatch never checks the tag out:
+# an old tag predates `bins/ctx`, which is how `package ID specification ctx
+# did not match any packages` happened. The resolve job refuses a build ref
+# without `bins/ctx` before any runner starts cargo, every archive of one run
+# is built from the same resolved commit, and the appended release notes
+# record that commit.
+#
+# Operator recipe (full text: deploy/README.md § ctx CLI release):
+#   gh release create vX.Y.Z --target main --title "ctx CLI vX.Y.Z" --notes "…"
+#     → the tag push runs this workflow from the tagged commit
+#   gh workflow run release-ctx.yml -f tag=vX.Y.Z
+#     → rebuild from the tip of main and (re)attach to that existing tag
+#   gh workflow run release-ctx.yml -f tag=vX.Y.Z -f build_ref=<sha|branch>
+# Any v*.*.* tag push also triggers deploy-prod.yml (fail-closed preflight).
 
 on:
   push:
@@ -11,19 +38,96 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to build and attach assets to"
+        description: "Existing release tag to attach the ctx assets to (publishing label, e.g. v3.3.30)"
         required: true
         type: string
+      build_ref:
+        description: "Branch, tag, or SHA to build ctx from (default: main)"
+        required: false
+        type: string
+        default: main
 
+# Read-only by default; only the job that touches the Release gets write.
 permissions:
-  contents: write
+  contents: read
+
+# A tag push and a dispatch for the same tag (or a re-run) would race on the
+# asset upload. Queue them per tag and never cancel a run about to publish.
+concurrency:
+  group: release-ctx-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  resolve:
+    name: resolve build ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.pick.outputs.tag }}
+      build_ref: ${{ steps.pick.outputs.build_ref }}
+      sha: ${{ steps.pick.outputs.sha }}
+    steps:
+      # Push: the pushed tag ref (checkout peels annotated tags to the commit).
+      # Dispatch: the build ref, never the release tag.
+      - name: Checkout build ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.build_ref || 'main') || github.ref }}
+
+      - name: Pick release tag and build commit
+        id: pick
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BUILD_REF: ${{ inputs.build_ref }}
+          PUSHED_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+            build_ref="${INPUT_BUILD_REF:-main}"
+            case "$tag" in
+              v*.*.*) ;;
+              *)
+                echo "::error::tag '$tag' does not match v*.*.* (the same shape the push trigger accepts)"
+                exit 1
+                ;;
+            esac
+            if ! git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null; then
+              echo "::error::tag '$tag' does not exist on origin. Create the tag / Release first (gh release create $tag --target main …), then dispatch again."
+              exit 1
+            fi
+          else
+            tag="$PUSHED_TAG"
+            build_ref="refs/tags/$tag"
+          fi
+
+          sha="$(git rev-parse HEAD)"
+          if [ ! -f bins/ctx/Cargo.toml ]; then
+            echo "::error::build ref '$build_ref' ($sha) has no bins/ctx — it predates the ctx CLI. Dispatch with build_ref=main (the default) so the release tag stays a label and the sources come from tip."
+            exit 1
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "build_ref=$build_ref"
+            echo "sha=$sha"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## release-ctx"
+            echo
+            echo "| Release tag | Build ref | Commit |"
+            echo "|-------------|-----------|--------|"
+            echo "| \`$tag\` | \`$build_ref\` | \`$sha\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "release tag $tag <- build ref $build_ref @ $sha"
+
   build:
     name: ctx ${{ matrix.name }}
+    needs: [resolve]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     strategy:
@@ -48,13 +152,15 @@ jobs:
             runner: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
+      # Every platform builds the one commit resolve picked, so the archives in
+      # SHA256SUMS.txt cannot straddle a push to main that lands mid-run.
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ needs.resolve.outputs.sha }}
 
       - name: Install Rust toolchain
-        # Pin by commit SHA. Never @master under contents:write.
+        # Pin by commit SHA. Never @master in a workflow that publishes.
         uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0
         with:
           toolchain: "1.96.0"
@@ -102,9 +208,11 @@ jobs:
 
   release:
     name: attach assets
-    needs: [build]
+    needs: [resolve, build]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -123,21 +231,47 @@ jobs:
           sha256sum ctx-* > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
+      # Hand-written notes stay. The install block is added once per release,
+      # however many times ctx is rebuilt for that tag; every build appends one
+      # provenance line naming the commit it came from.
+      - name: Release notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          BUILD_REF: ${{ needs.resolve.outputs.build_ref }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Empty when the tag has no Release yet (the next step creates it).
+          existing="$(gh release view "$TAG" --json body -q .body 2>/dev/null || true)"
+          {
+            echo "body<<NOTES_EOF"
+            if ! printf '%s' "$existing" | grep -qF "scripts/install-ctx.sh"; then
+              cat <<'BLOCK'
+          Cortex subnet CLI (`ctx`) for miners.
+
+          ```bash
+          curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
+          ctx challenges
+          ctx status
+          ```
+
+          Default gateway: https://gateway.cortex.foundation
+
+          BLOCK
+            fi
+            echo "ctx assets built from \`$SHA\` (\`$BUILD_REF\`) by [release-ctx]($RUN_URL)."
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Attach to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ needs.resolve.outputs.tag }}
           files: dist/*
           fail_on_unmatched_files: true
-          # Keep hand-written release notes; only add the install block.
           append_body: true
-          body: |
-            Cortex subnet CLI (`ctx`) for ${{ inputs.tag || github.ref_name }}.
-
-            ```bash
-            curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
-            ctx challenges
-            ctx status
-            ```
-
-            Default gateway: https://gateway.cortex.foundation
+          body: ${{ steps.notes.outputs.body }}

--- a/.github/workflows/release-ctx.yml
+++ b/.github/workflows/release-ctx.yml
@@ -75,7 +75,7 @@ jobs:
       # Dispatch: the tip of main — never an input, never the release tag.
       # Full history so the commit can be checked against main below.
       - name: Checkout build ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
           fetch-depth: 0
@@ -177,12 +177,14 @@ jobs:
       # Every platform builds the one commit resolve picked, so the archives in
       # SHA256SUMS.txt cannot straddle a push to main that lands mid-run.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ needs.resolve.outputs.revision }}
 
       - name: Install Rust toolchain
-        # Pin by commit SHA. Never @master in a workflow that publishes.
+        # Every third-party action here is pinned by commit SHA (version in the
+        # trailing comment). A movable tag in a workflow that publishes what
+        # miners install would let upstream change the code on this path.
         uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0
         with:
           toolchain: "1.96.0"
@@ -218,7 +220,7 @@ jobs:
           Remove-Item ctx.exe
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ctx-${{ matrix.name }}
           path: |
@@ -236,7 +238,7 @@ jobs:
       contents: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: ctx-*
           merge-multiple: true
@@ -266,19 +268,36 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          # Empty when the tag has no Release yet (the next step creates it).
-          existing="$(gh release view "$TAG" --json body -q .body 2>/dev/null || true)"
+          # Only "release not found" means the tag has no Release yet (the
+          # next step creates one). Any other failure is not an empty body:
+          # guessing would append a second install block to the real notes.
+          set +e
+          existing="$(gh release view "$TAG" --json body -q .body 2>"$RUNNER_TEMP/gh-release.err")"
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            if grep -q "release not found" "$RUNNER_TEMP/gh-release.err"; then
+              existing=""
+            else
+              echo "::error::could not read the release notes of $TAG (gh exit $rc); refusing to guess"
+              cat "$RUNNER_TEMP/gh-release.err"
+              exit 1
+            fi
+          fi
+          # The block is present when the notes carry this exact command — a
+          # bare link to the script is not the install instructions.
+          install_cmd='curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh'
           {
             echo "body<<NOTES_EOF"
-            if ! printf '%s' "$existing" | grep -qF "scripts/install-ctx.sh"; then
-              cat <<'BLOCK'
-          Cortex subnet CLI (`ctx`) for miners.
+            if ! printf '%s' "$existing" | grep -qF "$install_cmd"; then
+              cat <<BLOCK
+          Cortex subnet CLI (\`ctx\`) for miners.
 
-          ```bash
-          curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
+          \`\`\`bash
+          $install_cmd
           ctx challenges
           ctx status
-          ```
+          \`\`\`
 
           Default gateway: https://gateway.cortex.foundation
 
@@ -289,7 +308,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Attach to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}
           files: dist/*

--- a/.github/workflows/release-ctx.yml
+++ b/.github/workflows/release-ctx.yml
@@ -62,10 +62,14 @@ jobs:
     name: resolve build ref
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # `source` / `revision`, not `ref` / `sha`: CodeQL's untrusted-checkout
+    # heuristic (actions/cache-poisoning) classifies any checkout whose ref
+    # expression is named *ref*/*branch*/*head*/*sha*/*commit* as a PR head,
+    # whatever it flows from. The trust argument is the resolve step below.
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      build_ref: ${{ steps.commit.outputs.build_ref }}
-      sha: ${{ steps.commit.outputs.sha }}
+      source: ${{ steps.source.outputs.source }}
+      revision: ${{ steps.source.outputs.revision }}
     steps:
       # Push: the pushed tag ref (checkout peels annotated tags to the commit).
       # Dispatch: the tip of main — never an input, never the release tag.
@@ -103,45 +107,45 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       # Derived from the checkout alone (no input reaches this step), so the
-      # SHA every build job checks out is trusted code from main.
+      # commit every build job checks out is trusted code from main.
       - name: Resolve build commit
-        id: commit
+        id: source
         env:
-          BUILD_REF: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
+          SOURCE: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
         run: |
           set -euo pipefail
-          sha="$(git rev-parse HEAD)"
+          revision="$(git rev-parse HEAD)"
           # Miners install what this publishes, so it is built from commits on
           # the working branch only — never from an unmerged branch or a fork.
           git fetch -q --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          if ! git merge-base --is-ancestor "$sha" refs/remotes/origin/main; then
-            echo "::error::$BUILD_REF ($sha) is not on main. ctx is released from commits on main only; land the change first, or dispatch (which builds the tip of main)."
+          if ! git merge-base --is-ancestor "$revision" refs/remotes/origin/main; then
+            echo "::error::$SOURCE ($revision) is not on main. ctx is released from commits on main only; land the change first, or dispatch (which builds the tip of main)."
             exit 1
           fi
           if [ ! -f bins/ctx/Cargo.toml ]; then
-            echo "::error::$BUILD_REF ($sha) has no bins/ctx — it predates the ctx CLI. Dispatch instead: the release tag stays a label and the sources come from the tip of main."
+            echo "::error::$SOURCE ($revision) has no bins/ctx — it predates the ctx CLI. Dispatch instead: the release tag stays a label and the sources come from the tip of main."
             exit 1
           fi
           {
-            echo "build_ref=$BUILD_REF"
-            echo "sha=$sha"
+            echo "source=$SOURCE"
+            echo "revision=$revision"
           } >> "$GITHUB_OUTPUT"
 
       - name: Summary
         env:
           TAG: ${{ steps.tag.outputs.tag }}
-          BUILD_REF: ${{ steps.commit.outputs.build_ref }}
-          SHA: ${{ steps.commit.outputs.sha }}
+          SOURCE: ${{ steps.source.outputs.source }}
+          REVISION: ${{ steps.source.outputs.revision }}
         run: |
           set -euo pipefail
           {
             echo "## release-ctx"
             echo
-            echo "| Release tag | Build ref | Commit |"
-            echo "|-------------|-----------|--------|"
-            echo "| \`$TAG\` | \`$BUILD_REF\` | \`$SHA\` |"
+            echo "| Release tag | Built from | Commit |"
+            echo "|-------------|------------|--------|"
+            echo "| \`$TAG\` | \`$SOURCE\` | \`$REVISION\` |"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "release tag $TAG <- build ref $BUILD_REF @ $SHA"
+          echo "release tag $TAG <- $SOURCE @ $REVISION"
 
   build:
     name: ctx ${{ matrix.name }}
@@ -175,7 +179,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.resolve.outputs.sha }}
+          ref: ${{ needs.resolve.outputs.revision }}
 
       - name: Install Rust toolchain
         # Pin by commit SHA. Never @master in a workflow that publishes.
@@ -257,8 +261,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.resolve.outputs.tag }}
-          BUILD_REF: ${{ needs.resolve.outputs.build_ref }}
-          SHA: ${{ needs.resolve.outputs.sha }}
+          SOURCE: ${{ needs.resolve.outputs.source }}
+          REVISION: ${{ needs.resolve.outputs.revision }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -280,7 +284,7 @@ jobs:
 
           BLOCK
             fi
-            echo "ctx assets built from \`$SHA\` (\`$BUILD_REF\`) by [release-ctx]($RUN_URL)."
+            echo "ctx assets built from \`$REVISION\` (\`$SOURCE\`) by [release-ctx]($RUN_URL)."
             echo "NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-ctx.yml
+++ b/.github/workflows/release-ctx.yml
@@ -8,8 +8,10 @@ name: release-ctx
 # Build ref vs release tag — two different things:
 #
 #   * The **build ref** is the commit `ctx` is compiled from. On a tag push it
-#     is the tagged commit. On workflow_dispatch it is `build_ref`, default
-#     `main` (the tip of the working branch at run time).
+#     is the tagged commit. On workflow_dispatch it is the tip of `main` at
+#     run time — never an input. A publishing workflow must not check out a
+#     caller-chosen ref (privileged context, cache poisoning, untrusted code);
+#     to release an older commit on `main`, push a v*.*.* tag on it instead.
 #   * The **release tag** is the GitHub Release the archives are attached to.
 #     On a tag push it is the pushed tag. On workflow_dispatch it is `tag`,
 #     which must already exist: the operator cuts the tag / Release first, and
@@ -19,8 +21,8 @@ name: release-ctx
 # network's prod tags (deploy/README.md § Prod release flow) — while the `ctx`
 # sources come from the tip of `main`. A dispatch never checks the tag out:
 # an old tag predates `bins/ctx`, which is how `package ID specification ctx
-# did not match any packages` happened. The resolve job refuses a build ref
-# that is not a commit on `main` (miners install what this publishes; an
+# did not match any packages` happened. The resolve job refuses a build
+# commit that is not on `main` (miners install what this publishes; an
 # unmerged branch or a fork is never released) or has no `bins/ctx`, before
 # any runner starts cargo; every archive of one run is built from the same
 # resolved commit, and the appended release notes record that commit.
@@ -30,7 +32,6 @@ name: release-ctx
 #     → the tag push runs this workflow from the tagged commit
 #   gh workflow run release-ctx.yml -f tag=vX.Y.Z
 #     → rebuild from the tip of main and (re)attach to that existing tag
-#   gh workflow run release-ctx.yml -f tag=vX.Y.Z -f build_ref=<sha|branch>
 # Any v*.*.* tag push also triggers deploy-prod.yml (fail-closed preflight).
 
 on:
@@ -39,14 +40,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to attach the ctx assets to (publishing label, e.g. v3.3.30)"
+        description: "Existing release tag to attach the ctx assets to (publishing label, e.g. v3.3.30). Sources: tip of main."
         required: true
         type: string
-      build_ref:
-        description: "Branch, tag, or SHA to build ctx from (default: main)"
-        required: false
-        type: string
-        default: main
 
 # Read-only by default; only the job that touches the Release gets write.
 permissions:
@@ -67,31 +63,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      tag: ${{ steps.pick.outputs.tag }}
-      build_ref: ${{ steps.pick.outputs.build_ref }}
-      sha: ${{ steps.pick.outputs.sha }}
+      tag: ${{ steps.tag.outputs.tag }}
+      build_ref: ${{ steps.commit.outputs.build_ref }}
+      sha: ${{ steps.commit.outputs.sha }}
     steps:
       # Push: the pushed tag ref (checkout peels annotated tags to the commit).
-      # Dispatch: the build ref, never the release tag. Full history so the
-      # commit can be checked against main below.
+      # Dispatch: the tip of main — never an input, never the release tag.
+      # Full history so the commit can be checked against main below.
       - name: Checkout build ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.build_ref || 'main') || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
           fetch-depth: 0
 
-      - name: Pick release tag and build commit
-        id: pick
+      - name: Resolve release tag
+        id: tag
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
-          INPUT_BUILD_REF: ${{ inputs.build_ref }}
           PUSHED_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             tag="$INPUT_TAG"
-            build_ref="${INPUT_BUILD_REF:-main}"
             case "$tag" in
               v*.*.*) ;;
               *)
@@ -105,35 +99,49 @@ jobs:
             fi
           else
             tag="$PUSHED_TAG"
-            build_ref="refs/tags/$tag"
           fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      # Derived from the checkout alone (no input reaches this step), so the
+      # SHA every build job checks out is trusted code from main.
+      - name: Resolve build commit
+        id: commit
+        env:
+          BUILD_REF: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
+        run: |
+          set -euo pipefail
           sha="$(git rev-parse HEAD)"
           # Miners install what this publishes, so it is built from commits on
           # the working branch only — never from an unmerged branch or a fork.
           git fetch -q --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if ! git merge-base --is-ancestor "$sha" refs/remotes/origin/main; then
-            echo "::error::build ref '$build_ref' ($sha) is not on main. ctx is released from commits on main only; land the change first, or dispatch with build_ref=main (the default)."
+            echo "::error::$BUILD_REF ($sha) is not on main. ctx is released from commits on main only; land the change first, or dispatch (which builds the tip of main)."
             exit 1
           fi
           if [ ! -f bins/ctx/Cargo.toml ]; then
-            echo "::error::build ref '$build_ref' ($sha) has no bins/ctx — it predates the ctx CLI. Dispatch with build_ref=main (the default) so the release tag stays a label and the sources come from tip."
+            echo "::error::$BUILD_REF ($sha) has no bins/ctx — it predates the ctx CLI. Dispatch instead: the release tag stays a label and the sources come from the tip of main."
             exit 1
           fi
-
           {
-            echo "tag=$tag"
-            echo "build_ref=$build_ref"
+            echo "build_ref=$BUILD_REF"
             echo "sha=$sha"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          BUILD_REF: ${{ steps.commit.outputs.build_ref }}
+          SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
           {
             echo "## release-ctx"
             echo
             echo "| Release tag | Build ref | Commit |"
             echo "|-------------|-----------|--------|"
-            echo "| \`$tag\` | \`$build_ref\` | \`$sha\` |"
+            echo "| \`$TAG\` | \`$BUILD_REF\` | \`$SHA\` |"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "release tag $tag <- build ref $build_ref @ $sha"
+          echo "release tag $TAG <- build ref $BUILD_REF @ $SHA"
 
   build:
     name: ctx ${{ matrix.name }}

--- a/.github/workflows/release-ctx.yml
+++ b/.github/workflows/release-ctx.yml
@@ -20,9 +20,10 @@ name: release-ctx
 # sources come from the tip of `main`. A dispatch never checks the tag out:
 # an old tag predates `bins/ctx`, which is how `package ID specification ctx
 # did not match any packages` happened. The resolve job refuses a build ref
-# without `bins/ctx` before any runner starts cargo, every archive of one run
-# is built from the same resolved commit, and the appended release notes
-# record that commit.
+# that is not a commit on `main` (miners install what this publishes; an
+# unmerged branch or a fork is never released) or has no `bins/ctx`, before
+# any runner starts cargo; every archive of one run is built from the same
+# resolved commit, and the appended release notes record that commit.
 #
 # Operator recipe (full text: deploy/README.md § ctx CLI release):
 #   gh release create vX.Y.Z --target main --title "ctx CLI vX.Y.Z" --notes "…"
@@ -71,11 +72,13 @@ jobs:
       sha: ${{ steps.pick.outputs.sha }}
     steps:
       # Push: the pushed tag ref (checkout peels annotated tags to the commit).
-      # Dispatch: the build ref, never the release tag.
+      # Dispatch: the build ref, never the release tag. Full history so the
+      # commit can be checked against main below.
       - name: Checkout build ref
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.build_ref || 'main') || github.ref }}
+          fetch-depth: 0
 
       - name: Pick release tag and build commit
         id: pick
@@ -106,6 +109,13 @@ jobs:
           fi
 
           sha="$(git rev-parse HEAD)"
+          # Miners install what this publishes, so it is built from commits on
+          # the working branch only — never from an unmerged branch or a fork.
+          git fetch -q --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$sha" refs/remotes/origin/main; then
+            echo "::error::build ref '$build_ref' ($sha) is not on main. ctx is released from commits on main only; land the change first, or dispatch with build_ref=main (the default)."
+            exit 1
+          fi
           if [ ! -f bins/ctx/Cargo.toml ]; then
             echo "::error::build ref '$build_ref' ($sha) has no bins/ctx — it predates the ctx CLI. Dispatch with build_ref=main (the default) so the release tag stays a label and the sources come from tip."
             exit 1
@@ -166,10 +176,9 @@ jobs:
           toolchain: "1.96.0"
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
+      # No cargo cache on purpose: a release build is cold and reproducible,
+      # and a cache written after compiling a dispatched ref would be restored
+      # by every later run on main (cache poisoning).
 
       # `ring` needs a C toolchain, and the musl targets are what make the
       # Linux archives run on any distro without a glibc floor.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -219,6 +219,7 @@ Tunnel writes gitignored `deploy/env/local-tunnel.env` (`BASE_GATEWAY_PUBLIC_URL
 | Staging | CI green on `main` (`deploy-staging.yml`) | `--build-from source` on droplet OK for iteration |
 | Images | Push to `main` (`images.yml`) | Build/push GHCR digests; promote + **commit** `deploy/pins/staging.json` + `deploy/digests/<sha>.json` |
 | Prod | Tag `v*.*.*` (`deploy-prod.yml`) | **`--build-from registry` only** — promote staging→prod pins, pull GHCR digests; no Rust source build on prod hosts |
+| ctx CLI | Tag `v*.*.*`, or `workflow_dispatch tag=vX.Y.Z [build_ref=main]` (`release-ctx.yml`) | Builds `bins/ctx` from the tagged commit (push) or from `build_ref` (dispatch; default `main` tip — never the tag) and attaches `ctx-*` archives + `SHA256SUMS.txt` to that Release. Tag = publishing label, build ref = sources; `scripts/install-ctx.sh` refuses a release without the sums. Recipe: [`README.md`](README.md) § `ctx` CLI release |
 
 Ladder: CI → GHCR digests → `deploy/pins/staging.json` (committed by `images.yml`) → tag → preflight (CI + staging pins match tag SHA) → `promote.sh` → `remote-deploy.sh --build-from registry`. Details: [`README.md`](README.md) § Auto CI deploy and § Promotion pipeline.
 

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -219,7 +219,7 @@ Tunnel writes gitignored `deploy/env/local-tunnel.env` (`BASE_GATEWAY_PUBLIC_URL
 | Staging | CI green on `main` (`deploy-staging.yml`) | `--build-from source` on droplet OK for iteration |
 | Images | Push to `main` (`images.yml`) | Build/push GHCR digests; promote + **commit** `deploy/pins/staging.json` + `deploy/digests/<sha>.json` |
 | Prod | Tag `v*.*.*` (`deploy-prod.yml`) | **`--build-from registry` only** — promote staging→prod pins, pull GHCR digests; no Rust source build on prod hosts |
-| ctx CLI | Tag `v*.*.*`, or `workflow_dispatch tag=vX.Y.Z [build_ref=main]` (`release-ctx.yml`) | Builds `bins/ctx` from the tagged commit (push) or from `build_ref` (dispatch; default `main` tip — never the tag) and attaches `ctx-*` archives + `SHA256SUMS.txt` to that Release. Tag = publishing label, build ref = sources; `scripts/install-ctx.sh` refuses a release without the sums. Recipe: [`README.md`](README.md) § `ctx` CLI release |
+| ctx CLI | Tag `v*.*.*`, or `workflow_dispatch tag=vX.Y.Z [build_ref=main]` (`release-ctx.yml`) | Builds `bins/ctx` from the tagged commit (push) or from `build_ref` (dispatch; default `main` tip — never the tag), commits on `main` only, no cargo cache, and attaches `ctx-*` archives + `SHA256SUMS.txt` to that Release. Tag = publishing label, build ref = sources; `scripts/install-ctx.sh` refuses a release without the sums. Recipe: [`README.md`](README.md) § `ctx` CLI release |
 
 Ladder: CI → GHCR digests → `deploy/pins/staging.json` (committed by `images.yml`) → tag → preflight (CI + staging pins match tag SHA) → `promote.sh` → `remote-deploy.sh --build-from registry`. Details: [`README.md`](README.md) § Auto CI deploy and § Promotion pipeline.
 

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -219,7 +219,7 @@ Tunnel writes gitignored `deploy/env/local-tunnel.env` (`BASE_GATEWAY_PUBLIC_URL
 | Staging | CI green on `main` (`deploy-staging.yml`) | `--build-from source` on droplet OK for iteration |
 | Images | Push to `main` (`images.yml`) | Build/push GHCR digests; promote + **commit** `deploy/pins/staging.json` + `deploy/digests/<sha>.json` |
 | Prod | Tag `v*.*.*` (`deploy-prod.yml`) | **`--build-from registry` only** — promote staging→prod pins, pull GHCR digests; no Rust source build on prod hosts |
-| ctx CLI | Tag `v*.*.*`, or `workflow_dispatch tag=vX.Y.Z [build_ref=main]` (`release-ctx.yml`) | Builds `bins/ctx` from the tagged commit (push) or from `build_ref` (dispatch; default `main` tip — never the tag), commits on `main` only, no cargo cache, and attaches `ctx-*` archives + `SHA256SUMS.txt` to that Release. Tag = publishing label, build ref = sources; `scripts/install-ctx.sh` refuses a release without the sums. Recipe: [`README.md`](README.md) § `ctx` CLI release |
+| ctx CLI | Tag `v*.*.*`, or `workflow_dispatch tag=vX.Y.Z` (`release-ctx.yml`) | Builds `bins/ctx` from the tagged commit (push) or from the tip of `main` (dispatch — never the tag, never an input), commits on `main` only, no cargo cache, and attaches `ctx-*` archives + `SHA256SUMS.txt` to that Release. Tag = publishing label, build ref = sources; `scripts/install-ctx.sh` refuses a release without the sums. Recipe: [`README.md`](README.md) § `ctx` CLI release |
 
 Ladder: CI → GHCR digests → `deploy/pins/staging.json` (committed by `images.yml`) → tag → preflight (CI + staging pins match tag SHA) → `promote.sh` → `remote-deploy.sh --build-from registry`. Details: [`README.md`](README.md) § Auto CI deploy and § Promotion pipeline.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -137,8 +137,8 @@ sources come from**:
 
 | Trigger | Attaches to | Builds from |
 |---------|-------------|-------------|
-| push tag `v*.*.*` | that tag | the tagged commit |
-| `workflow_dispatch` | `tag` (must already exist) | `build_ref` (default `main` = tip at run time) |
+| push tag `v*.*.*` | that tag | the tagged commit (must be on `main`) |
+| `workflow_dispatch` | `tag` (must already exist) | the tip of `main` at run time — never an input |
 
 ```bash
 # 1. Cut the label on tip (the tag push runs release-ctx from the tagged commit).
@@ -146,20 +146,23 @@ gh release create vX.Y.Z --target main --title "ctx CLI vX.Y.Z" --notes "…"
 # 2. (Re)build ctx from the tip of main and attach it to that existing tag —
 #    also the fix for a release that has no ctx assets.
 gh workflow run release-ctx.yml -f tag=vX.Y.Z
-gh workflow run release-ctx.yml -f tag=vX.Y.Z -f build_ref=<sha-on-main>   # pin a build
+# 2b. To release an older commit on main, tag that commit instead of dispatching.
+git tag -a vX.Y.Z <sha-on-main> -m "ctx CLI vX.Y.Z" && git push origin vX.Y.Z
 # 3. Confirm the six assets, then install the way a miner does.
 gh run watch && gh release view vX.Y.Z --json assets -q '.assets[].name'
 curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
 ```
 
 A dispatch never checks the tag out: an old tag predates `bins/ctx` and used
-to fail with `package ID specification ctx did not match any packages`. The
-`resolve` job refuses a build ref that is not a commit on `main` (miners
-install what this publishes; an unmerged branch or a fork is never released)
-or has no `bins/ctx`, refuses a `tag` that does not exist (a typo cannot
-mint a release), builds all five archives cold — no cargo cache — from one
-resolved commit, and appends that commit to the release notes. Runs for
-the same tag queue (`concurrency`) instead of racing on the upload. Any
+to fail with `package ID specification ctx did not match any packages`. It
+takes no build ref either — a publishing workflow must not check out a
+caller-chosen ref (privileged context, cache poisoning). The `resolve` job
+refuses a build commit that is not on `main` (miners install what this
+publishes; an unmerged branch or a fork is never released) or has no
+`bins/ctx`, refuses a `tag` that does not exist (a typo cannot mint a
+release), builds all five archives cold — no cargo cache — from one resolved
+commit, and appends that commit to the release notes. Runs for the same tag
+queue (`concurrency`) instead of racing on the upload. Any
 `v*.*.*` tag push also triggers `deploy-prod.yml`, whose preflight fails
 closed unless CI is green for that SHA and `deploy/pins/staging.json` carries
 it — a ctx-only label therefore shows a failed `deploy-prod` preflight and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -126,6 +126,46 @@ combination. Verify locally: `./deploy/scripts/assert-compose-matrix.sh`.
 7. Both prod hosts: `remote-deploy.sh --build-from registry` (pull GHCR `@sha256`, retag to Compose tags, `up --no-build`).
 8. Smoke `/healthz`. `environment: production` (enable required reviewers in GitHub UI).
 
+**`ctx` CLI release (miner installer):** `.github/workflows/release-ctx.yml`
+builds `bins/ctx` for linux / darwin (amd64 + arm64) and windows and attaches
+`ctx-*.tar.gz` / `.zip` plus `SHA256SUMS.txt` to the GitHub Release.
+`scripts/install-ctx.sh` (the `curl … | sh` in the miner docs) installs from
+`releases/latest` — or `CTX_VERSION=vX.Y.Z` — and refuses a release without
+those files, so a release published without this workflow installs nothing.
+The **release tag is a publishing label**; the **build ref is where the
+sources come from**:
+
+| Trigger | Attaches to | Builds from |
+|---------|-------------|-------------|
+| push tag `v*.*.*` | that tag | the tagged commit |
+| `workflow_dispatch` | `tag` (must already exist) | `build_ref` (default `main` = tip at run time) |
+
+```bash
+# 1. Cut the label on tip (the tag push runs release-ctx from the tagged commit).
+gh release create vX.Y.Z --target main --title "ctx CLI vX.Y.Z" --notes "…"
+# 2. (Re)build ctx from the tip of main and attach it to that existing tag —
+#    also the fix for a release that has no ctx assets.
+gh workflow run release-ctx.yml -f tag=vX.Y.Z
+gh workflow run release-ctx.yml -f tag=vX.Y.Z -f build_ref=<sha-or-branch>   # pin a build
+# 3. Confirm the six assets, then install the way a miner does.
+gh run watch && gh release view vX.Y.Z --json assets -q '.assets[].name'
+curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
+```
+
+A dispatch never checks the tag out: an old tag predates `bins/ctx` and used
+to fail with `package ID specification ctx did not match any packages`. The
+`resolve` job refuses a build ref without `bins/ctx`, refuses a `tag` that
+does not exist (a typo cannot mint a release), builds all five archives from
+one resolved commit, and appends that commit to the release notes. Runs for
+the same tag queue (`concurrency`) instead of racing on the upload. Any
+`v*.*.*` tag push also triggers `deploy-prod.yml`, whose preflight fails
+closed unless CI is green for that SHA and `deploy/pins/staging.json` carries
+it — a ctx-only label therefore shows a failed `deploy-prod` preflight and
+deploys nothing. `releases/latest` is GitHub's newest non-draft,
+non-prerelease release, ordered by the tagged commit's date rather than the
+publish date — cut labels on tip, and mark experimental labels pre-release to
+keep them off the default install path.
+
 Required GitHub secrets:
 
 | Secret | Purpose |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -146,7 +146,7 @@ gh release create vX.Y.Z --target main --title "ctx CLI vX.Y.Z" --notes "…"
 # 2. (Re)build ctx from the tip of main and attach it to that existing tag —
 #    also the fix for a release that has no ctx assets.
 gh workflow run release-ctx.yml -f tag=vX.Y.Z
-gh workflow run release-ctx.yml -f tag=vX.Y.Z -f build_ref=<sha-or-branch>   # pin a build
+gh workflow run release-ctx.yml -f tag=vX.Y.Z -f build_ref=<sha-on-main>   # pin a build
 # 3. Confirm the six assets, then install the way a miner does.
 gh run watch && gh release view vX.Y.Z --json assets -q '.assets[].name'
 curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
@@ -154,9 +154,11 @@ curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/instal
 
 A dispatch never checks the tag out: an old tag predates `bins/ctx` and used
 to fail with `package ID specification ctx did not match any packages`. The
-`resolve` job refuses a build ref without `bins/ctx`, refuses a `tag` that
-does not exist (a typo cannot mint a release), builds all five archives from
-one resolved commit, and appends that commit to the release notes. Runs for
+`resolve` job refuses a build ref that is not a commit on `main` (miners
+install what this publishes; an unmerged branch or a fork is never released)
+or has no `bins/ctx`, refuses a `tag` that does not exist (a typo cannot
+mint a release), builds all five archives cold — no cargo cache — from one
+resolved commit, and appends that commit to the release notes. Runs for
 the same tag queue (`concurrency`) instead of racing on the upload. Any
 `v*.*.*` tag push also triggers `deploy-prod.yml`, whose preflight fails
 closed unless CI is green for that SHA and `deploy/pins/staging.json` carries

--- a/docs/external-miner/README.md
+++ b/docs/external-miner/README.md
@@ -32,6 +32,16 @@ ctx challenges
 ctx status
 ```
 
+The installer takes the newest [release](https://github.com/CortexLM/cortex/releases)
+and verifies `ctx-<os>-<arch>.tar.gz` against that release's `SHA256SUMS.txt`.
+It refuses anything unverified: a release published without those files
+stops with a message naming it and installs nothing. To install a specific
+release instead, pin the tag with `CTX_VERSION`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | CTX_VERSION=vX.Y.Z sh
+```
+
 Default gateway is [https://gateway.cortex.foundation](https://gateway.cortex.foundation).
 `--gateway` overrides it for a local stack. `LIUM_API_KEY` is forwarded as
 `X-Lium-Api-Key` and never printed.

--- a/docs/external-miner/troubleshoot.md
+++ b/docs/external-miner/troubleshoot.md
@@ -10,7 +10,9 @@ Install `ctx` from [README](./README.md). Proof miners pay Lium
 
 | Symptom | Likely cause | What to check |
 |---------|--------------|---------------|
-| `install-ctx` aborts on checksum | Missing or mismatched `SHA256SUMS.txt` | The installer refuses an unverified binary. Wait for a `v*.*.*` release, or build `ctx` from this repo |
+| `install-ctx` stops with `release vX.Y.Z has no ctx assets` | That release was published without the `release-ctx` workflow, so it carries no `ctx-*.tar.gz` / `SHA256SUMS.txt` | Nothing was installed. Pin a [release](https://github.com/CortexLM/cortex/releases) that lists them (`CTX_VERSION=vX.Y.Z`), or wait for the operator to attach `ctx` assets to that tag |
+| `install-ctx` says `no release named vX.Y.Z` | `CTX_VERSION` names a tag that has no release | Check the tag on the releases page, or unset `CTX_VERSION` for the newest release |
+| `install-ctx` aborts on checksum | Mismatched `SHA256SUMS.txt`, or `ctx-*.tar.gz` listed but absent | The installer refuses an unverified binary. Re-run later (an upload may be in progress), pin another release, or build `ctx` from this repo (`cargo build -p ctx --release --locked`) |
 | `request to … failed` | Gateway not reachable | `ctx status --gateway https://gateway.cortex.foundation`. A local stack needs `--gateway http://127.0.0.1:8080` |
 | `can_score: NO` / HTTP 503 | The host cannot score right now | Nothing was stored and nothing was rented. Read the error; do not retry-spend |
 

--- a/scripts/install-ctx.sh
+++ b/scripts/install-ctx.sh
@@ -102,12 +102,20 @@ release_label() {
 }
 
 # Whether $RELEASES/tag/<tag> exists at all, to tell "no such release" from
-# "release exists but was cut without ctx assets".
+# "release exists but was cut without ctx assets". Only a 404 means absent;
+# an outage or a network error aborts with its own message, so nobody is told
+# to change CTX_VERSION when GitHub is what is failing.
 release_exists() {
   case "$VERSION" in
     latest) return 0 ;;
   esac
-  curl -fsSLI -o /dev/null "$RELEASES/tag/$VERSION" >/dev/null 2>&1
+  code="$(curl -sSLI -o /dev/null -w '%{http_code}' "$RELEASES/tag/$VERSION")" \
+    || die "could not reach $RELEASES to check release $VERSION (network error); retry later"
+  case "$code" in
+    2??) return 0 ;;
+    404) return 44 ;;
+    *) die "HTTP $code from $RELEASES/tag/$VERSION while checking that the release exists; GitHub may be unavailable, retry later" ;;
+  esac
 }
 
 tmp="$(mktemp -d)"

--- a/scripts/install-ctx.sh
+++ b/scripts/install-ctx.sh
@@ -4,8 +4,17 @@
 #   curl -fsSL https://raw.githubusercontent.com/CortexLM/cortex/main/scripts/install-ctx.sh | sh
 #
 # Knobs (all optional):
-#   CTX_VERSION      release tag to install, e.g. v0.2.0 (default: latest)
+#   CTX_VERSION      release tag to install, e.g. vX.Y.Z (default: latest).
+#                    Pin it to install a specific release, or when `latest`
+#                    was published without ctx assets:
+#                      curl -fsSL .../install-ctx.sh | CTX_VERSION=vX.Y.Z sh
 #   CTX_INSTALL_DIR  install directory (default: $HOME/.local/bin)
+#
+# The ctx archives (ctx-<os>-<arch>.tar.gz) and SHA256SUMS.txt are attached
+# to a release by the release-ctx GitHub Actions workflow
+# (.github/workflows/release-ctx.yml). A release cut without that workflow has
+# neither file; this script then stops and names the release instead of
+# installing anything. Releases: https://github.com/CortexLM/cortex/releases
 #
 # The download is checksum-verified against the release's SHA256SUMS.txt. A
 # missing or mismatched checksum aborts the install rather than running an
@@ -17,6 +26,8 @@ REPO="CortexLM/cortex"
 GATEWAY="https://gateway.cortex.foundation"
 VERSION="${CTX_VERSION:-latest}"
 INSTALL_DIR="${CTX_INSTALL_DIR:-$HOME/.local/bin}"
+RELEASES="https://github.com/$REPO/releases"
+SCRIPT_URL="https://raw.githubusercontent.com/$REPO/main/scripts/install-ctx.sh"
 
 die() {
   echo "install-ctx: $*" >&2
@@ -34,7 +45,7 @@ need uname
 case "$(uname -s)" in
   Linux) os=linux ;;
   Darwin) os=darwin ;;
-  *) die "unsupported OS $(uname -s). Windows users: download ctx-windows-amd64.zip from https://github.com/$REPO/releases" ;;
+  *) die "unsupported OS $(uname -s). Windows users: download ctx-windows-amd64.zip from $RELEASES" ;;
 esac
 
 case "$(uname -m)" in
@@ -45,9 +56,9 @@ esac
 
 asset="ctx-${os}-${arch}.tar.gz"
 if [ "$VERSION" = "latest" ]; then
-  base="https://github.com/$REPO/releases/latest/download"
+  base="$RELEASES/latest/download"
 else
-  base="https://github.com/$REPO/releases/download/$VERSION"
+  base="$RELEASES/download/$VERSION"
 fi
 
 sha256_of() {
@@ -60,17 +71,75 @@ sha256_of() {
   fi
 }
 
+# Download $1 to $2. Returns 0 when fetched and 44 when the server answered
+# 404 (that file is not on the release); any other failure aborts the install
+# so a network error is never mistaken for a missing asset.
+fetch() {
+  code="$(curl -sSL -o "$2" -w '%{http_code}' "$1")" || die "download failed: $1"
+  case "$code" in
+    2??) return 0 ;;
+    404)
+      rm -f "$2"
+      return 44
+      ;;
+    *) die "download failed (HTTP $code): $1" ;;
+  esac
+}
+
+# The tag `latest` resolves to right now, so an error can name the release
+# that is missing ctx assets. Best effort: a failure here only degrades the
+# message, never the checksum verification.
+release_label() {
+  if [ "$VERSION" != "latest" ]; then
+    echo "$VERSION"
+    return 0
+  fi
+  url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$RELEASES/latest" 2>/dev/null || true)"
+  case "$url" in
+    */releases/tag/*) echo "${url##*/} (latest)" ;;
+    *) echo "latest" ;;
+  esac
+}
+
+# Whether $RELEASES/tag/<tag> exists at all, to tell "no such release" from
+# "release exists but was cut without ctx assets".
+release_exists() {
+  case "$VERSION" in
+    latest) return 0 ;;
+  esac
+  curl -fsSLI -o /dev/null "$RELEASES/tag/$VERSION" >/dev/null 2>&1
+}
+
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT INT TERM
 
-echo "install-ctx: downloading $asset ($VERSION)"
-curl -fsSL "$base/$asset" -o "$tmp/$asset" \
-  || die "download failed: $base/$asset"
-curl -fsSL "$base/SHA256SUMS.txt" -o "$tmp/SHA256SUMS.txt" \
-  || die "no SHA256SUMS.txt in that release; refusing to install unverified"
+label="$(release_label)"
+echo "install-ctx: release $label"
+
+# Sums first. A release published without the release-ctx workflow has no ctx
+# assets at all, and that deserves a clearer message than a 404 on the tarball.
+if ! fetch "$base/SHA256SUMS.txt" "$tmp/SHA256SUMS.txt"; then
+  if ! release_exists; then
+    die "no release named $VERSION under $RELEASES (set CTX_VERSION to an existing tag, or unset it for latest)"
+  fi
+  cat >&2 <<EOF
+install-ctx: release $label has no ctx assets (SHA256SUMS.txt is missing).
+install-ctx: ctx archives are attached by the release-ctx GitHub Actions workflow;
+install-ctx: this release was published without it. Refusing to install unverified.
+install-ctx: Either wait for the operator to run release-ctx against that tag
+install-ctx: (Actions -> release-ctx -> Run workflow -> tag=<that tag>), or pin a
+install-ctx: release that lists ctx-*.tar.gz and SHA256SUMS.txt under $RELEASES:
+install-ctx:   curl -fsSL $SCRIPT_URL | CTX_VERSION=vX.Y.Z sh
+EOF
+  exit 1
+fi
 
 want="$(grep " \{1,2\}\*\{0,1\}${asset}\$" "$tmp/SHA256SUMS.txt" | cut -d' ' -f1 | head -n1)"
-[ -n "$want" ] || die "$asset is not listed in SHA256SUMS.txt"
+[ -n "$want" ] || die "release $label has no ${os}-${arch} build ($asset is not listed in SHA256SUMS.txt)"
+
+echo "install-ctx: downloading $asset"
+fetch "$base/$asset" "$tmp/$asset" \
+  || die "$asset is listed in SHA256SUMS.txt but missing from release $label (incomplete upload?)"
 got="$(sha256_of "$tmp/$asset")"
 [ "$want" = "$got" ] || die "checksum mismatch for $asset (expected $want, got $got)"
 
@@ -81,7 +150,7 @@ mkdir -p "$INSTALL_DIR"
 cp "$tmp/ctx" "$INSTALL_DIR/ctx"
 chmod 755 "$INSTALL_DIR/ctx"
 
-echo "install-ctx: installed $("$INSTALL_DIR/ctx" --version) to $INSTALL_DIR/ctx"
+echo "install-ctx: installed $("$INSTALL_DIR/ctx" --version) from release $label to $INSTALL_DIR/ctx"
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) ;;
   *)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P0 miner install: `curl -fsSL …/scripts/install-ctx.sh | sh` must always get real `ctx` binaries.

**Root cause (verified in run [34415976577](https://github.com/CortexLM/cortex/actions/runs/34415976577)):** `release-ctx.yml` on `workflow_dispatch` checked out `inputs.tag`. Dispatching against a tag that predates `bins/ctx` (e.g. `v3.3.5`, then `releases/latest`) failed with `package ID specification ctx did not match any packages`, so `latest` kept zero ctx assets and the installer died on a bare 404.

### `.github/workflows/release-ctx.yml` — build ref ≠ release tag
- New `resolve` job picks the **release tag** (pushed tag, or the existing `tag` input) and the **build commit**: the tagged commit on push, the **tip of `main`** on dispatch. A dispatch never checks the tag out.
- No `build_ref` input on purpose: CodeQL (high) flags a privileged `workflow_dispatch` job that checks out an input-derived ref and runs cargo on it (cache poisoning / untrusted code), and an ancestry guard is invisible to static analysis. Releasing an older `main` commit = push a `v*.*.*` tag on it (push path). Tag validation (reads the input) is a separate step from commit resolution, so the commit the build jobs check out derives from the checkout alone.
- Fail-closed guards before any runner starts cargo: dispatch `tag` must exist on origin (a typo cannot mint a release) and match `v*.*.*`; the build commit must be an **ancestor of `origin/main`** (miners install what this publishes — an unmerged branch or a fork is never released) and must contain `bins/ctx` (the error names the old failure and the fix).
- All five platform jobs check out the **one resolved commit**, so `SHA256SUMS.txt` can never straddle a push to `main` mid-run. Outputs are named `revision` / `source` (not `sha` / `ref`): CodeQL's untrusted-checkout heuristic keys on those field names regardless of data flow; the workflow says so in a comment.
- **Every action SHA-pinned** with its version in a trailing comment (checkout v4.4.0, upload-artifact v4.6.2, download-artifact v4.3.0, action-gh-release v2.6.2; rust-toolchain was already pinned). SHAs resolved from the tags the workflow already used — no behaviour change.
- **No cargo cache**: a release build is cold and reproducible; a cache written by a publishing job would be restored by every later run on `main`.
- `concurrency` per tag (tag push + dispatch for the same tag queue instead of racing on upload); `contents: write` only on the `release` job.
- Release notes: install block added **once per release**, keyed on the exact canonical install command (the current `v3.3.30` body has it three times from repeated `append_body`), plus one provenance line per build (`built from <revision> (<source>) by release-ctx <run>`). The existing-notes lookup fails closed on anything but `release not found`, so a transient API error can never append a duplicate.
- Header documents that the Release tag is a publishing label while sources come from tip, and that any `v*.*.*` tag push also fires `deploy-prod.yml` (fail-closed preflight — observed on `v3.3.30` / `v0.2.0`, deployed nothing).

### `scripts/install-ctx.sh` — clear error instead of a 404
- Resolves which tag `latest` is, fetches `SHA256SUMS.txt` **first**, and when it is missing stops with a message naming the release, explaining that ctx assets come from `release-ctx`, and showing the `CTX_VERSION` pin. Separate messages for: no such release (404 only), release-probe outage (5xx / network, with a retry hint), no build for this platform, listed-but-missing archive, checksum mismatch, network error. Still never installs unverified.

### Docs
- `deploy/README.md`: operator recipe (`gh release create vX.Y.Z --target main …` → `gh workflow run release-ctx.yml -f tag=vX.Y.Z` → verify → `curl | sh`; older commit → tag it), the deploy-prod coupling, `releases/latest` ordering. `deploy/AGENTS.md`: lane row.
- `docs/external-miner/README.md`: `CTX_VERSION` pin; `troubleshoot.md`: rows for the new installer messages.

Out of scope, untouched: no digests invented, no releases deleted, `deploy-prod.yml` unchanged. `ctx --version` still prints the workspace version (`0.1.0`), not the release tag.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [x] Greptile has reviewed this PR; findings are fixed or answered (5 threads: action pinning P1+P2, notes lookup, block marker, release probe — all fixed in e9050eee / 9734de9b with replies)
- [x] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `actionlint` + `shellcheck` on the workflow; `shellcheck -s sh` on the installer (clean); CodeQL (actions) green on the head
- [x] `resolve` steps simulated against a local bare `origin`: dispatch tag OK / missing → error / malformed → error; commit on `main` tip OK; annotated tag on `main` → peeled commit; tag off `main` → "not on main" error; tag predating `bins/ctx` → error
- [x] Release-notes step simulated: no release → block; gh `HTTP 503` → step fails, no body; notes with the command → no duplicate; notes that only link the script → block; plain notes → block
- [x] Installer against real GitHub: `CTX_VERSION=v3.3.5` → "has no ctx assets" message, exit 1; `CTX_VERSION=v9.9.9` → "no release named"; default `latest` → installed real `ctx 0.1.0` from `v3.3.30` and `ctx challenges` runs
- [x] Installer against local servers: happy path, no build for platform, checksum mismatch, listed-but-missing; release probe 500 → outage message, 404 → absent, 200 → no-assets message, dead port → network error
- [x] `cargo run -p xtask -- external-docs-check` OK; `cargo test -p xtask` 57 passed (no Rust touched)
- [ ] The workflow itself runs only on a tag push / dispatch after merge — first real exercise is the next `gh workflow run release-ctx.yml -f tag=…` from `main`

## Risk

No deploy, miner CVM measurement, signature domain, or emission impact. Changes a publishing workflow and an installer: a bad edit here fails a release closed (no assets → installer refuses), never installs an unverified binary. Cold builds make each release run a few minutes longer. Operators must know that a `v*.*.*` label also triggers `deploy-prod` preflight (pre-existing coupling, now documented).

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b68b685-d46f-4e64-b634-25427734db7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b68b685-d46f-4e64-b634-25427734db7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

