### PR TITLE
fix(proof): harbor allow-list gate ignores pack agent_timeout floor

### DIFF
--- a/deploy/guest/runners/rlm_fc_in_guest_harbor/README.md
+++ b/deploy/guest/runners/rlm_fc_in_guest_harbor/README.md
@@ -190,13 +190,16 @@ from retained n15 x0017:
   `biped-contact-dynamics` / `cad-model` also stay out until verifier pytest
   is proven on metal.
 
-The deny/exclude list wins first, then the allow-list, then duration. An
-allow-listed name was measured under an hour, so only a measured
-`walls_sec` wall ≥ `max_task_duration_s` drops it — a pack `task.toml`
-`agent_timeout` is the harness ceiling, not a duration, and is ignored for
-those tasks (n15 attempt1 on pin `4a04eeb1` declared 28800 on all six and the
-3600 default emptied the pack). Every other task is still dropped on
-max(declared timeout, pack duration, adaptor hint).
+The deny/exclude list wins first, then the allow-list, then duration. A task
+named **exactly** on the allow-list was measured under an hour, so only a
+measured `walls_sec` wall ≥ `max_task_duration_s` drops it — a pack
+`task.toml` `agent_timeout` is the harness ceiling, not a duration, and is
+ignored for those tasks (n15 attempt1 on pin `4a04eeb1` declared 28800 on all
+six and the 3600 default emptied the pack). Every other task is still dropped
+on max(declared timeout, pack duration, adaptor hint), including an alias hit
+such as `cargo-flight-dispatch-extra` (a different task) and an unmeasured
+allow-list entry under a ceiling below 3600 (tighter than what the allow-list
+asserts); those also still honour `exclude_unknown_duration`.
 
 Do not put hour-plus or broken tasks in the default scorable pack for
 `n_concurrent` baselines or miner evals. An empty filtered copy fails closed.

--- a/deploy/guest/runners/rlm_fc_in_guest_harbor/README.md
+++ b/deploy/guest/runners/rlm_fc_in_guest_harbor/README.md
@@ -152,7 +152,7 @@ hardcoded to a benchmark name):
 | Param | Env | Role |
 |-------|------|------|
 | `tasks_dir` | `PROOF_PARAM_TASKS_DIR` | Relative path under the pack. Refused if absolute or contains `..` |
-| `max_task_duration_s` | `PROOF_PARAM_MAX_TASK_DURATION_S` | Drop pack tasks whose duration metadata is ≥ this many seconds (default **3600**). Pack `filter.json` may only **lower** the ceiling. Adaptor `duration_hints.json` default allow/exclude (n15 x0017) still applies. |
+| `max_task_duration_s` | `PROOF_PARAM_MAX_TASK_DURATION_S` | Drop pack tasks whose duration metadata is ≥ this many seconds (default **3600**). Pack `filter.json` may only **lower** the ceiling. Adaptor `duration_hints.json` default allow/exclude (n15 x0017) still applies. An **allow-listed** task is gated on its measured wall only — see below. |
 | `task_filter` | `PROOF_PARAM_TASK_FILTER` | Optional relative pack path to `filter.json` / allow-list |
 | `exclude_unknown_duration` | `PROOF_PARAM_EXCLUDE_UNKNOWN_DURATION` | `true` to drop tasks with no duration metadata |
 | `harbor_agent` | `PROOF_PARAM_HARBOR_AGENT` | Topic built-in for **baseline only** when no miner harness |
@@ -189,6 +189,14 @@ from retained n15 x0017:
   `distributed-dedup` (tmux), `coq-block-bound` (wall cut).
   `biped-contact-dynamics` / `cad-model` also stay out until verifier pytest
   is proven on metal.
+
+The deny/exclude list wins first, then the allow-list, then duration. An
+allow-listed name was measured under an hour, so only a measured
+`walls_sec` wall ≥ `max_task_duration_s` drops it — a pack `task.toml`
+`agent_timeout` is the harness ceiling, not a duration, and is ignored for
+those tasks (n15 attempt1 on pin `4a04eeb1` declared 28800 on all six and the
+3600 default emptied the pack). Every other task is still dropped on
+max(declared timeout, pack duration, adaptor hint).
 
 Do not put hour-plus or broken tasks in the default scorable pack for
 `n_concurrent` baselines or miner evals. An empty filtered copy fails closed.

--- a/deploy/guest/runners/rlm_fc_in_guest_harbor/harness/filter_tasks.py
+++ b/deploy/guest/runners/rlm_fc_in_guest_harbor/harness/filter_tasks.py
@@ -7,11 +7,14 @@ it (or an alias / ``key-`` prefix), when the adaptor ``duration_hints.json``
 ``exclude`` list names it, when it is absent from the default short-task
 allow-list, or when it is too slow for ``max_duration_s`` (default 3600).
 
-The duration gate reads two different things. An **allow-listed** task was
-measured under an hour, so only a measured wall (``walls_sec`` / adaptor hint)
-may drop it; a pack-declared ``agent_timeout`` is the harness ceiling rather
-than a duration and is ignored for it. Every other task is still excluded when
-max(declared timeout, pack duration, adaptor hint) is ≥ ``max_duration_s``.
+The duration gate reads two different things. A task named **exactly** on the
+allow-list was measured under an hour, so only a measured wall (``walls_sec`` /
+adaptor hint) may drop it; a pack-declared ``agent_timeout`` is the harness
+ceiling rather than a duration and is ignored for it. Every other task — an
+alias hit, or an unmeasured allow-list entry under a ceiling tighter than the
+``ALLOW_VETTED_UNDER_S`` the allow-list asserts — is still excluded when
+max(declared timeout, pack duration, adaptor hint) is ≥ ``max_duration_s``,
+and still honours ``exclude_unknown_duration``.
 
 Default pack filter (Dev, retained n15 x0017):
 
@@ -43,6 +46,9 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_MAX_S = 3600
+# What an allow-list entry asserts: the adaptor measured that exact task under
+# an hour. A tighter ceiling is outside that assertion.
+ALLOW_VETTED_UNDER_S = DEFAULT_MAX_S
 DEFAULT_HINTS = Path(__file__).resolve().parent / "duration_hints.json"
 TASK_MARKERS = (
     "task.toml",
@@ -337,16 +343,20 @@ def decide(
     if allow:
         if not listed(name, allow):
             return False, "not on allow-list"
-        # An allow-list entry is a measured <1h task. A pack ``task.toml``
-        # ``agent_timeout`` is the harness ceiling, not a duration, so it may
-        # not drop one (n15 attempt1: every allowlisted task declared 28800,
-        # the 3600 default then emptied the pack). Only a measured wall does.
-        wall = lookup_named(name, adaptor_hints)
-        if wall is not None and wall >= max_s:
-            return False, f"allow-list wall_s={wall} >= {max_s}"
+        # An exact allow-list entry is a task measured under
+        # ``ALLOW_VETTED_UNDER_S``. A pack ``task.toml`` ``agent_timeout`` is
+        # the harness ceiling, not a duration, so it may not drop one (n15
+        # attempt1: all six declared 28800 and the 3600 default emptied the
+        # pack). A measured wall still may, at any ceiling. An alias hit is a
+        # different task, and a ceiling tighter than the vetting bound is not
+        # covered by the allow-list, so both fall through to the metadata gate.
+        wall = lookup_named(name, adaptor_hints) if name in allow else None
         if wall is not None:
+            if wall >= max_s:
+                return False, f"allow-list wall_s={wall} >= {max_s}"
             return True, f"allow-list wall_s={wall}"
-        return True, "allow-list"
+        if name in allow and max_s >= ALLOW_VETTED_UNDER_S:
+            return True, "allow-list"
     duration = task_duration_s(task_dir, durations_map, adaptor_hints)
     if duration is None:
         if drop_unknown:

--- a/deploy/guest/runners/rlm_fc_in_guest_harbor/harness/filter_tasks.py
+++ b/deploy/guest/runners/rlm_fc_in_guest_harbor/harness/filter_tasks.py
@@ -2,11 +2,16 @@
 """Copy pack tasks that typically finish in under one hour.
 
 Duration is pack metadata plus adaptor-local measured walls (not a compiled
-Proof catalog). A task is excluded when max(declared timeout, pack duration,
-adaptor hint) is ≥ ``max_duration_s`` (default 3600), when a pack
-``filter.json`` deny-list names it (or an alias / ``key-`` prefix), when the
-adaptor ``duration_hints.json`` ``exclude`` list names it, or when it is
-absent from the default short-task allow-list.
+Proof catalog). A task is excluded when a pack ``filter.json`` deny-list names
+it (or an alias / ``key-`` prefix), when the adaptor ``duration_hints.json``
+``exclude`` list names it, when it is absent from the default short-task
+allow-list, or when it is too slow for ``max_duration_s`` (default 3600).
+
+The duration gate reads two different things. An **allow-listed** task was
+measured under an hour, so only a measured wall (``walls_sec`` / adaptor hint)
+may drop it; a pack-declared ``agent_timeout`` is the harness ceiling rather
+than a duration and is ignored for it. Every other task is still excluded when
+max(declared timeout, pack duration, adaptor hint) is ≥ ``max_duration_s``.
 
 Default pack filter (Dev, retained n15 x0017):
 
@@ -329,8 +334,19 @@ def decide(
     name = task_dir.name
     if listed(name, deny):
         return False, "deny-list"
-    if allow and not listed(name, allow):
-        return False, "not on allow-list"
+    if allow:
+        if not listed(name, allow):
+            return False, "not on allow-list"
+        # An allow-list entry is a measured <1h task. A pack ``task.toml``
+        # ``agent_timeout`` is the harness ceiling, not a duration, so it may
+        # not drop one (n15 attempt1: every allowlisted task declared 28800,
+        # the 3600 default then emptied the pack). Only a measured wall does.
+        wall = lookup_named(name, adaptor_hints)
+        if wall is not None and wall >= max_s:
+            return False, f"allow-list wall_s={wall} >= {max_s}"
+        if wall is not None:
+            return True, f"allow-list wall_s={wall}"
+        return True, "allow-list"
     duration = task_duration_s(task_dir, durations_map, adaptor_hints)
     if duration is None:
         if drop_unknown:

--- a/deploy/guest/runners/rlm_fc_in_guest_harbor/tests/test_filter_tasks.py
+++ b/deploy/guest/runners/rlm_fc_in_guest_harbor/tests/test_filter_tasks.py
@@ -371,6 +371,129 @@ class FilterTasksTests(unittest.TestCase):
                 self.assertEqual(dropped[name], "deny-list", name)
                 self.assertFalse((dest / name).exists(), name)
 
+    def test_allowlisted_task_survives_pack_agent_timeout_false_floor(self) -> None:
+        # n15 attempt1 (pin 4a04eeb1): every allowlisted task declares
+        # agent_timeout = 28800, which emptied the pack at the 3600 default.
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            for name in filter_tasks.X0017_ALLOW:
+                _task(tasks, name, 28_800)
+            dest = pack / "out"
+            summary = filter_tasks.filter_tasks(
+                tasks,
+                dest,
+                pack_dir=pack,
+                max_s=3600,
+                filter_rel=None,
+                drop_unknown=False,
+            )
+            kept = {row["name"] for row in summary["kept"]}
+            self.assertEqual(kept, set(filter_tasks.X0017_ALLOW))
+            for row in summary["kept"]:
+                self.assertEqual(row["reason"], "allow-list")
+
+    def test_deny_list_still_drops_long_tasks_at_a_raised_max(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, 28_800)
+            for name in filter_tasks.X0017_EXCLUDE:
+                _task(tasks, name, 600)
+            dest = pack / "out"
+            summary = filter_tasks.filter_tasks(
+                tasks,
+                dest,
+                pack_dir=pack,
+                max_s=30_000,
+                filter_rel=None,
+                drop_unknown=False,
+            )
+            self.assertEqual(summary["n_kept"], 1)
+            dropped = {row["name"]: row["reason"] for row in summary["dropped"]}
+            for name in filter_tasks.X0017_EXCLUDE:
+                self.assertEqual(dropped[name], "deny-list", name)
+                self.assertFalse((dest / name).exists(), name)
+
+    def test_allowlisted_task_dropped_by_measured_wall(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, 100)
+            _task(tasks, "fin-saccr-rwa", 100)
+            hints = pack / "hints.json"
+            hints.write_text(
+                json.dumps(
+                    {
+                        "allow": [KEEP, "fin-saccr-rwa"],
+                        "walls_sec": {"fin-saccr-rwa": 5400},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            dest = pack / "out"
+            summary = _generic_filter(tasks, dest, pack, hints_path=hints)
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["name"], KEEP)
+            self.assertFalse((dest / "fin-saccr-rwa").exists())
+            dropped = {row["name"]: row["reason"] for row in summary["dropped"]}
+            self.assertEqual(dropped["fin-saccr-rwa"], "allow-list wall_s=5400 >= 3600")
+
+    def test_allowlisted_task_kept_with_short_measured_wall(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, 28_800)
+            hints = pack / "hints.json"
+            hints.write_text(
+                json.dumps({"allow": [KEEP], "walls_sec": {KEEP: 900}}),
+                encoding="utf-8",
+            )
+            dest = pack / "out"
+            summary = _generic_filter(tasks, dest, pack, hints_path=hints)
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["reason"], "allow-list wall_s=900")
+
+    def test_pack_durations_do_not_drop_an_allowlisted_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, None)
+            (pack / "task_durations.json").write_text(
+                json.dumps({KEEP: 28_800}),
+                encoding="utf-8",
+            )
+            dest = pack / "out"
+            summary = filter_tasks.filter_tasks(
+                tasks,
+                dest,
+                pack_dir=pack,
+                max_s=3600,
+                filter_rel=None,
+                drop_unknown=False,
+            )
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["name"], KEEP)
+
+    def test_non_allowlisted_task_still_drops_on_declared_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, "quick", 100)
+            _task(tasks, "declared-long", 28_800)
+            dest = pack / "out"
+            summary = _generic_filter(tasks, dest, pack)
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["name"], "quick")
+            dropped = {row["name"]: row["reason"] for row in summary["dropped"]}
+            self.assertEqual(dropped["declared-long"], "duration_s=28800 >= 3600")
+
     def test_alias_match_does_not_eat_unrelated_prefix(self) -> None:
         self.assertFalse(filter_tasks.alias_match("cadillac", "cad"))
         self.assertTrue(filter_tasks.alias_match("cad-model", "cad"))

--- a/deploy/guest/runners/rlm_fc_in_guest_harbor/tests/test_filter_tasks.py
+++ b/deploy/guest/runners/rlm_fc_in_guest_harbor/tests/test_filter_tasks.py
@@ -480,6 +480,98 @@ class FilterTasksTests(unittest.TestCase):
             self.assertEqual(summary["n_kept"], 1)
             self.assertEqual(summary["kept"][0]["name"], KEEP)
 
+    def test_allow_list_alias_does_not_bypass_the_duration_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, 28_800)
+            _task(tasks, f"{KEEP}-extra", 7200)
+            (pack / "task_durations.json").write_text(
+                json.dumps({f"{KEEP}-extra": 7200}),
+                encoding="utf-8",
+            )
+            dest = pack / "out"
+            summary = filter_tasks.filter_tasks(
+                tasks,
+                dest,
+                pack_dir=pack,
+                max_s=3600,
+                filter_rel=None,
+                drop_unknown=False,
+            )
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["name"], KEEP)
+            dropped = {row["name"]: row["reason"] for row in summary["dropped"]}
+            self.assertEqual(dropped[f"{KEEP}-extra"], "duration_s=7200 >= 3600")
+
+    def test_tightened_ceiling_regates_unmeasured_allowlisted_task(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, 600)
+            _task(tasks, "fin-saccr-rwa", 28_800)
+            (pack / "filter.json").write_text(
+                json.dumps({"max_duration_s": 900}),
+                encoding="utf-8",
+            )
+            dest = pack / "out"
+            summary = filter_tasks.filter_tasks(
+                tasks,
+                dest,
+                pack_dir=pack,
+                max_s=3600,
+                filter_rel=None,
+                drop_unknown=False,
+            )
+            self.assertEqual(summary["max_duration_s"], 900)
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["reason"], "duration_s=600")
+            dropped = {row["name"]: row["reason"] for row in summary["dropped"]}
+            self.assertEqual(dropped["fin-saccr-rwa"], "duration_s=28800 >= 900")
+
+    def test_tightened_ceiling_honours_exclude_unknown_duration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, 100)
+            _task(tasks, "fin-saccr-rwa", None)
+            (pack / "filter.json").write_text(
+                json.dumps({"max_duration_s": 300, "exclude_unknown_duration": True}),
+                encoding="utf-8",
+            )
+            dest = pack / "out"
+            summary = filter_tasks.filter_tasks(
+                tasks,
+                dest,
+                pack_dir=pack,
+                max_s=3600,
+                filter_rel=None,
+                drop_unknown=False,
+            )
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["name"], KEEP)
+            dropped = {row["name"]: row["reason"] for row in summary["dropped"]}
+            self.assertEqual(dropped["fin-saccr-rwa"], "unknown duration")
+
+    def test_measured_wall_beats_declared_floor_under_a_tight_ceiling(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            tasks = pack / "tasks"
+            tasks.mkdir()
+            _task(tasks, KEEP, 28_800)
+            hints = pack / "hints.json"
+            hints.write_text(
+                json.dumps({"allow": [KEEP], "walls_sec": {KEEP: 400}}),
+                encoding="utf-8",
+            )
+            dest = pack / "out"
+            summary = _generic_filter(tasks, dest, pack, max_s=900, hints_path=hints)
+            self.assertEqual(summary["n_kept"], 1)
+            self.assertEqual(summary["kept"][0]["reason"], "allow-list wall_s=400")
+
     def test_non_allowlisted_task_still_drops_on_declared_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             pack = Path(tmp)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`deploy/guest/runners/rlm_fc_in_guest_harbor/harness/filter_tasks.py` emptied the filtered pack on metal (n15 attempt1, pin `4a04eeb1`). The adaptor allow-list of six short tasks was wired correctly, but every one of those tasks declares `agent_timeout = 28800` in its pack `task.toml`. `task_duration_s()` takes `max(declared, pack, wall)`, so each allow-listed task measured 28800 against the default `max_task_duration_s=3600` and was dropped; the deny-list took the rest, leaving 0 kept and the fail-closed empty-pack abort. The live workaround is `max_task_duration_s=30000`, which is only tolerable because the deny-list still covers the >1h tasks.

The declared `agent_timeout` is the harness ceiling, not a duration, so it must not gate a task the adaptor already measured under an hour. `decide()` now splits the gate:

1. deny / exclude still wins first (unchanged);
2. a task named **exactly** on the allow-list is gated on the measured `walls_sec` / adaptor hint only — wall ≥ `max_s` drops it, otherwise it is kept with reason `allow-list` (or `allow-list wall_s=N`); pack-declared timeouts and pack `task_durations.json` no longer drop it;
3. everything else keeps the existing `max(declared, pack, wall)` behaviour, including `exclude_unknown_duration`;
4. the six-task allow-list now survives the 3600 default without `max_task_duration_s=30000`.

The bypass is deliberately narrower than allow-list *membership*, so it cannot admit anything the old gate rejected (both cases below were raised as P1 by Greptile and fixed in `35d068e9`):

- an **alias** hit (`cargo-flight-dispatch-extra` matching `cargo-flight-dispatch`) is a different task and stays on the metadata gate;
- an allow-list entry with **no measured wall** under a ceiling tighter than the 3600 the allow-list asserts (`ALLOW_VETTED_UNDER_S`) is outside that assertion, so it falls back to the metadata gate and to `exclude_unknown_duration`. A measured wall still decides at any ceiling, so tightening cannot resurrect the false floor for a task that was actually measured.

No pins, topics, or bake scripts are touched; this is adaptor code plus its unit tests and README.

## Greptile

- [x] Greptile has reviewed this PR; findings are fixed or answered
- [x] If the bot was silent, I commented `@greptileai review`

Two P1 findings on the first pass, both fixed in `35d068e9`; the re-review after that push reported none and the check is green.

## Test plan

- [x] `bash deploy/guest/runners/rlm_fc_in_guest_harbor/tests/run.sh` — 28 `test_filter_tasks.py` cases plus the rest of the adaptor suite. New cases: all six allow-listed tasks declaring 28800 at `max_s=3600` are KEPT (this reproduces the n15 abort against the old code); every deny-list name is still dropped as `deny-list` at `max_s=30000`; an allow-listed task with `walls_sec` ≥ `max_s` is dropped; an allow-listed task with a short wall is kept; pack `task_durations.json` cannot drop an allow-listed task; a non-allow-listed task still drops on its declared 28800; an alias over budget is dropped; a tightened ceiling re-gates a declared-long allow-list entry and honours `exclude_unknown_duration`; a measured wall still beats the declared floor under a tight ceiling.
- [x] `cargo test -p proof-vm-guest --test bake_tooling` (the gate that runs this adaptor's suite from Rust)
- [x] `cargo run -p xtask -- loc-cap`
- [x] CI `fmt · clippy · test · deny · xtask` green on this branch.

## Risk

Scoring-path behaviour on the custom Harbor family only: an exactly-allow-listed task can no longer be filtered out by pack-declared metadata, which is the point. The empty-pack fail-closed abort, the deny-list, the pack `allow` intersect-only rule, and the "pack `max_duration_s` may only lower the ceiling" rule are all unchanged. No deploy pins, image digests, topics, or emission behaviour change.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f782872a-3eb0-4eba-b2b0-f4efd9beeda6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f782872a-3eb0-4eba-b2b0-f4efd9beeda6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

