### PR TITLE
feat(proof): queued submissions with defer_scoring and operator drain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,6 +3857,7 @@ dependencies = [
  "proof-score",
  "proof-task",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.19",
 ]

--- a/bins/ctx/src/proof.rs
+++ b/bins/ctx/src/proof.rs
@@ -8,8 +8,15 @@ use serde_json::{json, Value};
 use crate::api::{challenge_path, Client};
 use crate::catalog::{compact, find};
 
-/// States a submission does not move out of on its own.
+/// States a submission does not move out of on its own. `queued` is the one
+/// non-terminal state: the topic defers scoring and the operator drains the
+/// queue later, so `--wait` keeps polling through it.
 const TERMINAL_STATES: [&str; 3] = ["awaiting_admin", "rejected", "champion"];
+
+/// What a `queued` row means for the miner.
+const QUEUED_HINT: &str =
+    "Scoring is deferred on this topic: the row is queued (no eval, no rent yet) \
+     and is scored in order once the operator lifts the flag and drains the queue.";
 
 /// Poll interval for `--wait`.
 const POLL_SECS: u64 = 20;
@@ -83,6 +90,9 @@ pub async fn submit(client: &Client, input: &SubmitInput, json_out: bool) -> Res
     if !json_out {
         println!("Proof submission accepted");
         print_fields(&reply.body);
+        if is_queued(&reply.body) {
+            println!("  {QUEUED_HINT}");
+        }
         println!();
         println!("Track it:");
         println!("  ctx proof show {id}");
@@ -157,12 +167,19 @@ async fn poll(client: &Client, id: &str, wait: bool, json_out: bool) -> Result<(
         if !json_out {
             println!("proof {id}  state={state}");
             print_fields(&reply.body);
+            if is_queued(&reply.body) {
+                println!("  {QUEUED_HINT}");
+            }
         }
         if !wait || TERMINAL_STATES.contains(&state) {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_secs(POLL_SECS)).await;
     }
+}
+
+fn is_queued(body: &Value) -> bool {
+    body.get("state").and_then(Value::as_str) == Some("queued")
 }
 
 fn build_manifest(input: &SubmitInput) -> Result<Value, String> {
@@ -234,6 +251,7 @@ fn print_fields(body: &Value) {
         "eval_backend",
         "eligible",
         "submission_digest",
+        "detail",
         "error",
     ] {
         if let Some(v) = body.get(field) {
@@ -291,6 +309,16 @@ mod tests {
         assert!(normalize_hex64("abcd", "hotkey").is_err());
         let ok = "a".repeat(64);
         assert_eq!(normalize_hex64(&ok, "hotkey").unwrap(), ok);
+    }
+
+    #[test]
+    fn queued_is_the_only_non_terminal_state() {
+        assert!(!TERMINAL_STATES.contains(&"queued"));
+        assert!(is_queued(&serde_json::json!({ "state": "queued" })));
+        assert!(!is_queued(
+            &serde_json::json!({ "state": "awaiting_admin" })
+        ));
+        assert!(!is_queued(&serde_json::json!({})));
     }
 
     #[test]

--- a/bins/proof-challenge/src/main.rs
+++ b/bins/proof-challenge/src/main.rs
@@ -131,6 +131,16 @@ struct Cli {
     /// Seconds between emitter ticks.
     #[arg(long, env = "PROOF_EMIT_POLL_SECS", default_value_t = DEFAULT_EMIT_POLL_SECS)]
     emit_poll_secs: u64,
+    /// Seconds between queue-drain passes: `queued` rows of every open topic
+    /// that no longer defers scoring are scored oldest first, one at a time,
+    /// through the live path. `0` disables the loop — the queue then drains
+    /// only through `POST /v1/admin/proof/queue/drain`.
+    #[arg(
+        long,
+        env = "PROOF_QUEUE_DRAIN_POLL_SECS",
+        default_value_t = DEFAULT_QUEUE_DRAIN_POLL_SECS
+    )]
+    queue_drain_poll_secs: u64,
     /// Persisted scored-epoch watermark (survives process restart).
     #[arg(
         long,
@@ -248,7 +258,51 @@ fn run(cli: &Cli) -> Result<(), String> {
         vm_probe: Some(vm),
         epoch: 0,
     };
+    if cli.queue_drain_poll_secs == 0 {
+        tracing::info!(
+            "queue drain loop disabled (PROOF_QUEUE_DRAIN_POLL_SECS=0); queued rows score only \
+             through POST /v1/admin/proof/queue/drain"
+        );
+    } else {
+        rt.spawn(run_queue_drainer(
+            state.clone(),
+            Duration::from_secs(cli.queue_drain_poll_secs),
+        ));
+    }
     rt.block_on(serve(cli.bind, state))
+}
+
+/// Default seconds between queue-drain passes.
+const DEFAULT_QUEUE_DRAIN_POLL_SECS: u64 = 60;
+
+/// Score the `queued` rows of every open topic that no longer defers scoring
+/// (`constraints.params.defer_scoring` lifted by a re-publish), oldest first,
+/// one at a time, through the same path a live submit takes. A topic that
+/// still defers is never touched; a host that cannot score leaves the rows
+/// queued and says why, once per pass. Lifting the flag is the operator's
+/// "score now".
+async fn run_queue_drainer(state: AppState, poll: Duration) {
+    loop {
+        tokio::time::sleep(poll).await;
+        for report in state.drain_ready_queues().await {
+            let scored: Vec<&str> = report.drained.iter().map(|r| r.id.as_str()).collect();
+            if let Some(why) = &report.stopped {
+                tracing::warn!(
+                    topic_id = %report.topic_id,
+                    scored = ?scored,
+                    remaining = report.remaining,
+                    "queue drain stopped: {why}; the remaining rows stay queued for the next pass"
+                );
+            } else {
+                tracing::info!(
+                    topic_id = %report.topic_id,
+                    scored = ?scored,
+                    remaining = report.remaining,
+                    "queue drained"
+                );
+            }
+        }
+    }
 }
 
 fn build_live_scorer(

--- a/crates/proof-canon/src/lib.rs
+++ b/crates/proof-canon/src/lib.rs
@@ -30,6 +30,18 @@ pub const MAX_RULE_TEXT_LEN: usize = 2_048;
 /// Most opaque constraint params one topic may carry.
 pub const MAX_CONSTRAINT_PARAMS: usize = 32;
 
+/// `constraints.params` key that **defers scoring** on an open topic.
+///
+/// `"true"` keeps the topic `open` — submissions are validated and persisted
+/// as `queued` — but nothing is evaluated: no harvest rent, no topic VM, no
+/// judge call, until the operator re-publishes the topic without the flag
+/// and the queue is drained. This is how a topic accepts artefacts while its
+/// baseline / harness is still being installed. It is not `draft` (a draft
+/// answers 400) and it is not a scorer switch: `"false"` and an absent key
+/// are the same thing. Any other spelling is a publish reject. A value, like
+/// every param, that travels in the signed document — never host state.
+pub const PARAM_DEFER_SCORING: &str = "defer_scoring";
+
 /// Why a shared shape is malformed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShapeError {
@@ -103,7 +115,35 @@ impl Constraints {
         {
             return bad("params", "<=32 slug keys with printable values");
         }
+        if self
+            .params
+            .get(PARAM_DEFER_SCORING)
+            .is_some_and(|v| parse_bool_param(v).is_none())
+        {
+            return bad("params.defer_scoring", "\"true\" or \"false\"");
+        }
         Ok(())
+    }
+
+    /// Whether the signed topic defers scoring
+    /// (`params.defer_scoring = "true"`; see [`PARAM_DEFER_SCORING`]).
+    /// Absent, `"false"`, or — for a document that skipped
+    /// [`Self::validate_shape`] — malformed all read as **not** deferred, so
+    /// the flag can only ever hold evaluation back, never unlock it.
+    pub fn defer_scoring(&self) -> bool {
+        self.params
+            .get(PARAM_DEFER_SCORING)
+            .and_then(|v| parse_bool_param(v))
+            .unwrap_or(false)
+    }
+}
+
+/// `"true"` / `"false"` (trimmed, ASCII case-insensitive); anything else `None`.
+fn parse_bool_param(v: &str) -> Option<bool> {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
     }
 }
 
@@ -432,6 +472,40 @@ mod tests {
             tail.contains("byte-for-byte") && tail.contains("PROOF_VM_RUNNER_CUSTOM_IDS"),
             "{tail}"
         );
+    }
+
+    /// `defer_scoring` is a plain boolean word carried by the signed
+    /// document: a typo is a shape reject (never silently "not deferred"
+    /// at publish), and only the exact word `true` holds scoring back.
+    #[test]
+    fn defer_scoring_is_a_boolean_param_and_a_typo_is_a_shape_reject() {
+        let with = |v: &str| Constraints {
+            params: BTreeMap::from([(PARAM_DEFER_SCORING.to_owned(), v.to_owned())]),
+            ..Constraints::default()
+        };
+        assert!(!Constraints::default().defer_scoring());
+        for (value, want) in [("true", true), (" TRUE ", true), ("false", false)] {
+            let c = with(value);
+            c.validate_shape().expect(value);
+            assert_eq!(c.defer_scoring(), want, "{value:?}");
+        }
+        for bad in ["yes", "1", "maybe", "ture"] {
+            let c = with(bad);
+            let err = c.validate_shape().expect_err(bad);
+            assert_eq!(err.field, "constraints.params.defer_scoring", "{bad:?}");
+            assert!(
+                err.why.contains("\"true\" or \"false\""),
+                "{bad:?}: {}",
+                err.why
+            );
+            assert!(!c.defer_scoring(), "a malformed flag never defers: {bad:?}");
+        }
+        let other = Constraints {
+            params: BTreeMap::from([("unrelated_knob".to_owned(), "true".to_owned())]),
+            ..Constraints::default()
+        };
+        other.validate_shape().expect("other params are opaque");
+        assert!(!other.defer_scoring());
     }
 
     #[test]

--- a/crates/proof-http/Cargo.toml
+++ b/crates/proof-http/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json", "query"] }
 hex = "0.4"
 proof-eval = { path = "../proof-eval" }
 proof-executor = { path = "../proof-executor" }

--- a/crates/proof-http/src/lib.rs
+++ b/crates/proof-http/src/lib.rs
@@ -55,7 +55,8 @@ use proof_score::{
     MinerTopicRun, ProofKind, ProofVerdict,
 };
 use proof_store::{
-    freeze_submission_digest, ArtifactManifest, MemoryStore, Submission, SubmissionState,
+    freeze_submission_digest, ArtifactManifest, Enqueued, MemoryStore, StoreError, Submission,
+    SubmissionState,
 };
 use proof_task::{
     resolve_inference, InferenceOffer, MetricFamily, OfferError, ProofPin, TopicDocument,
@@ -579,34 +580,44 @@ async fn submit(
     Ok((StatusCode::CREATED, Json(resp)))
 }
 
-/// Persist an intake row as `queued`. A retry of the same artefact by the
-/// same hotkey (same frozen digest) finds its queued row (**200**) instead
-/// of queueing a second paid run.
+/// Persist an intake row as `queued` — one row per frozen digest per topic,
+/// in a single store step. A retry of the same artefact by the same hotkey
+/// (same frozen digest) finds its row (**200**) — still queued, or already
+/// scored after a drain — instead of queueing a second paid run; two
+/// identical submits racing each other yield one row.
 fn queue_deferred(
     st: &AppState,
     mut row: Submission,
 ) -> Result<(StatusCode, Json<SubmitResp>), ErrResp> {
-    if let Some(existing) = st
-        .store
-        .queued_by_digest(&row.topic_id, &row.submission_digest)
-        .map_err(|e| store_err(&e))?
-    {
-        let mut resp = SubmitResp::of(&existing, st.backend, false);
-        resp.detail = Some(format!(
-            "already queued as {}; {DEFERRED_DETAIL}",
-            existing.id
-        ));
-        return Ok((StatusCode::OK, Json(resp)));
-    }
     row.detail = Some(DEFERRED_DETAIL.to_owned());
-    let row = st
-        .store
-        .insert(row)
-        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "store"))?;
-    Ok((
-        StatusCode::CREATED,
-        Json(SubmitResp::of(&row, st.backend, false)),
-    ))
+    match st.store.enqueue(row).map_err(|e| store_err(&e))? {
+        Enqueued::Inserted(row) => Ok((
+            StatusCode::CREATED,
+            Json(SubmitResp::of(&row, st.backend, false)),
+        )),
+        Enqueued::Existing(existing) => {
+            let eligible = existing.verdict.as_ref().is_some_and(|v| v.pass);
+            let mut resp = SubmitResp::of(&existing, st.backend, eligible);
+            resp.detail = Some(if existing.state == SubmissionState::Queued {
+                format!("already queued as {}; {DEFERRED_DETAIL}", existing.id)
+            } else {
+                format!(
+                    "already submitted as {} and scored ({}); one run per artefact per topic",
+                    existing.id,
+                    state_name(existing.state)
+                )
+            });
+            Ok((StatusCode::OK, Json(resp)))
+        }
+    }
+}
+
+/// Wire name of a state (`queued`, `awaiting_admin`, …).
+fn state_name(state: SubmissionState) -> String {
+    serde_json::to_value(state)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_owned))
+        .unwrap_or_default()
 }
 
 /// Score one intake row on `topic` and persist the result: host readiness,
@@ -1046,6 +1057,8 @@ impl AppState {
     /// a re-publish that defers or closes it mid-pass stops the pass. The
     /// first host refusal stops the pass too: that row is released back to
     /// the queue unscored (nothing was rented) and later rows are not tried.
+    /// Another drain already holding the topic's claim stops it as well
+    /// (`stopped` names the row in flight) — a topic scores one row at a time.
     pub async fn drain_queue(&self, topic_id: &str, limit: usize) -> DrainReport {
         let mut report = DrainReport {
             topic_id: topic_id.to_owned(),
@@ -1061,14 +1074,22 @@ impl AppState {
                     break;
                 }
             };
-            let Ok(Some(row)) = self.store.claim_next_queued(topic_id) else {
-                break;
+            let row = match self.store.claim_next_queued(topic_id) {
+                Ok(Some(row)) => row,
+                Ok(None) => break,
+                Err(e) => {
+                    report.stopped = Some(e.to_string());
+                    break;
+                }
             };
-            let id = row.id.clone();
+            let claim = ClaimGuard::new(self.store.clone(), &row);
             match score_intake(self, row, &topic).await {
-                Ok(resp) => report.drained.push(resp),
+                Ok(resp) => {
+                    claim.landed();
+                    report.drained.push(resp);
+                }
                 Err((code, body)) => {
-                    let _ = self.store.release_claim(&id);
+                    drop(claim);
                     report.stopped = Some(format!("{code}: {}", error_text(&body)));
                     break;
                 }
@@ -1105,6 +1126,54 @@ fn error_text(body: &Json<serde_json::Value>) -> String {
         .map_or_else(|| body.0.to_string(), str::to_owned)
 }
 
+/// Holds a topic's queue claim for one row while it scores, and gives it
+/// back on **every** exit that did not land the row: the host refused, the
+/// scorer panicked, or the drain future was dropped (an operator's HTTP
+/// call cut mid-eval, the poll task cancelled). Without it an interrupted
+/// drain would leave the topic "busy" until a restart. [`Self::landed`]
+/// disarms it once the scored row is persisted (which settled the claim
+/// itself); a release is keyed by `(topic, row)`, so a late one can never
+/// drop a claim a later drain took.
+struct ClaimGuard {
+    store: MemoryStore,
+    topic_id: String,
+    id: String,
+    armed: bool,
+}
+
+impl ClaimGuard {
+    fn new(store: MemoryStore, row: &Submission) -> Self {
+        Self {
+            store,
+            topic_id: row.topic_id.clone(),
+            id: row.id.clone(),
+            armed: true,
+        }
+    }
+
+    /// The row landed scored: nothing to give back.
+    fn landed(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ClaimGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.store.release_claim(&self.topic_id, &self.id);
+        }
+    }
+}
+
+fn claim_err(e: StoreError) -> ErrResp {
+    match e {
+        StoreError::NotFound(_) => err(StatusCode::NOT_FOUND, "not_found"),
+        StoreError::Illegal(why) => err(StatusCode::CONFLICT, &why),
+        busy @ StoreError::Busy { .. } => err(StatusCode::CONFLICT, &busy.to_string()),
+        other => store_err(&other),
+    }
+}
+
 /// Operator drain: score the oldest `queued` rows of one topic through the
 /// live path. **200** with a [`DrainReport`]; **503** carrying the report
 /// (plus `error`) when the host refused before a single row scored — the
@@ -1123,6 +1192,9 @@ async fn drain_queue(
     }
     let topic_id = body.topic_id.trim().to_owned();
     st.drainable_topic(&topic_id)?;
+    if let Some(id) = st.store.scoring_row(&topic_id).map_err(|e| store_err(&e))? {
+        return Err(claim_err(StoreError::Busy { topic_id, id }));
+    }
     let report = st
         .drain_queue(&topic_id, body.limit.unwrap_or(1).max(1))
         .await;
@@ -1137,11 +1209,14 @@ async fn drain_queue(
     Ok((StatusCode::OK, Json(view)))
 }
 
-/// Operator: score one `queued` row now (same rules as a drain of one).
+/// Operator: score one `queued` row now (same rules as a drain of one). The
+/// row must be the **head** of its topic's queue — the queue drains oldest
+/// first, and promotion compares each run against the best at that moment.
 /// **200** with the scored row's reply; **404** unknown; **409** when the
-/// row is not `queued`, is already being scored, or its topic still defers
-/// / is not open; a host refusal is that refusal (**503**) with the row
-/// released back to the queue.
+/// row is not `queued`, is not the head (the error names the head), its
+/// topic already has a row in flight, or its topic still defers / is not
+/// open; a host refusal is that refusal (**503**) with the row released
+/// back to the queue.
 async fn score_queued(
     State(st): State<AppState>,
     headers: HeaderMap,
@@ -1153,25 +1228,12 @@ async fn score_queued(
     if !admin_ok(&headers, &st.admin_hashes) {
         return Err(err(StatusCode::UNAUTHORIZED, "unauthorized"));
     }
-    let row = st.store.claim_queued(&id).map_err(|e| match e {
-        proof_store::StoreError::NotFound(_) => err(StatusCode::NOT_FOUND, "not_found"),
-        proof_store::StoreError::Illegal(why) => err(StatusCode::CONFLICT, &why),
-        other => store_err(&other),
-    })?;
-    let topic = match st.drainable_topic(&row.topic_id) {
-        Ok(t) => t,
-        Err(e) => {
-            let _ = st.store.release_claim(&id);
-            return Err(e);
-        }
-    };
-    match score_intake(&st, row, &topic).await {
-        Ok(resp) => Ok((StatusCode::OK, Json(resp))),
-        Err(e) => {
-            let _ = st.store.release_claim(&id);
-            Err(e)
-        }
-    }
+    let row = st.store.claim_queued(&id).map_err(claim_err)?;
+    let claim = ClaimGuard::new(st.store.clone(), &row);
+    let topic = st.drainable_topic(&row.topic_id)?;
+    let resp = score_intake(&st, row, &topic).await?;
+    claim.landed();
+    Ok((StatusCode::OK, Json(resp)))
 }
 
 fn admin_ok(headers: &HeaderMap, hashes: &[String]) -> bool {
@@ -3922,8 +3984,10 @@ mod tests {
         );
         assert_eq!(queued_ids(app.clone(), None).await, queued[1..]);
 
-        // The single-row route scores exactly the row it names.
-        let (st, third) = json_req(
+        // The single-row route scores only the head of the queue: naming the
+        // third row while the second is still queued is a 409 that names
+        // the head; naming the head scores exactly that row.
+        let (st, body) = json_req(
             app.clone(),
             "POST",
             &format!("/v1/admin/proof/submissions/{}/score", queued[2]),
@@ -3931,10 +3995,25 @@ mod tests {
             Some("op"),
         )
         .await;
-        assert_eq!(st, StatusCode::OK, "{third}");
-        assert_eq!(third["id"], queued[2], "{third}");
-        assert_ne!(third["state"], "queued", "{third}");
-        assert_eq!(queued_ids(app.clone(), None).await, [queued[1].clone()]);
+        assert_eq!(st, StatusCode::CONFLICT, "out of order: {body}");
+        let msg = body["error"].as_str().unwrap_or_default();
+        assert!(
+            msg.contains("not the head") && msg.contains(&queued[1]),
+            "{body}"
+        );
+        assert_eq!(queued_ids(app.clone(), None).await, queued[1..]);
+        let (st, second) = json_req(
+            app.clone(),
+            "POST",
+            &format!("/v1/admin/proof/submissions/{}/score", queued[1]),
+            serde_json::json!({}),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{second}");
+        assert_eq!(second["id"], queued[1], "{second}");
+        assert_ne!(second["state"], "queued", "{second}");
+        assert_eq!(queued_ids(app.clone(), None).await, [queued[2].clone()]);
         let (st, body) = json_req(
             app.clone(),
             "POST",
@@ -3968,7 +4047,7 @@ mod tests {
         )
         .await;
         assert_eq!(st, StatusCode::OK, "{report}");
-        assert_eq!(report["drained"][0]["id"], queued[1], "{report}");
+        assert_eq!(report["drained"][0]["id"], queued[2], "{report}");
         assert_eq!(report["remaining"], 0, "{report}");
         let (st, report) = json_req(
             app.clone(),
@@ -4131,5 +4210,291 @@ mod tests {
         assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 2);
         assert!(state.drain_ready_queues().await.is_empty(), "nothing left");
         assert!(queued_ids(app, None).await.is_empty());
+    }
+
+    /// A topic's queue is scored one row at a time: while one drain holds
+    /// the topic's claim (its head is mid-eval), a second drain — the admin
+    /// route, the single-row route, or the poll pass — gets **409** / a
+    /// `stopped` report and scores nothing, so two rows of one topic never
+    /// run side by side and promotion stays oldest-first. Another topic is
+    /// unaffected. Once the claim is back, the drain proceeds in order.
+    #[tokio::test]
+    async fn a_topic_with_a_row_in_flight_refuses_a_second_drain() {
+        let scorer = Arc::new(FamilyStub::win(CUSTOM_ID));
+        let state = state_with_deferred_custom(scorer.clone(), true, true);
+        let pin = state.pin.clone();
+        let app = proof_router(state.clone());
+        let mut queued = Vec::new();
+        for label in ["head", "next"] {
+            let (st, created) = json_req(
+                app.clone(),
+                "POST",
+                "/v1/submissions",
+                custom_submit(label),
+                None,
+            )
+            .await;
+            assert_eq!(st, StatusCode::CREATED, "{created}");
+            queued.push(created["id"].as_str().expect("id").to_owned());
+        }
+        republish_custom(app.clone(), &pin, None).await;
+
+        // Another drain is mid-eval on the head: it holds the topic's claim.
+        let in_flight = state
+            .store
+            .claim_next_queued(CUSTOM)
+            .expect("claim")
+            .expect("head");
+        assert_eq!(in_flight.id, queued[0]);
+
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": CUSTOM, "limit": 5 }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CONFLICT, "{body}");
+        let msg = body["error"].as_str().unwrap_or_default();
+        assert!(msg.contains("already has a row being scored"), "{body}");
+        assert!(msg.contains(&queued[0]), "names the row in flight: {body}");
+        for id in &queued {
+            let (st, body) = json_req(
+                app.clone(),
+                "POST",
+                &format!("/v1/admin/proof/submissions/{id}/score"),
+                serde_json::json!({}),
+                Some("op"),
+            )
+            .await;
+            assert_eq!(st, StatusCode::CONFLICT, "{id}: {body}");
+        }
+        let reports = state.drain_ready_queues().await;
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert!(reports[0].drained.is_empty(), "{reports:?}");
+        assert!(
+            reports[0]
+                .stopped
+                .as_deref()
+                .is_some_and(|s| s.contains("already has a row being scored")),
+            "{reports:?}"
+        );
+        assert_eq!(
+            scorer.inner.hits.load(Ordering::SeqCst),
+            0,
+            "nothing else ran"
+        );
+        assert_eq!(queued_ids(app.clone(), None).await, queued);
+
+        // The other topic's queue is independent of this topic's claim.
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": "dt-no-ib-v0" }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{report}");
+
+        // The in-flight drain gives the head back (it was refused): the next
+        // drain scores head then next, in that order.
+        state
+            .store
+            .release_claim(CUSTOM, &in_flight.id)
+            .expect("release");
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": CUSTOM, "limit": 5 }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{report}");
+        let drained: Vec<String> = report["drained"]
+            .as_array()
+            .expect("drained")
+            .iter()
+            .filter_map(|r| r["id"].as_str().map(str::to_owned))
+            .collect();
+        assert_eq!(drained, queued, "oldest first, one at a time");
+        assert_eq!(report["remaining"], 0);
+        assert_eq!(state.store.scoring_row(CUSTOM).expect("q"), None);
+        assert!(queued_ids(app, None).await.is_empty());
+    }
+
+    /// An interrupted drain must not leave its topic busy until a restart:
+    /// dropping the claim guard without landing (a panic, a cancelled poll
+    /// task, an operator HTTP call cut mid-eval) releases the claim; landing
+    /// disarms it; and a stale guard from an earlier drain never drops the
+    /// claim a later drain holds.
+    #[tokio::test]
+    async fn the_claim_guard_releases_on_interruption_and_only_its_own_claim() {
+        let state = state_with_deferred_custom(Arc::new(FamilyStub::win(CUSTOM_ID)), true, true);
+        let app = proof_router(state.clone());
+        for label in ["one", "two"] {
+            let (st, created) = json_req(
+                app.clone(),
+                "POST",
+                "/v1/submissions",
+                custom_submit(label),
+                None,
+            )
+            .await;
+            assert_eq!(st, StatusCode::CREATED, "{created}");
+        }
+        let store = state.store.clone();
+
+        // Interrupted: the guard drops armed and the head is claimable again.
+        let head = store
+            .claim_next_queued(CUSTOM)
+            .expect("claim")
+            .expect("head");
+        assert_eq!(store.scoring_row(CUSTOM).expect("q"), Some(head.id.clone()));
+        {
+            let _guard = ClaimGuard::new(store.clone(), &head);
+            assert!(matches!(
+                store.claim_next_queued(CUSTOM),
+                Err(StoreError::Busy { .. })
+            ));
+        }
+        assert_eq!(
+            store.scoring_row(CUSTOM).expect("q"),
+            None,
+            "released on drop"
+        );
+        assert!(std::panic::catch_unwind(|| {
+            let head = store
+                .claim_next_queued(CUSTOM)
+                .expect("claim")
+                .expect("head");
+            let _guard = ClaimGuard::new(store.clone(), &head);
+            panic!("scorer blew up mid-eval");
+        })
+        .is_err());
+        assert_eq!(
+            store.scoring_row(CUSTOM).expect("q"),
+            None,
+            "released on unwind"
+        );
+
+        // Landed: the guard disarms; the claim was settled by the insert.
+        let head = store
+            .claim_next_queued(CUSTOM)
+            .expect("claim")
+            .expect("head");
+        let guard = ClaimGuard::new(store.clone(), &head);
+        let mut scored = head.clone();
+        scored.state = SubmissionState::AwaitingAdmin;
+        store.insert(scored).expect("land");
+        assert_eq!(store.scoring_row(CUSTOM).expect("q"), None);
+        // A later drain takes the next row before the old guard is gone.
+        let next = store
+            .claim_next_queued(CUSTOM)
+            .expect("claim")
+            .expect("next");
+        assert_ne!(next.id, head.id);
+        guard.landed();
+        assert_eq!(
+            store.scoring_row(CUSTOM).expect("q"),
+            Some(next.id.clone()),
+            "the later claim is untouched"
+        );
+        // Even a stale *armed* guard for the old row cannot drop the new claim.
+        drop(ClaimGuard::new(store.clone(), &head));
+        assert_eq!(store.scoring_row(CUSTOM).expect("q"), Some(next.id));
+    }
+
+    /// Deduplication is one atomic store step: two identical submits racing
+    /// each other yield one queued row (one **201**, one **200**), and a retry
+    /// after the row was drained finds the *scored* row (**200**, its final
+    /// state) — never a second queued row and never a second paid run.
+    #[tokio::test]
+    async fn identical_submits_yield_one_row_for_the_rows_whole_life() {
+        let scorer = Arc::new(FamilyStub::win(CUSTOM_ID));
+        let state = state_with_deferred_custom(scorer.clone(), true, true);
+        let pin = state.pin.clone();
+        let app = proof_router(state.clone());
+
+        let (a, b) = tokio::join!(
+            json_req(
+                app.clone(),
+                "POST",
+                "/v1/submissions",
+                custom_submit("raced"),
+                None,
+            ),
+            json_req(
+                app.clone(),
+                "POST",
+                "/v1/submissions",
+                custom_submit("raced"),
+                None,
+            ),
+        );
+        let mut codes = [a.0, b.0];
+        codes.sort();
+        assert_eq!(
+            codes,
+            [StatusCode::OK, StatusCode::CREATED],
+            "{} {}",
+            a.1,
+            b.1
+        );
+        assert_eq!(a.1["id"], b.1["id"], "one row: {} {}", a.1, b.1);
+        let id = a.1["id"].as_str().expect("id").to_owned();
+        assert_eq!(
+            queued_ids(app.clone(), None).await,
+            std::slice::from_ref(&id)
+        );
+
+        republish_custom(app.clone(), &pin, None).await;
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": CUSTOM }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{report}");
+        assert_eq!(report["drained"][0]["id"], id, "{report}");
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 1);
+
+        // Defer again and retry the same artefact: the scored row answers.
+        republish_custom(app.clone(), &pin, Some("true")).await;
+        let (st, again) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("raced"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{again}");
+        assert_eq!(again["id"], id, "{again}");
+        assert_eq!(again["state"], "champion", "{again}");
+        assert_eq!(again["eligible"], true, "{again}");
+        assert!(
+            again["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("already submitted"),
+            "{again}"
+        );
+        assert!(
+            queued_ids(app.clone(), None).await.is_empty(),
+            "no second row"
+        );
+        assert_eq!(status_of(app.clone()).await["queued_submissions"], 0);
+        republish_custom(app.clone(), &pin, None).await;
+        assert!(state.drain_ready_queues().await.is_empty());
+        assert_eq!(
+            scorer.inner.hits.load(Ordering::SeqCst),
+            1,
+            "never scored twice"
+        );
     }
 }

--- a/crates/proof-http/src/lib.rs
+++ b/crates/proof-http/src/lib.rs
@@ -7,12 +7,25 @@
 //! GET  /v1/proof/topics/{id}
 //! GET  /v1/proof/executor         public EvalExecutorOffer + pin ceilings
 //! POST /v1/submissions            miner submit (topic_id required)
-//! GET  /v1/submissions
+//! GET  /v1/submissions            ?state=queued&topic_id=… filters
 //! GET  /v1/submissions/{id}
 //! POST /v1/admin/proof/topics     operator publish (signed document)
 //! POST /v1/admin/proof/executor   operator rotate the live executor offer
 //! GET  /v1/admin/proof/vm-orchestrator   operator probe: topic-VM orchestrator readiness + agent health
+//! POST /v1/admin/proof/queue/drain       operator: score `queued` rows of one topic, in order
+//! POST /v1/admin/proof/submissions/{id}/score   operator: score one `queued` row
 //! ```
+//!
+//! **Deferred scoring.** An open topic whose signed document carries
+//! `constraints.params.defer_scoring = "true"` accepts submissions the same
+//! way (every intake gate applies) but persists them as `queued` (**201**)
+//! instead of evaluating: no readiness check, no harvest rent, no topic VM,
+//! no judge call, no verdict, no topic mass. The rows wait until the operator
+//! re-publishes the topic without the flag and the queue is drained (the
+//! admin route here, or the binary's poll loop) — one row at a time, oldest
+//! first, through the exact path a live submit takes. A drain on a topic
+//! that still defers is a **409**; a host that cannot score leaves the rows
+//! `queued` (**503**, nothing rented), never a reject.
 
 #![forbid(unsafe_code)]
 #![allow(
@@ -26,7 +39,7 @@
 use std::sync::{Arc, PoisonError, RwLock};
 
 use async_trait::async_trait;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
@@ -246,7 +259,9 @@ impl AppState {
 
     /// Open topics this host can score right now: judge config resolves and,
     /// on a live host, the family's scorer is wired (a custom topic whose
-    /// runner is not registered is open but not scorable).
+    /// runner is not registered is open but not scorable). A topic that
+    /// defers scoring is open — it accepts and queues — but is not scored
+    /// right now, so it is not listed here ([`Self::deferred_topics`]).
     fn scorable_topics(&self) -> Vec<String> {
         if !self.host_ready() {
             return Vec::new();
@@ -258,6 +273,7 @@ impl AppState {
             .iter()
             .filter(|t| {
                 t.is_open_at(self.epoch)
+                    && !t.constraints.defer_scoring()
                     && resolve_inference(
                         &self.pin,
                         Some(&t.inference),
@@ -267,6 +283,18 @@ impl AppState {
                     .ready_to_score()
                     && self.live().is_none_or(|s| s.ready_for_topic(t).is_ok())
             })
+            .map(|t| t.id.clone())
+            .collect()
+    }
+
+    /// Open topics whose signed document defers scoring: a submit there is
+    /// a **201** `queued` row, whatever the host can score right now.
+    fn deferred_topics(&self) -> Vec<String> {
+        self.store
+            .topics()
+            .unwrap_or_default()
+            .iter()
+            .filter(|t| t.is_open_at(self.epoch) && t.constraints.defer_scoring())
             .map(|t| t.id.clone())
             .collect()
     }
@@ -292,6 +320,8 @@ pub fn proof_router(state: AppState) -> Router {
             "/v1/admin/proof/vm-orchestrator",
             get(vm_orchestrator_probe),
         )
+        .route("/v1/admin/proof/queue/drain", post(drain_queue))
+        .route("/v1/admin/proof/submissions/{id}/score", post(score_queued))
         .with_state(state)
 }
 
@@ -334,6 +364,8 @@ async fn status(State(st): State<AppState>) -> impl IntoResponse {
         "baseline_sealed": baseline_sealed,
         "open_topics": open,
         "scorable_topics": st.scorable_topics(),
+        "deferred_topics": st.deferred_topics(),
+        "queued_submissions": st.store.queued(None).map_or(0, |q| q.len()),
         "registered_custom": registered_custom,
         "custom_ready": st.custom_ready(),
         "epoch": st.epoch,
@@ -388,15 +420,45 @@ struct SubmitBody {
     manifest: ArtifactManifest,
 }
 
-#[derive(Debug, Serialize)]
-struct SubmitResp {
-    id: String,
-    submission_digest: String,
-    topic_id: String,
-    state: SubmissionState,
-    eval_backend: EvalBackend,
-    eligible: bool,
+/// What a submit — or a drain of one row — answers.
+#[derive(Debug, Clone, Serialize)]
+pub struct SubmitResp {
+    /// Row id (`pf_…`).
+    pub id: String,
+    /// Frozen digest.
+    pub submission_digest: String,
+    /// Topic scored (or queued) against.
+    pub topic_id: String,
+    /// Lifecycle; `queued` when the topic defers scoring.
+    pub state: SubmissionState,
+    /// Backend that scored — the host's when nothing has run yet.
+    pub eval_backend: EvalBackend,
+    /// Clean pass. Always `false` on a `queued` row.
+    pub eligible: bool,
+    /// Why the row is where it is: the deferred-scoring note on a `queued`
+    /// row, the failed gates on a reject. `None` on a clean pass.
+    pub detail: Option<String>,
 }
+
+impl SubmitResp {
+    fn of(row: &Submission, backend: EvalBackend, eligible: bool) -> Self {
+        Self {
+            id: row.id.clone(),
+            submission_digest: row.submission_digest.clone(),
+            topic_id: row.topic_id.clone(),
+            state: row.state,
+            eval_backend: backend,
+            eligible,
+            detail: row.detail.clone(),
+        }
+    }
+}
+
+/// `detail` of every `queued` row: what the miner sees while the operator
+/// finishes the topic, and why nothing has run.
+pub const DEFERRED_DETAIL: &str = "scoring deferred until the topic is ready: the signed topic sets constraints.params.defer_scoring, so this row is queued (no eval, no rent, no judge call yet) and is scored in order once the operator lifts the flag and drains the queue";
+
+type ErrResp = (StatusCode, Json<serde_json::Value>);
 
 fn parse_hex64(s: &str, field: &str) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
     let t = s.trim().trim_start_matches("0x");
@@ -482,7 +544,83 @@ async fn submit(
 
     let nonce = nonce_from(&hotkey, &topic_id, &artifact);
     let submission_digest = freeze_submission_digest(&hotkey, &topic_id, &artifact, &nonce);
+    // The intake row: every miner-supplied field, frozen digest, no host
+    // stamps yet. It is either queued as-is or scored right now.
+    let row = Submission {
+        id: String::new(),
+        topic_id: topic_id.clone(),
+        miner_hotkey: hotkey,
+        artifact_digest: artifact,
+        artifact_uri: artifact_uri.map(str::to_owned),
+        claim: body.claim,
+        declared_flops: body.declared_flops,
+        architecture: body.architecture,
+        inference_offer_id: String::new(),
+        config_commitment: String::new(),
+        executor_offer_id: String::new(),
+        executor_commitment: String::new(),
+        manifest: body.manifest,
+        nonce,
+        submission_digest,
+        state: SubmissionState::Queued,
+        receipt_json: None,
+        verdict: None,
+        detail: None,
+    };
 
+    // A topic that defers scoring accepts the artefact now and scores it
+    // later: the row is persisted `queued` before any readiness check, so a
+    // host still installing its baseline / harness never rents, boots, or
+    // judges for it — and never refuses it either.
+    if topic.constraints.defer_scoring() {
+        return queue_deferred(&st, row);
+    }
+    let resp = score_intake(&st, row, &topic).await?;
+    Ok((StatusCode::CREATED, Json(resp)))
+}
+
+/// Persist an intake row as `queued`. A retry of the same artefact by the
+/// same hotkey (same frozen digest) finds its queued row (**200**) instead
+/// of queueing a second paid run.
+fn queue_deferred(
+    st: &AppState,
+    mut row: Submission,
+) -> Result<(StatusCode, Json<SubmitResp>), ErrResp> {
+    if let Some(existing) = st
+        .store
+        .queued_by_digest(&row.topic_id, &row.submission_digest)
+        .map_err(|e| store_err(&e))?
+    {
+        let mut resp = SubmitResp::of(&existing, st.backend, false);
+        resp.detail = Some(format!(
+            "already queued as {}; {DEFERRED_DETAIL}",
+            existing.id
+        ));
+        return Ok((StatusCode::OK, Json(resp)));
+    }
+    row.detail = Some(DEFERRED_DETAIL.to_owned());
+    let row = st
+        .store
+        .insert(row)
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "store"))?;
+    Ok((
+        StatusCode::CREATED,
+        Json(SubmitResp::of(&row, st.backend, false)),
+    ))
+}
+
+/// Score one intake row on `topic` and persist the result: host readiness,
+/// the judge / executor offers, the sealed baseline, the holdout unseal, the
+/// contamination gate (a persisted reject with no rent), then the eval and
+/// the judge. The same path serves a live submit (a fresh row) and a drain
+/// (a `queued` row that keeps its id). Every refusal is an error with no
+/// row change — the caller decides whether that means "no row" (submit) or
+/// "still queued" (drain).
+async fn score_intake(
+    st: &AppState,
+    row: Submission,
+    topic: &TopicDocument,
+) -> Result<SubmitResp, ErrResp> {
     // One snapshot of the executor for this request: rotation mid-submit
     // must not score under one offer and stamp another.
     let executor = st.executor_offer();
@@ -499,19 +637,19 @@ async fn submit(
     // A custom topic whose runner is not registered on this host is a 503
     // here, before any row or rent, not a rejected row downstream.
     if let Some(live) = st.live() {
-        live.ready_for_topic(&topic).map_err(|e| eval_err(&e))?;
+        live.ready_for_topic(topic).map_err(|e| eval_err(&e))?;
     }
     let Some(offer) = st.offer.as_ref() else {
         return Err(eval_err(&EvalError::InferenceOfferMissing));
     };
     offer
-        .serves_topic(&st.pin, &topic)
+        .serves_topic(&st.pin, topic)
         .map_err(|e| offer_err(&e))?;
     if st.backend == EvalBackend::Lium {
         executor
             .as_ref()
             .ok_or(EvalError::ExecutorOfferMissing)
-            .and_then(|x| x.serves_topic(&topic).map_err(proof_eval::map_executor_err))
+            .and_then(|x| x.serves_topic(topic).map_err(proof_eval::map_executor_err))
             .map_err(|e| eval_err(&e))?;
     }
     let resolved = resolve_inference(
@@ -526,7 +664,7 @@ async fn submit(
 
     let sealed = st
         .store
-        .baseline(&topic_id)
+        .baseline(&topic.id)
         .map_err(|e| store_err(&e))?
         .ok_or_else(|| {
             err(
@@ -537,10 +675,10 @@ async fn submit(
 
     let holdout = st
         .store
-        .unseal_holdout(&topic_id, &submission_digest)
+        .unseal_holdout(&topic.id, &row.submission_digest)
         .map_err(|e| err(StatusCode::SERVICE_UNAVAILABLE, &e.to_string()))?;
 
-    let (declared, hits) = contamination_evidence(&body.manifest, &holdout);
+    let (declared, hits) = contamination_evidence(&row.manifest, &holdout);
     if !declared || !hits.is_empty() {
         let failed = if declared {
             vec![GateFail::Contamination]
@@ -549,30 +687,20 @@ async fn submit(
                 field: "contamination_evidence".into(),
             }]
         };
-        return persist_pre_eval_reject(
-            &st,
-            executor.as_ref(),
-            body,
-            &topic,
-            hotkey,
-            artifact,
-            nonce,
-            submission_digest,
-            &failed,
-        );
+        return persist_pre_eval_reject(st, executor.as_ref(), row, topic, &failed);
     }
 
     let eval = eval_after_freeze(
         &st.pin,
-        &topic,
+        topic,
         offer,
         executor.as_ref(),
-        &submission_digest,
-        &artifact,
-        artifact_uri,
-        body.declared_flops,
+        &row.submission_digest,
+        &row.artifact_digest,
+        row.artifact_uri.as_deref(),
+        row.declared_flops,
         &holdout,
-        &body.claim,
+        &row.claim,
         st.backend,
         st.live(),
         st.judge_api_key.as_deref(),
@@ -583,7 +711,7 @@ async fn submit(
 
     let registered = st.registered_custom();
     let verdict = judge_topic(
-        &topic,
+        topic,
         &eval.agent,
         &eval.harness,
         &sealed,
@@ -592,15 +720,11 @@ async fn submit(
     );
     let receipt_json = serde_json::to_string(&eval.receipt).unwrap_or_default();
     persist_scored(
-        &st,
+        st,
         executor.as_ref(),
         eval.executor.as_ref(),
-        body,
-        &topic,
-        hotkey,
-        artifact,
-        nonce,
-        submission_digest,
+        row,
+        topic,
         verdict,
         receipt_json,
         eval.backend,
@@ -608,18 +732,40 @@ async fn submit(
     .await
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Stamp the judge offer and the executor offer the run was held to.
+fn stamp_offers(
+    st: &AppState,
+    executor: Option<&EvalExecutorOffer>,
+    plan: Option<&ExecutorPlan>,
+    row: &mut Submission,
+) {
+    row.inference_offer_id = st
+        .offer
+        .as_ref()
+        .map(|o| o.offer_id.clone())
+        .unwrap_or_default();
+    row.config_commitment = st
+        .offer
+        .as_ref()
+        .map(|o| o.config_commitment.clone())
+        .unwrap_or_default();
+    row.executor_offer_id = executor.map(|x| x.offer_id.clone()).unwrap_or_default();
+    // A live run stamps the configuration it was actually held to (template,
+    // 1x, effective deadline); sim has no plan and no rent, and a pre-eval
+    // reject stamps the offer's own commitment.
+    row.executor_commitment = plan
+        .map(|p| p.config_commitment.clone())
+        .or_else(|| executor.map(|x| x.config_commitment.clone()))
+        .unwrap_or_default();
+}
+
 fn persist_pre_eval_reject(
     st: &AppState,
     executor: Option<&EvalExecutorOffer>,
-    body: SubmitBody,
+    mut row: Submission,
     topic: &TopicDocument,
-    hotkey: String,
-    artifact: String,
-    nonce: String,
-    submission_digest: String,
     failed: &[GateFail],
-) -> Result<(StatusCode, Json<SubmitResp>), (StatusCode, Json<serde_json::Value>)> {
+) -> Result<SubmitResp, ErrResp> {
     let verdict = ProofVerdict {
         pass: false,
         agent: AgentVerdict {
@@ -639,39 +785,14 @@ fn persist_pre_eval_reject(
         failed: failed.to_vec(),
         lattice: 0,
     };
+    stamp_offers(st, executor, None, &mut row);
+    row.state = SubmissionState::Rejected;
+    row.receipt_json = None;
+    row.verdict = Some(verdict);
+    row.detail = Some(format!("gates={failed:?}"));
     let row = st
         .store
-        .insert(Submission {
-            id: String::new(),
-            topic_id: topic.id.clone(),
-            miner_hotkey: hotkey,
-            artifact_digest: artifact,
-            artifact_uri: body.artifact_uri,
-            claim: body.claim,
-            declared_flops: body.declared_flops,
-            architecture: body.architecture,
-            inference_offer_id: st
-                .offer
-                .as_ref()
-                .map(|o| o.offer_id.clone())
-                .unwrap_or_default(),
-            config_commitment: st
-                .offer
-                .as_ref()
-                .map(|o| o.config_commitment.clone())
-                .unwrap_or_default(),
-            executor_offer_id: executor.map(|x| x.offer_id.clone()).unwrap_or_default(),
-            executor_commitment: executor
-                .map(|x| x.config_commitment.clone())
-                .unwrap_or_default(),
-            manifest: body.manifest,
-            nonce,
-            submission_digest,
-            state: SubmissionState::Rejected,
-            receipt_json: None,
-            verdict: Some(verdict),
-            detail: Some(format!("gates={failed:?}")),
-        })
+        .insert(row)
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "store"))?;
     let _ = st.store.record_topic_run(
         &row.miner_hotkey,
@@ -683,34 +804,19 @@ fn persist_pre_eval_reject(
             near_duplicate: false,
         },
     );
-    Ok((
-        StatusCode::CREATED,
-        Json(SubmitResp {
-            id: row.id,
-            submission_digest: row.submission_digest,
-            topic_id: topic.id.clone(),
-            state: row.state,
-            eval_backend: st.backend,
-            eligible: false,
-        }),
-    ))
+    Ok(SubmitResp::of(&row, st.backend, false))
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn persist_scored(
     st: &AppState,
     executor: Option<&EvalExecutorOffer>,
     plan: Option<&ExecutorPlan>,
-    body: SubmitBody,
+    mut row: Submission,
     topic: &TopicDocument,
-    hotkey: String,
-    artifact: String,
-    nonce: String,
-    submission_digest: String,
     verdict: ProofVerdict,
     receipt_json: String,
     backend: EvalBackend,
-) -> Result<(StatusCode, Json<SubmitResp>), (StatusCode, Json<serde_json::Value>)> {
+) -> Result<SubmitResp, ErrResp> {
     let topic_id = topic.id.clone();
     let pass = verdict.pass;
     let primary = primary_from_harness(topic, &verdict.harness);
@@ -725,58 +831,28 @@ async fn persist_scored(
                 st.store.champion_primary(topic).ok().flatten(),
             );
             promoted = live
-                .auto_promote(topic, &submission_digest, pass, primary, bar)
+                .auto_promote(topic, &row.submission_digest, pass, primary, bar)
                 .await;
         }
     }
-    let artifact_digest = artifact.clone();
-    let detail = if pass {
+    stamp_offers(st, executor, plan, &mut row);
+    row.state = if promoted {
+        SubmissionState::Champion
+    } else if pass {
+        SubmissionState::AwaitingAdmin
+    } else {
+        SubmissionState::Rejected
+    };
+    row.receipt_json = Some(receipt_json);
+    row.detail = if pass {
         None
     } else {
         Some(format!("gates={:?}", verdict.failed))
     };
+    row.verdict = Some(verdict);
     let row = st
         .store
-        .insert(Submission {
-            id: String::new(),
-            topic_id: topic_id.clone(),
-            miner_hotkey: hotkey,
-            artifact_digest: artifact,
-            artifact_uri: body.artifact_uri,
-            claim: body.claim,
-            declared_flops: body.declared_flops,
-            architecture: body.architecture,
-            inference_offer_id: st
-                .offer
-                .as_ref()
-                .map(|o| o.offer_id.clone())
-                .unwrap_or_default(),
-            config_commitment: st
-                .offer
-                .as_ref()
-                .map(|o| o.config_commitment.clone())
-                .unwrap_or_default(),
-            executor_offer_id: executor.map(|x| x.offer_id.clone()).unwrap_or_default(),
-            // A live run stamps the configuration it was actually held to
-            // (template, 1x, effective deadline); sim has no plan and no rent.
-            executor_commitment: plan
-                .map(|p| p.config_commitment.clone())
-                .or_else(|| executor.map(|x| x.config_commitment.clone()))
-                .unwrap_or_default(),
-            manifest: body.manifest,
-            nonce,
-            submission_digest,
-            state: if promoted {
-                SubmissionState::Champion
-            } else if pass {
-                SubmissionState::AwaitingAdmin
-            } else {
-                SubmissionState::Rejected
-            },
-            receipt_json: Some(receipt_json),
-            verdict: Some(verdict),
-            detail,
-        })
+        .insert(row)
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "store"))?;
     let _ = st.store.record_topic_run(
         &row.miner_hotkey,
@@ -784,7 +860,7 @@ async fn persist_scored(
         MinerTopicRun {
             pass,
             primary,
-            artifact_digest,
+            artifact_digest: row.artifact_digest.clone(),
             near_duplicate: false,
         },
     );
@@ -792,21 +868,34 @@ async fn persist_scored(
         live.on_persisted(&topic_id, &row.submission_digest, &row.id, promoted)
             .await;
     }
-    Ok((
-        StatusCode::CREATED,
-        Json(SubmitResp {
-            id: row.id,
-            submission_digest: row.submission_digest,
-            topic_id,
-            state: row.state,
-            eval_backend: backend,
-            eligible: pass,
-        }),
-    ))
+    Ok(SubmitResp::of(&row, backend, pass))
 }
 
-async fn list_subs(State(st): State<AppState>) -> impl IntoResponse {
-    let rows = st.store.list().unwrap_or_default();
+/// `GET /v1/submissions` filters. Both optional; `state` is the wire name
+/// (`queued`, `awaiting_admin`, `rejected`, `champion`).
+#[derive(Debug, Default, Deserialize)]
+struct ListQuery {
+    #[serde(default)]
+    state: Option<SubmissionState>,
+    #[serde(default)]
+    topic_id: Option<String>,
+}
+
+/// Newest first. An unknown `state` value is axum's **400**.
+async fn list_subs(State(st): State<AppState>, Query(q): Query<ListQuery>) -> impl IntoResponse {
+    let topic = q
+        .topic_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty());
+    let rows: Vec<Submission> = st
+        .store
+        .list()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|r| q.state.is_none_or(|s| r.state == s))
+        .filter(|r| topic.is_none_or(|t| r.topic_id == t))
+        .collect();
     Json(serde_json::json!({ "items": rows }))
 }
 
@@ -897,6 +986,192 @@ async fn vm_orchestrator_probe(
     report.registered_custom = st.registered_custom();
     report.custom_family_wired = !report.registered_custom.is_empty();
     Ok(Json(report))
+}
+
+/// `POST /v1/admin/proof/queue/drain` body.
+#[derive(Debug, Deserialize)]
+struct DrainBody {
+    /// Topic whose `queued` rows to score.
+    topic_id: String,
+    /// Rows to score this call, oldest first (default 1, floor 1). The reply's
+    /// `remaining` says what is still queued.
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// What one drain pass over one topic did.
+#[derive(Debug, Clone, Serialize)]
+pub struct DrainReport {
+    /// Topic drained.
+    pub topic_id: String,
+    /// Rows scored this pass, in queue order, each in its final state.
+    pub drained: Vec<SubmitResp>,
+    /// Rows still `queued` on the topic after this pass.
+    pub remaining: usize,
+    /// Why the pass stopped with rows still queued: the host refused the next
+    /// row (it went back to the queue unscored, nothing rented) or the topic
+    /// was re-published to defer / close mid-pass. `None` when the pass ran
+    /// to its limit or emptied the queue.
+    pub stopped: Option<String>,
+}
+
+impl AppState {
+    /// The topic whose queue may be drained right now: published, open at
+    /// this epoch, and not deferring. A topic that still defers is a **409**
+    /// (lift `constraints.params.defer_scoring` by re-publishing first);
+    /// unknown is **400**, not open **409**. Nothing is touched on refusal.
+    fn drainable_topic(&self, topic_id: &str) -> Result<TopicDocument, ErrResp> {
+        let topic = self
+            .store
+            .topic(topic_id)
+            .map_err(|_| err(StatusCode::BAD_REQUEST, "unknown topic"))?;
+        if !topic.is_open_at(self.epoch) {
+            return Err(err(
+                StatusCode::CONFLICT,
+                "topic is not open; its queued rows stay queued",
+            ));
+        }
+        if topic.constraints.defer_scoring() {
+            return Err(err(
+                StatusCode::CONFLICT,
+                "topic still defers scoring (constraints.params.defer_scoring = \"true\"); re-publish the signed topic without it, then drain",
+            ));
+        }
+        Ok(topic)
+    }
+
+    /// Score up to `limit` `queued` rows of `topic_id`, oldest first, each
+    /// through the exact path a live submit takes ([`score_intake`]), and
+    /// land each result on its row. The topic is re-read before every row so
+    /// a re-publish that defers or closes it mid-pass stops the pass. The
+    /// first host refusal stops the pass too: that row is released back to
+    /// the queue unscored (nothing was rented) and later rows are not tried.
+    pub async fn drain_queue(&self, topic_id: &str, limit: usize) -> DrainReport {
+        let mut report = DrainReport {
+            topic_id: topic_id.to_owned(),
+            drained: Vec::new(),
+            remaining: 0,
+            stopped: None,
+        };
+        for _ in 0..limit {
+            let topic = match self.drainable_topic(topic_id) {
+                Ok(t) => t,
+                Err((_, body)) => {
+                    report.stopped = Some(error_text(&body));
+                    break;
+                }
+            };
+            let Ok(Some(row)) = self.store.claim_next_queued(topic_id) else {
+                break;
+            };
+            let id = row.id.clone();
+            match score_intake(self, row, &topic).await {
+                Ok(resp) => report.drained.push(resp),
+                Err((code, body)) => {
+                    let _ = self.store.release_claim(&id);
+                    report.stopped = Some(format!("{code}: {}", error_text(&body)));
+                    break;
+                }
+            }
+        }
+        report.remaining = self.store.queued(Some(topic_id)).map_or(0, |q| q.len());
+        report
+    }
+
+    /// One pass for a poll loop: drain every open topic that has `queued`
+    /// rows and no longer defers scoring, until each queue is empty or the
+    /// host refuses (those rows stay queued for the next pass). Topics that
+    /// still defer are skipped — lifting the flag is the operator's
+    /// "score now". Returns one report per topic that had queued rows.
+    pub async fn drain_ready_queues(&self) -> Vec<DrainReport> {
+        let mut reports = Vec::new();
+        for topic in self.store.topics().unwrap_or_default() {
+            if !topic.is_open_at(self.epoch) || topic.constraints.defer_scoring() {
+                continue;
+            }
+            let queued = self.store.queued(Some(&topic.id)).map_or(0, |q| q.len());
+            if queued == 0 {
+                continue;
+            }
+            reports.push(self.drain_queue(&topic.id, queued).await);
+        }
+        reports
+    }
+}
+
+fn error_text(body: &Json<serde_json::Value>) -> String {
+    body.0["error"]
+        .as_str()
+        .map_or_else(|| body.0.to_string(), str::to_owned)
+}
+
+/// Operator drain: score the oldest `queued` rows of one topic through the
+/// live path. **200** with a [`DrainReport`]; **503** carrying the report
+/// (plus `error`) when the host refused before a single row scored — the
+/// rows are still queued, nothing was rented. Same bearer as every admin
+/// route; the topic must be open and no longer deferring (**409**).
+async fn drain_queue(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<DrainBody>,
+) -> Result<impl IntoResponse, ErrResp> {
+    if st.admin_hashes.is_empty() {
+        return Err(err(StatusCode::SERVICE_UNAVAILABLE, "auth_unconfigured"));
+    }
+    if !admin_ok(&headers, &st.admin_hashes) {
+        return Err(err(StatusCode::UNAUTHORIZED, "unauthorized"));
+    }
+    let topic_id = body.topic_id.trim().to_owned();
+    st.drainable_topic(&topic_id)?;
+    let report = st
+        .drain_queue(&topic_id, body.limit.unwrap_or(1).max(1))
+        .await;
+    let mut view = serde_json::to_value(&report)
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "report"))?;
+    if report.drained.is_empty() {
+        if let Some(why) = &report.stopped {
+            view["error"] = serde_json::Value::String(why.clone());
+            return Ok((StatusCode::SERVICE_UNAVAILABLE, Json(view)));
+        }
+    }
+    Ok((StatusCode::OK, Json(view)))
+}
+
+/// Operator: score one `queued` row now (same rules as a drain of one).
+/// **200** with the scored row's reply; **404** unknown; **409** when the
+/// row is not `queued`, is already being scored, or its topic still defers
+/// / is not open; a host refusal is that refusal (**503**) with the row
+/// released back to the queue.
+async fn score_queued(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ErrResp> {
+    if st.admin_hashes.is_empty() {
+        return Err(err(StatusCode::SERVICE_UNAVAILABLE, "auth_unconfigured"));
+    }
+    if !admin_ok(&headers, &st.admin_hashes) {
+        return Err(err(StatusCode::UNAUTHORIZED, "unauthorized"));
+    }
+    let row = st.store.claim_queued(&id).map_err(|e| match e {
+        proof_store::StoreError::NotFound(_) => err(StatusCode::NOT_FOUND, "not_found"),
+        proof_store::StoreError::Illegal(why) => err(StatusCode::CONFLICT, &why),
+        other => store_err(&other),
+    })?;
+    let topic = match st.drainable_topic(&row.topic_id) {
+        Ok(t) => t,
+        Err(e) => {
+            let _ = st.store.release_claim(&id);
+            return Err(e);
+        }
+    };
+    match score_intake(&st, row, &topic).await {
+        Ok(resp) => Ok((StatusCode::OK, Json(resp))),
+        Err(e) => {
+            let _ = st.store.release_claim(&id);
+            Err(e)
+        }
+    }
 }
 
 fn admin_ok(headers: &HeaderMap, hashes: &[String]) -> bool {
@@ -3083,5 +3358,778 @@ mod tests {
         assert_eq!(row["verdict"]["pass"], true, "{row}");
         assert_eq!(row["verdict"]["agent"]["rationale"], "sim stub win");
         assert_eq!(row["verdict"]["failed"].as_array().map(Vec::len), Some(0));
+    }
+
+    // ----- deferred scoring: `queued` rows and the drain -----
+
+    const CUSTOM: &str = "custom-topic-v0";
+    const CUSTOM_ID: &str = "topic_minted_metric";
+
+    /// The signed custom topic of [`app_with_live_scorer`], with
+    /// `constraints.params.defer_scoring` set to `value` when given.
+    fn custom_topic_with_defer(pin: &ProofPin, value: Option<&str>) -> TopicDocument {
+        let mut draft = unsigned_custom_topic(&[], CUSTOM_ID);
+        if let Some(v) = value {
+            draft
+                .constraints
+                .params
+                .insert(proof_task::PARAM_DEFER_SCORING.to_owned(), v.to_owned());
+        }
+        let (topic, _) = seal_topic_with(pin, draft, &[CUSTOM_ID]);
+        topic
+    }
+
+    /// Live Lium host like [`app_with_live_scorer`] — open sealed throughput
+    /// topic `dt-no-ib-v0` plus the custom topic — where the custom topic
+    /// carries `defer_scoring = "true"` when `defer` is set. `custom_baseline`
+    /// false models a host still installing that topic's baseline (no sealed
+    /// vector recorded, so scoring it would be a 503).
+    fn state_with_deferred_custom(
+        live: Arc<dyn LiveScorer>,
+        defer: bool,
+        custom_baseline: bool,
+    ) -> AppState {
+        let p = pin(&format!("sha256:{}", "ab".repeat(32)));
+        let store = MemoryStore::new();
+        let recs = synthetic_holdout(STRATUM_SIZE, 1);
+        let (harvest, meas) = seal_topic(&p, unsigned_topic(&recs));
+        store.put_topic(harvest.clone()).expect("topic");
+        store.load_holdout(&harvest.id, recs).expect("holdout");
+        store
+            .set_baseline(&harvest.id, meas.into_sealed())
+            .expect("baseline");
+
+        let mut draft = unsigned_custom_topic(&[], CUSTOM_ID);
+        if defer {
+            draft.constraints.params.insert(
+                proof_task::PARAM_DEFER_SCORING.to_owned(),
+                "true".to_owned(),
+            );
+        }
+        let recs = synthetic_holdout(STRATUM_SIZE, 1);
+        let (custom, meas) = seal_topic_with(&p, draft, &[CUSTOM_ID]);
+        assert_eq!(custom.constraints.defer_scoring(), defer);
+        store.put_topic(custom.clone()).expect("topic");
+        store.load_holdout(&custom.id, recs).expect("holdout");
+        if custom_baseline {
+            let mut sealed = meas.into_sealed();
+            sealed.custom_value = Some(0.5);
+            store.set_baseline(&custom.id, sealed).expect("baseline");
+        }
+        let executor = test_executor(&p);
+        AppState {
+            store,
+            pin: p,
+            backend: EvalBackend::Lium,
+            live_scorer: Some(live),
+            offer: Some(offer()),
+            executor: executor_slot(Some(executor)),
+            judge_api_key: Some("test-judge-key".into()),
+            admin_hashes: Arc::new(vec![hash_admin_token("op")]),
+            vm_probe: None,
+            epoch: 0,
+        }
+    }
+
+    fn custom_submit(label: &str) -> serde_json::Value {
+        submit_body(
+            label,
+            &serde_json::json!({
+                "topic_id": CUSTOM,
+                "artifact_uri": format!("https://example.invalid/{label}.tar"),
+            }),
+        )
+    }
+
+    fn ids_of(v: &serde_json::Value, key: &str) -> Vec<String> {
+        v[key]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .filter_map(|x| x.as_str().map(str::to_owned))
+            .collect()
+    }
+
+    async fn status_of(app: Router) -> serde_json::Value {
+        let (st, status) = json_req(app, "GET", "/v1/status", serde_json::json!({}), None).await;
+        assert_eq!(st, StatusCode::OK);
+        status
+    }
+
+    async fn queued_ids(app: Router, topic: Option<&str>) -> Vec<String> {
+        let uri = match topic {
+            Some(t) => format!("/v1/submissions?state=queued&topic_id={t}"),
+            None => "/v1/submissions?state=queued".to_owned(),
+        };
+        let (st, list) = json_req(app, "GET", &uri, serde_json::json!({}), None).await;
+        assert_eq!(st, StatusCode::OK, "{list}");
+        // The public list is newest first; intake order is what the queue
+        // assertions compare against.
+        let mut ids: Vec<String> = list["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .filter_map(|r| r["id"].as_str().map(str::to_owned))
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    /// Re-publish the custom topic through the admin route with the flag set
+    /// to `value` (`None` removes it). Re-signed under the test topic key.
+    async fn republish_custom(
+        app: Router,
+        pin: &ProofPin,
+        value: Option<&str>,
+    ) -> serde_json::Value {
+        let doc = custom_topic_with_defer(pin, value);
+        let (st, body) = json_req(
+            app,
+            "POST",
+            "/v1/admin/proof/topics",
+            serde_json::to_value(&doc).expect("json"),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{body}");
+        body
+    }
+
+    /// An open topic whose signed document defers scoring accepts the
+    /// submission under every intake gate and persists it `queued`: **201**,
+    /// no scorer call, no persist hook, no stamps, no verdict, no mass. The
+    /// public list and status show it; a retry of the same artefact finds its
+    /// row (**200**) instead of queueing twice; the other open topic scores
+    /// as before.
+    #[tokio::test]
+    async fn a_deferring_topic_queues_submissions_without_scoring() {
+        let scorer = Arc::new(FamilyStub::win(CUSTOM_ID));
+        let app = proof_router(state_with_deferred_custom(scorer.clone(), true, true));
+
+        let status = status_of(app.clone()).await;
+        assert_eq!(ids_of(&status, "deferred_topics"), [CUSTOM], "{status}");
+        assert_eq!(
+            ids_of(&status, "scorable_topics"),
+            ["dt-no-ib-v0"],
+            "a deferring topic is open but not scored right now: {status}"
+        );
+        let mut open = ids_of(&status, "open_topics");
+        open.sort();
+        assert_eq!(open, [CUSTOM, "dt-no-ib-v0"], "{status}");
+        assert_eq!(status["queued_submissions"], 0, "{status}");
+
+        let (st, created) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("deferred-artifact"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{created}");
+        assert_eq!(created["state"], "queued", "{created}");
+        assert_eq!(created["eligible"], false, "{created}");
+        assert_eq!(created["topic_id"], CUSTOM);
+        assert_eq!(created["eval_backend"], "lium");
+        let detail = created["detail"].as_str().unwrap_or_default();
+        assert!(detail.contains("scoring deferred"), "{created}");
+        assert!(detail.contains("defer_scoring"), "{created}");
+        let id = created["id"].as_str().expect("id").to_owned();
+        assert!(id.starts_with("pf_"), "{created}");
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 0, "no run");
+        assert!(scorer.persisted.lock().expect("p").is_empty(), "no hook");
+
+        let (st, row) = json_req(
+            app.clone(),
+            "GET",
+            &format!("/v1/submissions/{id}"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{row}");
+        assert_eq!(row["state"], "queued", "{row}");
+        assert!(row["verdict"].is_null(), "{row}");
+        assert!(row["receipt_json"].is_null(), "{row}");
+        assert_eq!(row["inference_offer_id"], "", "no host stamp yet: {row}");
+        assert_eq!(row["executor_offer_id"], "", "no host stamp yet: {row}");
+        assert_eq!(
+            row["artifact_uri"],
+            "https://example.invalid/deferred-artifact.tar"
+        );
+        assert_eq!(row["declared_flops"], FLOPS_BUDGET_MAX / 2, "{row}");
+        assert!(
+            row["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("scoring deferred"),
+            "{row}"
+        );
+
+        assert_eq!(
+            queued_ids(app.clone(), None).await,
+            std::slice::from_ref(&id)
+        );
+        assert_eq!(
+            queued_ids(app.clone(), Some(CUSTOM)).await,
+            std::slice::from_ref(&id)
+        );
+        assert!(queued_ids(app.clone(), Some("dt-no-ib-v0"))
+            .await
+            .is_empty());
+        let (st, list) = json_req(
+            app.clone(),
+            "GET",
+            "/v1/submissions?state=rejected",
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK);
+        assert!(
+            list["items"].as_array().is_some_and(Vec::is_empty),
+            "{list}"
+        );
+        let (st, _) = json_req(
+            app.clone(),
+            "GET",
+            "/v1/submissions?state=bogus",
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::BAD_REQUEST, "an unknown state filter");
+        assert_eq!(status_of(app.clone()).await["queued_submissions"], 1);
+
+        // The same artefact again is the same queued row, not a second run.
+        let (st, again) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("deferred-artifact"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{again}");
+        assert_eq!(again["id"], id, "{again}");
+        assert_eq!(again["state"], "queued", "{again}");
+        assert!(
+            again["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("already queued"),
+            "{again}"
+        );
+        assert_eq!(queued_ids(app.clone(), None).await.len(), 1);
+        // A different artefact by the same hotkey queues behind it.
+        let (st, second) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("second-artifact"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{second}");
+        assert_ne!(second["id"], id);
+        assert_eq!(queued_ids(app.clone(), None).await.len(), 2);
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 0, "still no run");
+
+        // Intake gates still refuse before any row: no locator, over budget.
+        for (label, extra) in [
+            (
+                "no locator",
+                serde_json::json!({ "topic_id": CUSTOM, "artifact_uri": "" }),
+            ),
+            (
+                "over budget",
+                serde_json::json!({
+                    "topic_id": CUSTOM,
+                    "artifact_uri": "https://example.invalid/x.tar",
+                    "declared_flops": u64::MAX,
+                }),
+            ),
+        ] {
+            let (st, body) = json_req(
+                app.clone(),
+                "POST",
+                "/v1/submissions",
+                submit_body("gated", &extra),
+                None,
+            )
+            .await;
+            assert_eq!(st, StatusCode::BAD_REQUEST, "{label}: {body}");
+        }
+        assert_eq!(
+            queued_ids(app.clone(), None).await.len(),
+            2,
+            "no row on a 400"
+        );
+
+        // The other open topic is not deferred and scores right now.
+        let (st, harvest_row) = json_req(
+            app,
+            "POST",
+            "/v1/submissions",
+            submit_body("harvest-artifact", &serde_json::json!({})),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{harvest_row}");
+        assert_ne!(harvest_row["state"], "queued", "{harvest_row}");
+        assert!(harvest_row["detail"].is_null() || harvest_row["detail"].is_string());
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 1);
+    }
+
+    /// The reason the flag exists: a host whose topic cannot be scored yet
+    /// (runner registered but its VM backend not wired, no sealed baseline
+    /// recorded) answers **503** with no row without the flag — and **201**
+    /// `queued` with it. Nothing about host readiness is consulted on the
+    /// queued path.
+    #[tokio::test]
+    async fn a_deferring_topic_queues_even_when_the_host_cannot_score_it() {
+        let refusing = proof_router(state_with_deferred_custom(
+            Arc::new(FamilyStub::unwired(CUSTOM_ID)),
+            false,
+            false,
+        ));
+        let (st, body) = json_req(
+            refusing.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("not-yet"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+        assert!(
+            queued_ids(refusing, None).await.is_empty(),
+            "no row on a 503"
+        );
+
+        let scorer = Arc::new(FamilyStub::unwired(CUSTOM_ID));
+        let app = proof_router(state_with_deferred_custom(scorer.clone(), true, false));
+        let status = status_of(app.clone()).await;
+        assert_eq!(ids_of(&status, "deferred_topics"), [CUSTOM], "{status}");
+        assert_eq!(
+            ids_of(&status, "scorable_topics"),
+            ["dt-no-ib-v0"],
+            "{status}"
+        );
+        assert!(ids_of(&status, "custom_ready").is_empty(), "{status}");
+        let (st, created) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("not-yet"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{created}");
+        assert_eq!(created["state"], "queued", "{created}");
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 0);
+        assert_eq!(queued_ids(app, Some(CUSTOM)).await.len(), 1);
+    }
+
+    /// A malformed flag is a publish **400** naming the param; a `draft`
+    /// topic that defers is still a submit **400** (deferring is not a
+    /// way around `open`).
+    #[tokio::test]
+    async fn a_malformed_defer_flag_is_a_publish_400_and_draft_stays_400() {
+        let state = state_with_deferred_custom(Arc::new(FamilyStub::win(CUSTOM_ID)), false, true);
+        let pin = state.pin.clone();
+        let app = proof_router(state);
+        // Built past the ceremony helper (which validates): a signed document
+        // whose flag is not a boolean word.
+        let mut bad = custom_topic_with_defer(&pin, None);
+        bad.constraints.params.insert(
+            proof_task::PARAM_DEFER_SCORING.to_owned(),
+            "maybe".to_owned(),
+        );
+        bad.signature = bad.sign_with(&sk()).expect("sign");
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/topics",
+            serde_json::to_value(&bad).expect("json"),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::BAD_REQUEST, "{body}");
+        let msg = body["error"].as_str().unwrap_or_default();
+        assert!(msg.contains("constraints.params.defer_scoring"), "{body}");
+        assert!(msg.contains("\"true\" or \"false\""), "{body}");
+
+        let mut draft = custom_topic_with_defer(&pin, Some("true"));
+        draft.status = TopicStatus::Draft;
+        draft.signature = draft.sign_with(&sk()).expect("sign");
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/topics",
+            serde_json::to_value(&draft).expect("json"),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{body}");
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("draft-artifact"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::BAD_REQUEST, "{body}");
+        assert_eq!(body["error"], "topic is not open");
+        let status = status_of(app.clone()).await;
+        assert!(ids_of(&status, "deferred_topics").is_empty(), "{status}");
+        assert!(queued_ids(app, None).await.is_empty());
+    }
+
+    /// The operator path: a drain on a topic that still defers is a **409**
+    /// and touches nothing; once the topic is re-published without the flag
+    /// the queue drains oldest first through the live path — each row keeps
+    /// its id, lands scored with the host stamps and the persist hook fires
+    /// — under the caller's `limit`, until the queue is empty.
+    #[tokio::test]
+    async fn drain_refuses_while_deferred_then_scores_the_queue_in_order() {
+        let scorer = Arc::new(FamilyStub::win(CUSTOM_ID));
+        let state = state_with_deferred_custom(scorer.clone(), true, true);
+        let pin = state.pin.clone();
+        let app = proof_router(state);
+        let mut queued = Vec::new();
+        for label in ["first", "second", "third"] {
+            let (st, created) = json_req(
+                app.clone(),
+                "POST",
+                "/v1/submissions",
+                custom_submit(label),
+                None,
+            )
+            .await;
+            assert_eq!(st, StatusCode::CREATED, "{created}");
+            queued.push(created["id"].as_str().expect("id").to_owned());
+        }
+        let drain = serde_json::json!({ "topic_id": CUSTOM });
+
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            drain.clone(),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::UNAUTHORIZED, "{body}");
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            drain.clone(),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CONFLICT, "{body}");
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("still defers scoring"),
+            "{body}"
+        );
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            &format!("/v1/admin/proof/submissions/{}/score", queued[0]),
+            serde_json::json!({}),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CONFLICT, "{body}");
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 0, "nothing ran");
+        assert_eq!(queued_ids(app.clone(), None).await, queued);
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": "nope-v0" }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::BAD_REQUEST, "{body}");
+
+        // Lift the flag: the re-signed document replaces the topic.
+        republish_custom(app.clone(), &pin, None).await;
+        let status = status_of(app.clone()).await;
+        assert!(ids_of(&status, "deferred_topics").is_empty(), "{status}");
+        assert!(
+            ids_of(&status, "scorable_topics").contains(&CUSTOM.to_owned()),
+            "{status}"
+        );
+        assert_eq!(
+            status["queued_submissions"], 3,
+            "the queue survives a re-publish"
+        );
+
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": CUSTOM, "limit": 1 }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{report}");
+        assert_eq!(report["topic_id"], CUSTOM);
+        assert_eq!(
+            report["drained"].as_array().map(Vec::len),
+            Some(1),
+            "{report}"
+        );
+        assert_eq!(
+            report["drained"][0]["id"], queued[0],
+            "oldest first: {report}"
+        );
+        assert_eq!(report["drained"][0]["state"], "champion", "{report}");
+        assert_eq!(report["drained"][0]["eligible"], true, "{report}");
+        assert_eq!(report["remaining"], 2, "{report}");
+        assert!(report["stopped"].is_null(), "{report}");
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            scorer.persisted.lock().expect("p").clone(),
+            vec![(CUSTOM.to_owned(), queued[0].clone(), true)]
+        );
+        let (st, row) = json_req(
+            app.clone(),
+            "GET",
+            &format!("/v1/submissions/{}", queued[0]),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{row}");
+        assert_eq!(row["state"], "champion", "{row}");
+        assert!(row["verdict"]["pass"].as_bool().unwrap_or(false), "{row}");
+        assert_eq!(row["inference_offer_id"], "master-v0", "judge stamp: {row}");
+        assert_eq!(
+            row["executor_offer_id"], "lium-1x-v0",
+            "executor stamp: {row}"
+        );
+        assert!(
+            row["detail"].is_null(),
+            "a clean pass carries no detail: {row}"
+        );
+        assert_eq!(queued_ids(app.clone(), None).await, queued[1..]);
+
+        // The single-row route scores exactly the row it names.
+        let (st, third) = json_req(
+            app.clone(),
+            "POST",
+            &format!("/v1/admin/proof/submissions/{}/score", queued[2]),
+            serde_json::json!({}),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{third}");
+        assert_eq!(third["id"], queued[2], "{third}");
+        assert_ne!(third["state"], "queued", "{third}");
+        assert_eq!(queued_ids(app.clone(), None).await, [queued[1].clone()]);
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            &format!("/v1/admin/proof/submissions/{}/score", queued[0]),
+            serde_json::json!({}),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(
+            st,
+            StatusCode::CONFLICT,
+            "a scored row is not queued: {body}"
+        );
+        let (st, _) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/submissions/pf_missing/score",
+            serde_json::json!({}),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::NOT_FOUND);
+
+        // Default limit is one row; an empty queue is a 200 with nothing drained.
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            drain.clone(),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{report}");
+        assert_eq!(report["drained"][0]["id"], queued[1], "{report}");
+        assert_eq!(report["remaining"], 0, "{report}");
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            drain,
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{report}");
+        assert!(
+            report["drained"].as_array().is_some_and(Vec::is_empty),
+            "{report}"
+        );
+        assert_eq!(report["remaining"], 0);
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 3);
+        assert_eq!(status_of(app).await["queued_submissions"], 0);
+    }
+
+    /// Fail closed on the drain: a host that cannot score the topic leaves
+    /// every row `queued` (**503**, the report says why, nothing rented) —
+    /// on the drain route, on the single-row route, and in the poll pass —
+    /// and a topic re-published to defer again is skipped by the pass.
+    #[tokio::test]
+    async fn a_drain_the_host_refuses_leaves_the_rows_queued() {
+        let scorer = Arc::new(FamilyStub::unwired(CUSTOM_ID));
+        let state = state_with_deferred_custom(scorer.clone(), true, true);
+        let pin = state.pin.clone();
+        let app = proof_router(state.clone());
+        let (st, created) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/submissions",
+            custom_submit("waiting"),
+            None,
+        )
+        .await;
+        assert_eq!(st, StatusCode::CREATED, "{created}");
+        let id = created["id"].as_str().expect("id").to_owned();
+
+        // Still deferring: the poll pass skips the topic entirely.
+        assert!(state.drain_ready_queues().await.is_empty());
+        republish_custom(app.clone(), &pin, None).await;
+
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": CUSTOM, "limit": 5 }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::SERVICE_UNAVAILABLE, "{report}");
+        let why = report["error"].as_str().unwrap_or_default();
+        assert!(why.contains("503") && why.contains("not wired"), "{report}");
+        assert_eq!(report["stopped"], report["error"], "{report}");
+        assert!(
+            report["drained"].as_array().is_some_and(Vec::is_empty),
+            "{report}"
+        );
+        assert_eq!(report["remaining"], 1, "{report}");
+
+        let (st, body) = json_req(
+            app.clone(),
+            "POST",
+            &format!("/v1/admin/proof/submissions/{id}/score"),
+            serde_json::json!({}),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+
+        let reports = state.drain_ready_queues().await;
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert!(reports[0].drained.is_empty());
+        assert_eq!(reports[0].remaining, 1);
+        assert!(
+            reports[0]
+                .stopped
+                .as_deref()
+                .is_some_and(|s| s.contains("not wired")),
+            "{reports:?}"
+        );
+
+        assert_eq!(
+            scorer.inner.hits.load(Ordering::SeqCst),
+            0,
+            "nothing rented"
+        );
+        assert_eq!(
+            queued_ids(app.clone(), None).await,
+            std::slice::from_ref(&id)
+        );
+        let (_, row) = json_req(
+            app.clone(),
+            "GET",
+            &format!("/v1/submissions/{id}"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(row["state"], "queued", "released back to the queue: {row}");
+
+        // A topic with no queue is a no-op drain; deferring again pauses the pass.
+        let (st, report) = json_req(
+            app.clone(),
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": "dt-no-ib-v0" }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{report}");
+        assert_eq!(report["remaining"], 0);
+        republish_custom(app.clone(), &pin, Some("true")).await;
+        assert!(state.drain_ready_queues().await.is_empty());
+        let (st, body) = json_req(
+            app,
+            "POST",
+            "/v1/admin/proof/queue/drain",
+            serde_json::json!({ "topic_id": CUSTOM }),
+            Some("op"),
+        )
+        .await;
+        assert_eq!(st, StatusCode::CONFLICT, "{body}");
+    }
+
+    /// The poll pass the binary runs: it scores the whole queue of a lifted
+    /// topic in order and returns one report per topic that had rows.
+    #[tokio::test]
+    async fn the_poll_pass_drains_a_lifted_topic_in_order() {
+        let scorer = Arc::new(FamilyStub::win(CUSTOM_ID));
+        let state = state_with_deferred_custom(scorer.clone(), true, true);
+        let pin = state.pin.clone();
+        let app = proof_router(state.clone());
+        let mut queued = Vec::new();
+        for label in ["a", "b"] {
+            let (st, created) = json_req(
+                app.clone(),
+                "POST",
+                "/v1/submissions",
+                custom_submit(label),
+                None,
+            )
+            .await;
+            assert_eq!(st, StatusCode::CREATED, "{created}");
+            queued.push(created["id"].as_str().expect("id").to_owned());
+        }
+        assert!(
+            state.drain_ready_queues().await.is_empty(),
+            "deferred: skipped"
+        );
+        republish_custom(app.clone(), &pin, None).await;
+        let reports = state.drain_ready_queues().await;
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        let drained: Vec<String> = reports[0].drained.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(drained, queued);
+        assert_eq!(reports[0].remaining, 0);
+        assert!(reports[0].stopped.is_none());
+        assert_eq!(scorer.inner.hits.load(Ordering::SeqCst), 2);
+        assert!(state.drain_ready_queues().await.is_empty(), "nothing left");
+        assert!(queued_ids(app, None).await.is_empty());
     }
 }

--- a/crates/proof-store/Cargo.toml
+++ b/crates/proof-store/Cargo.toml
@@ -16,5 +16,8 @@ sha2 = "0.10"
 hex = "0.4"
 thiserror = "2"
 
+[dev-dependencies]
+serde_json = "1"
+
 [lints]
 workspace = true

--- a/crates/proof-store/src/lib.rs
+++ b/crates/proof-store/src/lib.rs
@@ -23,10 +23,17 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-/// Submission lifecycle.
+/// Submission lifecycle. Wire names are the snake_case of the variant
+/// (`queued`, `awaiting_admin`, `rejected`, `champion`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SubmissionState {
+    /// Accepted and persisted on an open topic whose signed document defers
+    /// scoring (`constraints.params.defer_scoring = "true"`). Nothing has
+    /// run: no harvest rent, no topic VM, no judge call, no verdict, no
+    /// topic mass. The only non-terminal state — the row moves on when the
+    /// operator lifts the flag and the queue is drained (FIFO by id).
+    Queued,
     /// Eval finished; waiting operator audit (informational).
     AwaitingAdmin,
     /// Rejected (gates / integrity).
@@ -142,6 +149,11 @@ pub struct MemoryStore {
 struct Inner {
     next: u64,
     submissions: BTreeMap<String, Submission>,
+    /// Queued rows a drain has claimed and is scoring right now. A claim is
+    /// what keeps two concurrent drains from renting twice for one row; it
+    /// is cleared when the scored row lands ([`MemoryStore::insert`]) or the
+    /// drain gives the row back ([`MemoryStore::release_claim`]).
+    scoring: BTreeSet<String>,
     topics: BTreeMap<String, TopicDocument>,
     holdouts: BTreeMap<String, Vec<HoldoutRecord>>,
     baselines: BTreeMap<String, SealedBaseline>,
@@ -248,7 +260,11 @@ impl MemoryStore {
         }))
     }
 
-    /// Insert a scored submission in its final state.
+    /// Insert a submission: a scored row in its final state, or a `queued`
+    /// row awaiting a drain. An empty id mints the next `pf_…` (ids are
+    /// monotonic, so id order is intake order); a row that carries its id
+    /// replaces the stored one — that is how a drained `queued` row lands
+    /// scored — and settles any claim on it.
     pub fn insert(&self, mut row: Submission) -> Result<Submission, StoreError> {
         let mut g = self.lock()?;
         if row.id.is_empty() {
@@ -256,6 +272,7 @@ impl MemoryStore {
             g.next = g.next.saturating_add(1);
             row.id = format!("pf_{n:016x}");
         }
+        g.scoring.remove(&row.id);
         g.submissions.insert(row.id.clone(), row.clone());
         Ok(row)
     }
@@ -275,6 +292,89 @@ impl MemoryStore {
         let mut rows: Vec<_> = g.submissions.values().cloned().collect();
         rows.sort_by(|a, b| b.id.cmp(&a.id));
         Ok(rows)
+    }
+
+    /// `queued` rows, oldest first (the drain order), on one topic or all.
+    /// Rows a drain is scoring right now are still `queued` and still listed.
+    pub fn queued(&self, topic_id: Option<&str>) -> Result<Vec<Submission>, StoreError> {
+        Ok(self
+            .lock()?
+            .submissions
+            .values()
+            .filter(|r| r.state == SubmissionState::Queued)
+            .filter(|r| topic_id.is_none_or(|t| r.topic_id == t))
+            .cloned()
+            .collect())
+    }
+
+    /// The `queued` row with `submission_digest` on `topic_id`, if any: one
+    /// artefact per hotkey is queued once, so a retried submit finds its row
+    /// instead of queueing a second paid run.
+    pub fn queued_by_digest(
+        &self,
+        topic_id: &str,
+        submission_digest: &str,
+    ) -> Result<Option<Submission>, StoreError> {
+        Ok(self
+            .lock()?
+            .submissions
+            .values()
+            .find(|r| {
+                r.state == SubmissionState::Queued
+                    && r.topic_id == topic_id
+                    && r.submission_digest == submission_digest
+            })
+            .cloned())
+    }
+
+    /// Claim the oldest `queued` row on `topic_id` nobody is scoring, for
+    /// this caller to score. `None` when the queue (minus claimed rows) is
+    /// empty. Atomic: two drains never get the same row.
+    pub fn claim_next_queued(&self, topic_id: &str) -> Result<Option<Submission>, StoreError> {
+        let mut g = self.lock()?;
+        let next = g
+            .submissions
+            .values()
+            .find(|r| {
+                r.state == SubmissionState::Queued
+                    && r.topic_id == topic_id
+                    && !g.scoring.contains(&r.id)
+            })
+            .cloned();
+        if let Some(row) = &next {
+            g.scoring.insert(row.id.clone());
+        }
+        Ok(next)
+    }
+
+    /// Claim one `queued` row by id. A row that is not `queued`, or that
+    /// another drain already claimed, is [`StoreError::Illegal`].
+    pub fn claim_queued(&self, id: &str) -> Result<Submission, StoreError> {
+        let mut g = self.lock()?;
+        let row = g
+            .submissions
+            .get(id)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound(id.to_owned()))?;
+        if row.state != SubmissionState::Queued {
+            return Err(StoreError::Illegal(format!(
+                "submission {id} is {:?}, not queued",
+                row.state
+            )));
+        }
+        if !g.scoring.insert(id.to_owned()) {
+            return Err(StoreError::Illegal(format!(
+                "submission {id} is already being scored"
+            )));
+        }
+        Ok(row)
+    }
+
+    /// Give a claimed row back unscored (the host refused): it stays
+    /// `queued` and the next drain may claim it again.
+    pub fn release_claim(&self, id: &str) -> Result<(), StoreError> {
+        self.lock()?.scoring.remove(id);
+        Ok(())
     }
 
     /// Persist one topic attempt for a hotkey so emission can run WTA / discovery.
@@ -448,5 +548,114 @@ mod tests {
         t.status = TopicStatus::Draft;
         st.put_topic(t).expect("topic");
         assert!(st.open_ids(0).expect("ids").is_empty());
+    }
+
+    fn queued_row(topic_id: &str, label: &str) -> Submission {
+        let hotkey = "aa".repeat(32);
+        let artifact = format!("{label:0>64}");
+        let nonce = format!("nonce-{label}");
+        Submission {
+            id: String::new(),
+            topic_id: topic_id.into(),
+            miner_hotkey: hotkey.clone(),
+            artifact_digest: artifact.clone(),
+            artifact_uri: Some("https://example.invalid/a.tar".into()),
+            claim: "claim".into(),
+            declared_flops: 1,
+            architecture: String::new(),
+            inference_offer_id: String::new(),
+            config_commitment: String::new(),
+            executor_offer_id: String::new(),
+            executor_commitment: String::new(),
+            manifest: ArtifactManifest::default(),
+            submission_digest: freeze_submission_digest(&hotkey, topic_id, &artifact, &nonce),
+            nonce,
+            state: SubmissionState::Queued,
+            receipt_json: None,
+            verdict: None,
+            detail: Some("scoring deferred".into()),
+        }
+    }
+
+    /// The queue is FIFO by id, a claim is exclusive until the row lands or
+    /// is released, and landing the scored row (same id) settles the claim.
+    #[test]
+    fn queued_rows_drain_in_order_and_a_claim_is_exclusive() {
+        let st = MemoryStore::new();
+        let first = st.insert(queued_row("t", "1")).expect("first");
+        let second = st.insert(queued_row("t", "2")).expect("second");
+        let other = st.insert(queued_row("u", "3")).expect("other topic");
+        assert!(first.id < second.id, "ids are monotonic");
+        let ids = |rows: Vec<Submission>| rows.into_iter().map(|r| r.id).collect::<Vec<_>>();
+        assert_eq!(
+            ids(st.queued(None).expect("all")),
+            [first.id.clone(), second.id.clone(), other.id.clone()]
+        );
+        assert_eq!(
+            ids(st.queued(Some("t")).expect("t")),
+            [first.id.clone(), second.id.clone()]
+        );
+        assert_eq!(
+            st.queued_by_digest("t", &first.submission_digest)
+                .expect("lookup")
+                .map(|r| r.id),
+            Some(first.id.clone())
+        );
+        assert!(st
+            .queued_by_digest("u", &first.submission_digest)
+            .expect("lookup")
+            .is_none());
+
+        let claimed = st.claim_next_queued("t").expect("claim").expect("row");
+        assert_eq!(claimed.id, first.id, "oldest first");
+        assert!(
+            matches!(st.claim_queued(&first.id), Err(StoreError::Illegal(_))),
+            "a claimed row cannot be claimed twice"
+        );
+        let next = st.claim_next_queued("t").expect("claim").expect("row");
+        assert_eq!(next.id, second.id, "the claimed row is skipped");
+        assert!(st.claim_next_queued("t").expect("claim").is_none());
+        assert_eq!(
+            st.queued(Some("t")).expect("still listed").len(),
+            2,
+            "claimed rows are still queued to readers"
+        );
+
+        st.release_claim(&second.id).expect("release");
+        assert_eq!(
+            st.claim_next_queued("t").expect("claim").map(|r| r.id),
+            Some(second.id.clone()),
+            "a released row is claimable again"
+        );
+
+        let mut scored = claimed;
+        scored.state = SubmissionState::AwaitingAdmin;
+        let landed = st.insert(scored).expect("land");
+        assert_eq!(landed.id, first.id, "the scored row keeps its id");
+        assert_eq!(
+            st.get(&first.id).expect("get").state,
+            SubmissionState::AwaitingAdmin
+        );
+        assert!(
+            matches!(st.claim_queued(&first.id), Err(StoreError::Illegal(_))),
+            "a scored row is not queued"
+        );
+        assert!(matches!(
+            st.claim_queued("pf_missing"),
+            Err(StoreError::NotFound(_))
+        ));
+        assert_eq!(ids(st.queued(Some("t")).expect("t")), [second.id]);
+    }
+
+    #[test]
+    fn submission_states_have_snake_case_wire_names() {
+        for (state, wire) in [
+            (SubmissionState::Queued, "\"queued\""),
+            (SubmissionState::AwaitingAdmin, "\"awaiting_admin\""),
+            (SubmissionState::Rejected, "\"rejected\""),
+            (SubmissionState::Champion, "\"champion\""),
+        ] {
+            assert_eq!(serde_json::to_string(&state).expect("json"), wire);
+        }
     }
 }

--- a/crates/proof-store/src/lib.rs
+++ b/crates/proof-store/src/lib.rs
@@ -64,7 +64,7 @@ impl ArtifactManifest {
 }
 
 /// One miner submission against one topic.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Submission {
     /// Stable id (`pf_` + 16 hex).
     pub id: String,
@@ -131,12 +131,43 @@ pub enum StoreError {
     /// Illegal state transition.
     #[error("illegal state {0}")]
     Illegal(String),
+    /// A drain already holds this topic's one in-flight claim.
+    #[error(
+        "topic {topic_id} already has a row being scored ({id}); a topic's queue drains one row at a time, oldest first — retry when it lands"
+    )]
+    Busy {
+        /// Topic whose queue is being drained.
+        topic_id: String,
+        /// The row in flight.
+        id: String,
+    },
     /// Topic document failed verification.
     #[error("topic: {0}")]
     Topic(#[from] TopicError),
     /// Holdout file did not match the topic commitment.
     #[error("holdout: {0}")]
     Holdout(#[from] HoldoutError),
+}
+
+/// What [`MemoryStore::enqueue`] did with an intake row.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Enqueued {
+    /// No row on that topic had this frozen digest: the row was inserted
+    /// `queued` under a fresh id.
+    Inserted(Submission),
+    /// A row on that topic already carries this frozen digest — queued,
+    /// scored, or rejected — and is returned unchanged. Nothing was inserted.
+    Existing(Submission),
+}
+
+impl Enqueued {
+    /// The row, either way.
+    #[must_use]
+    pub fn row(&self) -> &Submission {
+        match self {
+            Self::Inserted(r) | Self::Existing(r) => r,
+        }
+    }
 }
 
 /// In-memory store (v0).
@@ -149,15 +180,36 @@ pub struct MemoryStore {
 struct Inner {
     next: u64,
     submissions: BTreeMap<String, Submission>,
-    /// Queued rows a drain has claimed and is scoring right now. A claim is
-    /// what keeps two concurrent drains from renting twice for one row; it
-    /// is cleared when the scored row lands ([`MemoryStore::insert`]) or the
-    /// drain gives the row back ([`MemoryStore::release_claim`]).
-    scoring: BTreeSet<String>,
+    /// The one `queued` row per topic a drain is scoring right now
+    /// (`topic_id → row id`). One entry per topic is the invariant that
+    /// keeps a topic's queue oldest-first and one-at-a-time — promotion
+    /// compares each run against the best *at that moment*, so two rows of
+    /// one topic must never score side by side — and keeps two concurrent
+    /// drains from renting twice for one row. Cleared when the scored row
+    /// lands ([`MemoryStore::insert`]) or the drain gives the row back
+    /// ([`MemoryStore::release_claim`]).
+    scoring: BTreeMap<String, String>,
     topics: BTreeMap<String, TopicDocument>,
     holdouts: BTreeMap<String, Vec<HoldoutRecord>>,
     baselines: BTreeMap<String, SealedBaseline>,
     scores: BTreeMap<String, BTreeMap<String, MinerTopicRun>>,
+}
+
+impl Inner {
+    /// Next `pf_…` id. Monotonic, so id order is intake order.
+    fn mint_id(&mut self) -> String {
+        let n = self.next;
+        self.next = self.next.saturating_add(1);
+        format!("pf_{n:016x}")
+    }
+
+    /// The oldest `queued` row on `topic_id` (rows iterate in id order).
+    fn queue_head(&self, topic_id: &str) -> Option<Submission> {
+        self.submissions
+            .values()
+            .find(|r| r.state == SubmissionState::Queued && r.topic_id == topic_id)
+            .cloned()
+    }
 }
 
 impl MemoryStore {
@@ -264,17 +316,50 @@ impl MemoryStore {
     /// row awaiting a drain. An empty id mints the next `pf_…` (ids are
     /// monotonic, so id order is intake order); a row that carries its id
     /// replaces the stored one — that is how a drained `queued` row lands
-    /// scored — and settles any claim on it.
+    /// scored — and settles the topic's claim when it is on this row.
     pub fn insert(&self, mut row: Submission) -> Result<Submission, StoreError> {
         let mut g = self.lock()?;
         if row.id.is_empty() {
-            let n = g.next;
-            g.next = g.next.saturating_add(1);
-            row.id = format!("pf_{n:016x}");
+            row.id = g.mint_id();
         }
-        g.scoring.remove(&row.id);
+        if g.scoring.get(&row.topic_id) == Some(&row.id) {
+            g.scoring.remove(&row.topic_id);
+        }
         g.submissions.insert(row.id.clone(), row.clone());
         Ok(row)
+    }
+
+    /// Queue an intake row **once per frozen digest per topic**, atomically:
+    /// under one lock, a row on `row.topic_id` that already carries
+    /// `row.submission_digest` — `queued`, scored, or rejected — is returned
+    /// as [`Enqueued::Existing`] and nothing is inserted; otherwise the row
+    /// is minted an id and stored `queued` ([`Enqueued::Inserted`]). Two
+    /// concurrent identical submits therefore yield one row, and a retry
+    /// after the row was drained finds the scored row rather than queueing a
+    /// second paid run. The caller must pass an empty id.
+    pub fn enqueue(&self, mut row: Submission) -> Result<Enqueued, StoreError> {
+        if !row.id.is_empty() {
+            return Err(StoreError::Illegal(
+                "enqueue mints the id; pass an empty one".into(),
+            ));
+        }
+        if row.state != SubmissionState::Queued {
+            return Err(StoreError::Illegal(
+                "enqueue takes a queued intake row".into(),
+            ));
+        }
+        let mut g = self.lock()?;
+        if let Some(existing) = g
+            .submissions
+            .values()
+            .find(|r| r.topic_id == row.topic_id && r.submission_digest == row.submission_digest)
+            .cloned()
+        {
+            return Ok(Enqueued::Existing(existing));
+        }
+        row.id = g.mint_id();
+        g.submissions.insert(row.id.clone(), row.clone());
+        Ok(Enqueued::Inserted(row))
     }
 
     /// Fetch one row.
@@ -307,48 +392,35 @@ impl MemoryStore {
             .collect())
     }
 
-    /// The `queued` row with `submission_digest` on `topic_id`, if any: one
-    /// artefact per hotkey is queued once, so a retried submit finds its row
-    /// instead of queueing a second paid run.
-    pub fn queued_by_digest(
-        &self,
-        topic_id: &str,
-        submission_digest: &str,
-    ) -> Result<Option<Submission>, StoreError> {
-        Ok(self
-            .lock()?
-            .submissions
-            .values()
-            .find(|r| {
-                r.state == SubmissionState::Queued
-                    && r.topic_id == topic_id
-                    && r.submission_digest == submission_digest
-            })
-            .cloned())
+    /// The row a drain is scoring on `topic_id` right now, if any.
+    pub fn scoring_row(&self, topic_id: &str) -> Result<Option<String>, StoreError> {
+        Ok(self.lock()?.scoring.get(topic_id).cloned())
     }
 
-    /// Claim the oldest `queued` row on `topic_id` nobody is scoring, for
-    /// this caller to score. `None` when the queue (minus claimed rows) is
-    /// empty. Atomic: two drains never get the same row.
+    /// Claim the head of `topic_id`'s queue — its oldest `queued` row — for
+    /// this caller to score. `None` when the queue is empty;
+    /// [`StoreError::Busy`] while another drain holds the topic's claim, so
+    /// two drains never score two rows of one topic side by side (nor one
+    /// row twice). Atomic under the store lock.
     pub fn claim_next_queued(&self, topic_id: &str) -> Result<Option<Submission>, StoreError> {
         let mut g = self.lock()?;
-        let next = g
-            .submissions
-            .values()
-            .find(|r| {
-                r.state == SubmissionState::Queued
-                    && r.topic_id == topic_id
-                    && !g.scoring.contains(&r.id)
-            })
-            .cloned();
-        if let Some(row) = &next {
-            g.scoring.insert(row.id.clone());
+        if let Some(id) = g.scoring.get(topic_id) {
+            return Err(StoreError::Busy {
+                topic_id: topic_id.to_owned(),
+                id: id.clone(),
+            });
         }
-        Ok(next)
+        let head = g.queue_head(topic_id);
+        if let Some(row) = &head {
+            g.scoring.insert(topic_id.to_owned(), row.id.clone());
+        }
+        Ok(head)
     }
 
-    /// Claim one `queued` row by id. A row that is not `queued`, or that
-    /// another drain already claimed, is [`StoreError::Illegal`].
+    /// Claim one `queued` row by id. It must be the head of its topic's
+    /// queue (the queue drains oldest first — [`StoreError::Illegal`] names
+    /// the head otherwise), not already scored ([`StoreError::Illegal`]),
+    /// and its topic must have no row in flight ([`StoreError::Busy`]).
     pub fn claim_queued(&self, id: &str) -> Result<Submission, StoreError> {
         let mut g = self.lock()?;
         let row = g
@@ -362,18 +434,31 @@ impl MemoryStore {
                 row.state
             )));
         }
-        if !g.scoring.insert(id.to_owned()) {
+        if let Some(in_flight) = g.scoring.get(&row.topic_id) {
+            return Err(StoreError::Busy {
+                topic_id: row.topic_id.clone(),
+                id: in_flight.clone(),
+            });
+        }
+        if let Some(head) = g.queue_head(&row.topic_id).filter(|h| h.id != id) {
             return Err(StoreError::Illegal(format!(
-                "submission {id} is already being scored"
+                "submission {id} is not the head of topic {}'s queue; it drains oldest first — score {} first",
+                row.topic_id, head.id
             )));
         }
+        g.scoring.insert(row.topic_id.clone(), id.to_owned());
         Ok(row)
     }
 
-    /// Give a claimed row back unscored (the host refused): it stays
-    /// `queued` and the next drain may claim it again.
-    pub fn release_claim(&self, id: &str) -> Result<(), StoreError> {
-        self.lock()?.scoring.remove(id);
+    /// Give a claimed row back unscored (the host refused, or the drain was
+    /// interrupted): it stays `queued` and the next drain may claim it
+    /// again. A no-op unless `id` is the row holding `topic_id`'s claim, so
+    /// a late release can never drop a claim another drain took since.
+    pub fn release_claim(&self, topic_id: &str, id: &str) -> Result<(), StoreError> {
+        let mut g = self.lock()?;
+        if g.scoring.get(topic_id).is_some_and(|held| held == id) {
+            g.scoring.remove(topic_id);
+        }
         Ok(())
     }
 
@@ -577,10 +662,13 @@ mod tests {
         }
     }
 
-    /// The queue is FIFO by id, a claim is exclusive until the row lands or
-    /// is released, and landing the scored row (same id) settles the claim.
+    /// The queue is FIFO by id and a topic has **one** claim at a time: while
+    /// its head is in flight nothing else on that topic can be claimed (not
+    /// the next row, not the same row again); other topics are independent.
+    /// Landing the scored row (same id) or releasing the claim frees the
+    /// topic; a release names its row, so it never drops a newer claim.
     #[test]
-    fn queued_rows_drain_in_order_and_a_claim_is_exclusive() {
+    fn a_topic_drains_one_row_at_a_time_oldest_first() {
         let st = MemoryStore::new();
         let first = st.insert(queued_row("t", "1")).expect("first");
         let second = st.insert(queued_row("t", "2")).expect("second");
@@ -595,37 +683,50 @@ mod tests {
             ids(st.queued(Some("t")).expect("t")),
             [first.id.clone(), second.id.clone()]
         );
-        assert_eq!(
-            st.queued_by_digest("t", &first.submission_digest)
-                .expect("lookup")
-                .map(|r| r.id),
-            Some(first.id.clone())
+        assert_eq!(st.scoring_row("t").expect("q"), None);
+
+        // The second row is not the head: it cannot be scored out of order.
+        let err = st.claim_queued(&second.id).expect_err("not the head");
+        assert!(
+            matches!(&err, StoreError::Illegal(m) if m.contains(&first.id)),
+            "{err}"
         );
-        assert!(st
-            .queued_by_digest("u", &first.submission_digest)
-            .expect("lookup")
-            .is_none());
 
         let claimed = st.claim_next_queued("t").expect("claim").expect("row");
         assert_eq!(claimed.id, first.id, "oldest first");
+        assert_eq!(st.scoring_row("t").expect("q"), Some(first.id.clone()));
         assert!(
-            matches!(st.claim_queued(&first.id), Err(StoreError::Illegal(_))),
-            "a claimed row cannot be claimed twice"
+            matches!(st.claim_next_queued("t"), Err(StoreError::Busy { ref id, .. }) if *id == first.id),
+            "a second drain on the same topic is busy, not the next row"
         );
-        let next = st.claim_next_queued("t").expect("claim").expect("row");
-        assert_eq!(next.id, second.id, "the claimed row is skipped");
-        assert!(st.claim_next_queued("t").expect("claim").is_none());
+        assert!(
+            matches!(st.claim_queued(&first.id), Err(StoreError::Busy { .. })),
+            "the in-flight row cannot be claimed twice"
+        );
+        assert!(
+            matches!(st.claim_queued(&second.id), Err(StoreError::Busy { .. })),
+            "nor the row behind it"
+        );
+        assert_eq!(
+            st.claim_next_queued("u").expect("claim").map(|r| r.id),
+            Some(other.id.clone()),
+            "another topic's queue is independent"
+        );
         assert_eq!(
             st.queued(Some("t")).expect("still listed").len(),
             2,
             "claimed rows are still queued to readers"
         );
 
-        st.release_claim(&second.id).expect("release");
+        // A release names its row: releasing the wrong id changes nothing.
+        st.release_claim("t", &second.id).expect("release");
+        assert_eq!(st.scoring_row("t").expect("q"), Some(first.id.clone()));
+        st.release_claim("t", &first.id).expect("release");
+        assert_eq!(st.scoring_row("t").expect("q"), None);
         assert_eq!(
             st.claim_next_queued("t").expect("claim").map(|r| r.id),
-            Some(second.id.clone()),
-            "a released row is claimable again"
+            Some(first.id.clone()),
+            "a released head is claimable again, still first"
         );
 
         let mut scored = claimed;
@@ -636,6 +737,11 @@ mod tests {
             st.get(&first.id).expect("get").state,
             SubmissionState::AwaitingAdmin
         );
+        assert_eq!(
+            st.scoring_row("t").expect("q"),
+            None,
+            "landing settles the claim"
+        );
         assert!(
             matches!(st.claim_queued(&first.id), Err(StoreError::Illegal(_))),
             "a scored row is not queued"
@@ -644,7 +750,62 @@ mod tests {
             st.claim_queued("pf_missing"),
             Err(StoreError::NotFound(_))
         ));
-        assert_eq!(ids(st.queued(Some("t")).expect("t")), [second.id]);
+        assert_eq!(
+            ids(st.queued(Some("t")).expect("t")),
+            std::slice::from_ref(&second.id)
+        );
+        // Now the second row is the head and can be named directly.
+        assert_eq!(st.claim_queued(&second.id).expect("head").id, second.id);
+        // A stale release from the first row's drain must not free it.
+        st.release_claim("t", &first.id).expect("stale release");
+        assert_eq!(st.scoring_row("t").expect("q"), Some(second.id));
+    }
+
+    /// `enqueue` is the deferred path's one atomic step: one row per frozen
+    /// digest per topic for the row's whole life — a duplicate finds the
+    /// queued row, and a retry after the row was scored finds the scored row
+    /// (never a second paid run); the same digest on another topic is its
+    /// own row.
+    #[test]
+    fn enqueue_is_idempotent_per_topic_and_digest_for_the_rows_whole_life() {
+        let st = MemoryStore::new();
+        let Enqueued::Inserted(row) = st.enqueue(queued_row("t", "1")).expect("enqueue") else {
+            panic!("first enqueue inserts");
+        };
+        assert!(row.id.starts_with("pf_"));
+        assert_eq!(st.queued(Some("t")).expect("q").len(), 1);
+
+        let again = st.enqueue(queued_row("t", "1")).expect("enqueue");
+        assert_eq!(again, Enqueued::Existing(row.clone()));
+        assert_eq!(again.row().id, row.id);
+        assert_eq!(st.queued(Some("t")).expect("q").len(), 1, "no second row");
+
+        let Enqueued::Inserted(elsewhere) = st.enqueue(queued_row("u", "1")).expect("enqueue")
+        else {
+            panic!("another topic is another row");
+        };
+        assert_ne!(elsewhere.id, row.id);
+
+        let mut scored = row.clone();
+        scored.state = SubmissionState::Rejected;
+        st.insert(scored.clone()).expect("land");
+        let after = st.enqueue(queued_row("t", "1")).expect("enqueue");
+        assert_eq!(
+            after,
+            Enqueued::Existing(scored),
+            "a retry after scoring finds the scored row, not a new queued one"
+        );
+        assert!(st.queued(Some("t")).expect("q").is_empty());
+
+        let mut with_id = queued_row("t", "9");
+        with_id.id = "pf_given".into();
+        assert!(matches!(st.enqueue(with_id), Err(StoreError::Illegal(_))));
+        let mut not_queued = queued_row("t", "9");
+        not_queued.state = SubmissionState::AwaitingAdmin;
+        assert!(matches!(
+            st.enqueue(not_queued),
+            Err(StoreError::Illegal(_))
+        ));
     }
 
     #[test]

--- a/crates/proof-task/src/lib.rs
+++ b/crates/proof-task/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) use proof_canon::is_http_origin;
 pub use proof_canon::{
     canonical_json, is_custom_id, is_hex64, is_model_pin, is_opaque_param, is_slug, ChecklistRule,
     Constraints, MAX_CHECKLIST_RULES, MAX_CONSTRAINT_PARAMS, MAX_RULE_TEXT_LEN,
+    PARAM_DEFER_SCORING,
 };
 pub use proof_holdout::{
     contamination, holdout_commitment, synthetic_holdout, verify_holdout, HoldoutError,

--- a/deploy/env/proof-challenge.env.example
+++ b/deploy/env/proof-challenge.env.example
@@ -17,6 +17,13 @@ BASE_NETUID=541
 PROOF_EMIT_POLL_SECS=120
 # PROOF_SCORED_EPOCH_FILE=/var/lib/proof/scored_epoch
 
+# Seconds between queue-drain passes. A topic whose signed document sets
+# constraints.params.defer_scoring="true" accepts submissions as `queued`
+# rows (201, no eval, no rent); once the operator re-publishes it without the
+# flag, each pass scores its queue oldest first through the live path. 0
+# disables the loop (drain only via POST /v1/admin/proof/queue/drain).
+# PROOF_QUEUE_DRAIN_POLL_SECS=60
+
 # Sim is CI/local only and is never a fallback. On a live host the service
 # needs all of: a sha256 eval_image_digest in config/proof-pin.toml, a wired
 # scorer for the topic's family — the Lium harvest (LIUM_API_KEY +

--- a/docs/PROOF.md
+++ b/docs/PROOF.md
@@ -221,7 +221,11 @@ Trust-root keygen is the throwaway owner path in
   `custom_family_wired` (a custom-family scorer with ≥1 registered runner is
   on this host, independent of Lium), `baseline_sealed`, `open_topics`,
   `scorable_topics` (open topics whose family's scorer is wired on this
-  host; `can_score` is true when it is non-empty), `registered_custom`
+  host **and** that do not defer scoring; `can_score` is true when it is
+  non-empty), `deferred_topics` (open topics whose signed document sets
+  `constraints.params.defer_scoring = "true"`: submits there are **201**
+  `queued`, nothing is evaluated), `queued_submissions` (rows waiting for a
+  drain), `registered_custom`
   (custom ids with a runner), `custom_ready` (registered ids whose runner
   could run right now: topic-VM orchestrator bearer file present, image
   pinned — independent of which topics are open), public
@@ -246,6 +250,18 @@ Trust-root keygen is the throwaway owner path in
   data. Names env vars and container
   paths, never the bearer. Run over loopback; wrapped by
   [`deploy/scripts/proof-vm-wire-check.sh`](../deploy/scripts/proof-vm-wire-check.sh).
+- `POST /v1/admin/proof/queue/drain` — operator bearer; body
+  `{"topic_id": "<id>", "limit": 1}`. Scores that topic's `queued` rows
+  oldest first through the live submit path (`limit` rows per call, default
+  1) and answers a report (`drained[]`, `remaining`, `stopped`). **409**
+  while the topic still defers scoring or is not open (nothing touched);
+  **400** unknown topic; **503** carrying the report when the host refused
+  before one row scored — every row stays `queued`, nothing was rented. See
+  § Deferred scoring.
+- `POST /v1/admin/proof/submissions/{id}/score` — operator bearer; scores
+  one `queued` row now under the same rules (**404** unknown, **409** not
+  queued / already being scored / topic still deferring, **503** host
+  refusal with the row released back to the queue).
 - `POST /v1/submissions` **requires** `topic_id`. Missing/unknown/not-open →
   **400**. Miners do **not** bind the judge offer or the executor offer. Zero
   open / unsealed baseline / empty digest / missing or closed RLM judge
@@ -254,7 +270,15 @@ Trust-root keygen is the throwaway owner path in
   `custom_id` / `nll` or `throughput` topic on a host with no Lium harvest
   → **503**. Refusals must **not** persist rows. Scored rows
   stamp `executor_offer_id` + `executor_commitment` next to the judge
-  `inference_offer_id` + `config_commitment`.
+  `inference_offer_id` + `config_commitment`. On a topic listed in
+  `deferred_topics` the same intake gates apply (**400**s unchanged) but
+  the host gates are not consulted: the row persists as **`queued`**
+  (**201**, `eligible: false`, `detail` names the deferral) with no eval,
+  no rent, no judge call, no stamps, no mass; the same artefact from the
+  same hotkey again is **200** with the existing row.
+- `GET /v1/submissions?state=<queued|awaiting_admin|rejected|champion>&topic_id=<id>`
+  — both filters optional; newest first. `GET /v1/submissions/{id}` shows a
+  `queued` row with `verdict: null` until it is drained.
 - A pass that the family scorer crowns (custom: green checklist and
   `primary >= bar * (1 + epsilon_rel)` direction-aware, bar = sealed value or
   reigning best) persists as `champion`; other passes stay `awaiting_admin`.
@@ -267,6 +291,55 @@ Trust-root keygen is the throwaway owner path in
 - Contamination / empty manifest: persist **rejected** without renting.
 
 Miner-facing: [`external-miner/proof.md`](./external-miner/proof.md).
+
+## Deferred scoring (`queued` rows)
+
+An open topic may **accept artefacts before its scoring path is ready** —
+the live case is a topic whose in-guest baseline / harness is still being
+installed on the KVM host while miners already have recipes to file. The
+switch is topic data, signed like every other binding:
+
+```json
+"constraints": { "params": { "defer_scoring": "true" } }
+```
+
+(`params` values are strings — quote it in YAML too: `defer_scoring: "true"`.
+`"false"` and an absent key are the same thing; any other spelling is a
+publish **400** naming `constraints.params.defer_scoring`.)
+
+Semantics, none of which weaken a product rule:
+
+| Rule | With `defer_scoring = "true"` |
+|------|-------------------------------|
+| Topic status | Stays **`open`**: it needs a sealed baseline to publish, it is listed in `open_topics`, and it is **not** `draft` (a draft is still a submit **400**). |
+| Intake gates | Unchanged: hotkey / digest shape, digest-of-nothing, unknown / not-open topic, `declared_flops` over budget, missing `artifact_uri` on a custom topic are the same **400**s with no row. |
+| Host gates | **Not consulted.** The row persists as **`queued`** (**201**) whether or not the host could score it right now — no readiness check, no harvest rent, no topic VM, no judge call, no verdict, no stamps, no topic mass, no emission. |
+| Status | The topic is in `deferred_topics`, **not** in `scorable_topics`; `can_score` keeps its meaning (something is scored right now). `queued_submissions` counts the waiting rows. |
+| Duplicates | One `queued` row per frozen digest per topic: the same artefact from the same hotkey again is **200** with the existing id (`detail: already queued …`). |
+| Drain | A drain of a topic that still defers is **409**, nothing touched. |
+
+**Lifting the flag** is a re-publish: sign the same document without the
+param (or with `"false"`) and `POST /v1/admin/proof/topics`. The queue
+survives the re-publish (rows bind `topic_id`, not a signature). From then
+on the rows score **oldest first, one at a time, through the exact path a
+live submit takes** (readiness → offers → sealed baseline → holdout unseal →
+contamination gate → eval → judge → persist with the host stamps and the
+family scorer's promotion / persist hooks), each row keeping its `pf_…` id:
+
+- automatically, by the binary's poll loop (`PROOF_QUEUE_DRAIN_POLL_SECS`,
+  default 60; `0` disables it) — lifting the flag *is* "score now";
+- on demand, with `POST /v1/admin/proof/queue/drain {"topic_id": …, "limit": n}`
+  (default one row per call; the report says what is `remaining`), or one
+  row with `POST /v1/admin/proof/submissions/{id}/score`.
+
+Fail-closed on the drain: a host refusal (unwired runner, closed executor,
+no sealed baseline recorded, agent down, …) leaves that row **`queued`** —
+never a reject — and stops the pass (**503** with the reason when nothing
+scored); a contamination / empty-manifest row persists **`rejected`** with no
+rent, exactly as a live submit would. Two concurrent drains never score one
+row twice (a claimed row is skipped until it lands or is released). Re-publishing
+the topic with the flag back on **pauses** the queue mid-pass. `queued` is the
+only non-terminal state; `ctx proof show --wait` keeps polling through it.
 
 ## Example topics (not live)
 

--- a/docs/PROOF.md
+++ b/docs/PROOF.md
@@ -259,9 +259,11 @@ Trust-root keygen is the throwaway owner path in
   before one row scored — every row stays `queued`, nothing was rented. See
   § Deferred scoring.
 - `POST /v1/admin/proof/submissions/{id}/score` — operator bearer; scores
-  one `queued` row now under the same rules (**404** unknown, **409** not
-  queued / already being scored / topic still deferring, **503** host
-  refusal with the row released back to the queue).
+  one `queued` row now under the same rules. The row must be the **head**
+  of its topic's queue (**404** unknown, **409** not queued / not the head —
+  the error names the head — / topic already has a row in flight / topic
+  still deferring, **503** host refusal with the row released back to the
+  queue).
 - `POST /v1/submissions` **requires** `topic_id`. Missing/unknown/not-open →
   **400**. Miners do **not** bind the judge offer or the executor offer. Zero
   open / unsealed baseline / empty digest / missing or closed RLM judge
@@ -275,7 +277,9 @@ Trust-root keygen is the throwaway owner path in
   the host gates are not consulted: the row persists as **`queued`**
   (**201**, `eligible: false`, `detail` names the deferral) with no eval,
   no rent, no judge call, no stamps, no mass; the same artefact from the
-  same hotkey again is **200** with the existing row.
+  same hotkey again is **200** with the existing row — still queued, or
+  already scored after a drain (one row per frozen digest per topic, decided
+  in one atomic store step).
 - `GET /v1/submissions?state=<queued|awaiting_admin|rejected|champion>&topic_id=<id>`
   — both filters optional; newest first. `GET /v1/submissions/{id}` shows a
   `queued` row with `verdict: null` until it is drained.
@@ -315,7 +319,7 @@ Semantics, none of which weaken a product rule:
 | Intake gates | Unchanged: hotkey / digest shape, digest-of-nothing, unknown / not-open topic, `declared_flops` over budget, missing `artifact_uri` on a custom topic are the same **400**s with no row. |
 | Host gates | **Not consulted.** The row persists as **`queued`** (**201**) whether or not the host could score it right now — no readiness check, no harvest rent, no topic VM, no judge call, no verdict, no stamps, no topic mass, no emission. |
 | Status | The topic is in `deferred_topics`, **not** in `scorable_topics`; `can_score` keeps its meaning (something is scored right now). `queued_submissions` counts the waiting rows. |
-| Duplicates | One `queued` row per frozen digest per topic: the same artefact from the same hotkey again is **200** with the existing id (`detail: already queued …`). |
+| Duplicates | One row per frozen digest per topic, for the row's whole life, decided in one atomic store step: the same artefact from the same hotkey again is **200** with the existing row (`detail: already queued …`), and after a drain it is **200** with the *scored* row (`already submitted … and scored`) — two identical submits racing each other yield one row, and a retry never buys a second paid run. |
 | Drain | A drain of a topic that still defers is **409**, nothing touched. |
 
 **Lifting the flag** is a re-publish: sign the same document without the
@@ -329,17 +333,25 @@ family scorer's promotion / persist hooks), each row keeping its `pf_…` id:
 - automatically, by the binary's poll loop (`PROOF_QUEUE_DRAIN_POLL_SECS`,
   default 60; `0` disables it) — lifting the flag *is* "score now";
 - on demand, with `POST /v1/admin/proof/queue/drain {"topic_id": …, "limit": n}`
-  (default one row per call; the report says what is `remaining`), or one
-  row with `POST /v1/admin/proof/submissions/{id}/score`.
+  (default one row per call; the report says what is `remaining`), or the
+  head of the queue with `POST /v1/admin/proof/submissions/{id}/score`.
 
 Fail-closed on the drain: a host refusal (unwired runner, closed executor,
 no sealed baseline recorded, agent down, …) leaves that row **`queued`** —
 never a reject — and stops the pass (**503** with the reason when nothing
 scored); a contamination / empty-manifest row persists **`rejected`** with no
-rent, exactly as a live submit would. Two concurrent drains never score one
-row twice (a claimed row is skipped until it lands or is released). Re-publishing
-the topic with the flag back on **pauses** the queue mid-pass. `queued` is the
-only non-terminal state; `ctx proof show --wait` keeps polling through it.
+rent, exactly as a live submit would. **A topic holds one claim at a time:**
+while its head is mid-eval, a second drain of that topic (admin route,
+single-row route, or the poll pass) is a **409** / a `stopped` report that
+names the row in flight and scores nothing — two rows of one topic never run
+side by side, so promotion always compares against the best at that moment;
+other topics are independent. The claim is released on every path that does
+not land the row — host refusal, panic, or a drain interrupted mid-eval (an
+operator HTTP call cut, the poll task cancelled) — so an interruption never
+leaves a topic busy until a restart; a late release can never drop a claim a
+later drain took. Re-publishing the topic with the flag back on **pauses**
+the queue mid-pass. `queued` is the only non-terminal state;
+`ctx proof show --wait` keeps polling through it.
 
 ## Example topics (not live)
 

--- a/docs/external-miner/proof.md
+++ b/docs/external-miner/proof.md
@@ -83,7 +83,9 @@ keys. `GET /challenge/proof/v1/proof/executor` shows the executor alone with
 `ready` and a `reason` when it cannot rent.
 
 `can_score: false` means submits **503**. Nothing is stored and nothing is
-rented.
+rented. The one exception is a topic listed in `deferred_topics`: it accepts
+your submission and stores it as **`queued`** (see § 3) while the operator
+finishes installing its scoring path — nothing is evaluated or rented yet.
 
 | Status field | What it means |
 |--------------|----------------|
@@ -91,7 +93,9 @@ rented.
 | `inference_offer` | Public RLM **judge** backend (id, kind, mode, model_ref, token caps, commitment, status). Missing/closed/misconfigured → **503**. You do not pass an offer id |
 | `eval_executor` | Public `1x` **executor**: the Lium machine class your recipe is re-run on (`lium_template_id`, `machine_shape`, `max_proof_deadline_s`, commitment, status). Your recipe must finish inside `max_proof_deadline_s` (≤ pin ceiling 7200 s; a topic may name a shorter one) on **one** GPU — the host never rents more. Missing/closed/any shape but `1x` → **503**. You do not pass or rent it |
 | `open_topics` empty | No currently `open` signed topic with a sealed baseline → **503** |
-| `scorable_topics` | Open topics whose family's scorer is wired on this host. An open topic **not** listed here (a `custom` topic whose runner is not registered or not wired; an `nll` / `throughput` topic on a host whose Lium harvest is not wired) answers **503** |
+| `scorable_topics` | Open topics whose family's scorer is wired on this host and that are scored right now. An open topic **not** listed here (a `custom` topic whose runner is not registered or not wired; an `nll` / `throughput` topic on a host whose Lium harvest is not wired) answers **503** — unless it is in `deferred_topics` |
+| `deferred_topics` | Open topics whose signed document sets `constraints.params.defer_scoring = "true"`: the operator is still installing the baseline / harness. Submits are accepted (**201**) and stored as **`queued`**; nothing is evaluated or rented until the operator lifts the flag and drains the queue, oldest first |
+| `queued_submissions` | Rows waiting in that queue across topics |
 | `registered_custom` | Custom metric ids with a registered runner. Nothing is compiled in; ids come from signed topics |
 | `custom_ready` | The subset of `registered_custom` whose runner can run right now (topic-VM orchestrator reachable by config, image pinned). A registered id missing here → its topics answer **503** |
 | `baseline_sealed: false` | An open topic without `script_sha256` + `metrics_commitment` → **503** |
@@ -116,7 +120,7 @@ Each topic is a signed document. Read at least:
 |-------|------------------------|
 | `id` | The `topic_id` you submit against |
 | `statement` | The research problem in English |
-| `constraints` | Fabric / comms caps the eval image enforces (it never trusts the claim). Custom topics may add `firecracker_required`, `model_pin`, an opaque `task_slice`, and `params` |
+| `constraints` | Fabric / comms caps the eval image enforces (it never trusts the claim). Custom topics may add `firecracker_required`, `model_pin`, an opaque `task_slice`, and `params`. `params.defer_scoring: "true"` means the topic accepts submits but scores them later (`queued`) |
 | `checklist` | Anti-cheat rules `[{id, text}]` the topic's RLM ticks over your artefact **before any paid inference** |
 | `eval_executor` | Executor commitment (`require_offer_commitment`, tighten-only `max_proof_deadline_s`) |
 | `metric.family` | `nll` \| `throughput` \| `custom` (`metric.custom_id` names the metric; it is topic data) |
@@ -190,7 +194,9 @@ ctx proof submit \
 ```
 
 `--wait` keeps polling until the row is terminal (`awaiting_admin`,
-`rejected`, or `champion`).
+`rejected`, or `champion`). A `queued` row is not terminal: on a topic that
+defers scoring, `--wait` keeps polling until the operator drains the queue,
+which can take as long as the operator's install does.
 
 The same submit with `curl`:
 
@@ -216,7 +222,8 @@ claim against public numbers and checks FLOPs against the topic budget.
 
 Poll `GET /challenge/proof/v1/submissions/{id}`. While `can_score` is
 `false` (empty digest, missing/closed RLM judge backend, incomplete pin+topic
-judge config, no open sealed topic), submissions answer **503**.
+judge config, no open sealed topic), submissions answer **503** — except on
+a topic in `deferred_topics`, where they answer **201** `queued`.
 
 ### Required POST JSON
 
@@ -247,6 +254,7 @@ curl -sS https://gateway.cortex.foundation/challenge/proof/v1/submissions/<id>
 
 | `state` | Meaning |
 |---------|---------|
+| `queued` | Accepted and stored, **not yet evaluated**: the topic defers scoring (`constraints.params.defer_scoring`) while the operator finishes its baseline / harness install. No eval, no rent, no judge call, no mass yet; `verdict` is `null` and `detail` says so. The only non-terminal state — the row is scored later, oldest first, when the operator lifts the flag and drains the queue, and then becomes one of the three below. Re-sending the same artefact returns the same row (**200**). |
 | `awaiting_admin` | Clean pass; mass recorded. Operator audit is informational. |
 | `rejected` | Gates failed (contamination, unreproduced claim, NLL miss, red anti-cheat checklist, …). No rent and no paid inference on pre-eval rejects. |
 | `champion` | Promoted: operator crown, or automatic on custom topics when a pass beats the current best by `epsilon_rel` with a green checklist. Proof pays on pass, not on a crown. |
@@ -277,6 +285,8 @@ Refusals (**400** / **503**) do **not** persist a submission row.
 | **503** missing / closed / non-`1x` executor | Live `eval_executor` cannot rent the `1x` machine | no | no |
 | **503** `proof deadline … exceeded` | Your recipe did not finish inside `max_proof_deadline_s`; the body carries the run's `stdout_tail` | no | no (pod torn down) |
 | **503** `custom metric … has no registered runner` / `not wired` | The topic's `custom_id` has no runner on this host, or its topic VM is not configured | no | no |
+| **201** `queued` | Topic in `deferred_topics` (operator still installing its scoring path); every **400** above still applies first | **yes** (queued, scored later) | **no** (not yet) |
+| **200** `queued` + `already queued …` | Same artefact + hotkey re-sent to a deferring topic | existing row | **no** |
 | **201** `rejected` + `contamination_evidence_missing` | Empty manifest | **yes** (rejected) | **no** |
 | **201** `rejected` + contamination | Holdout shard / corpus id in `manifest` | **yes** (rejected) | **no** |
 | **201** `rejected` + `anti-cheat checklist red` | A topic rule failed on your artefact | **yes** (rejected) | **no** (no paid inference) |

--- a/docs/external-miner/proof.md
+++ b/docs/external-miner/proof.md
@@ -254,7 +254,7 @@ curl -sS https://gateway.cortex.foundation/challenge/proof/v1/submissions/<id>
 
 | `state` | Meaning |
 |---------|---------|
-| `queued` | Accepted and stored, **not yet evaluated**: the topic defers scoring (`constraints.params.defer_scoring`) while the operator finishes its baseline / harness install. No eval, no rent, no judge call, no mass yet; `verdict` is `null` and `detail` says so. The only non-terminal state — the row is scored later, oldest first, when the operator lifts the flag and drains the queue, and then becomes one of the three below. Re-sending the same artefact returns the same row (**200**). |
+| `queued` | Accepted and stored, **not yet evaluated**: the topic defers scoring (`constraints.params.defer_scoring`) while the operator finishes its baseline / harness install. No eval, no rent, no judge call, no mass yet; `verdict` is `null` and `detail` says so. The only non-terminal state — the row is scored later, oldest first and one at a time per topic, when the operator lifts the flag and drains the queue, and then becomes one of the three below. Re-sending the same artefact returns the same row (**200**) — before *and* after it is scored: one run per artefact per topic. |
 | `awaiting_admin` | Clean pass; mass recorded. Operator audit is informational. |
 | `rejected` | Gates failed (contamination, unreproduced claim, NLL miss, red anti-cheat checklist, …). No rent and no paid inference on pre-eval rejects. |
 | `champion` | Promoted: operator crown, or automatic on custom topics when a pass beats the current best by `epsilon_rel` with a green checklist. Proof pays on pass, not on a crown. |
@@ -286,7 +286,7 @@ Refusals (**400** / **503**) do **not** persist a submission row.
 | **503** `proof deadline … exceeded` | Your recipe did not finish inside `max_proof_deadline_s`; the body carries the run's `stdout_tail` | no | no (pod torn down) |
 | **503** `custom metric … has no registered runner` / `not wired` | The topic's `custom_id` has no runner on this host, or its topic VM is not configured | no | no |
 | **201** `queued` | Topic in `deferred_topics` (operator still installing its scoring path); every **400** above still applies first | **yes** (queued, scored later) | **no** (not yet) |
-| **200** `queued` + `already queued …` | Same artefact + hotkey re-sent to a deferring topic | existing row | **no** |
+| **200** existing row (`already queued …` / `already submitted … and scored`) | Same artefact + hotkey re-sent to a deferring topic, before or after its row was drained | existing row | **no** |
 | **201** `rejected` + `contamination_evidence_missing` | Empty manifest | **yes** (rejected) | **no** |
 | **201** `rejected` + contamination | Holdout shard / corpus id in `manifest` | **yes** (rejected) | **no** |
 | **201** `rejected` + `anti-cheat checklist red` | A topic rule failed on your artefact | **yes** (rejected) | **no** (no paid inference) |


### PR DESCRIPTION
## Summary
- Accept Proof submits into a **Queued** state (HTTP 201) when Harbor/eval is not ready or topic has `defer_scoring`, instead of failing closed / rejecting.
- Operator drain path to score queued submissions once the topic/eval path is ready.
- Docs + `ctx` / proof-http / store updates for the queued lifecycle.

## Context
Metal Harbor path-C n=15 in flight on `fe1f1a93`. Miners must keep submitting; Owner sets `defer_scoring` after this merges + metal tip. Separate from hotkey-signature PR (#259 Owner).

## Test plan
- [ ] Unit/integration for Queued accept-201 without Harbor eval
- [ ] Drain when topic ready scores queued rows
- [ ] Open `tbench` still accepts submits (no draft pause)
- [ ] Metal tip after merge; Owner toggles `defer_scoring`

@greptileai