### PR TITLE
fix(proof): harvest scored runs when vsock drops done

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,11 +3716,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proof-fc-harvest"
+version = "0.1.0"
+dependencies = [
+ "proof-rlm",
+ "proof-vm-agent",
+ "proof-vm-proto",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "proof-fc-host"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "hex",
+ "proof-fc-harvest",
  "proof-rlm",
  "proof-vm-agent",
  "proof-vm-proto",

--- a/bins/proof-vm-guest-agent/src/main.rs
+++ b/bins/proof-vm-guest-agent/src/main.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use clap::Parser;
 use proof_vm_guest::{GuestAgent, GuestConfig, AGENT_NAME};
 use proof_vm_proto::guest::RLM_JOB_PORT;
-use proof_vm_proto::ProtoError;
 
 /// Guest agent CLI. Every flag has a `PROOF_GUEST_*` env twin for the init
 /// script baked into the image.
@@ -138,13 +137,12 @@ async fn serve_vsock(agent: Arc<GuestAgent>, port: u32) -> Result<(), String> {
                 tracing::debug!(cid = peer.cid(), port = peer.port(), "host connected");
                 let agent = agent.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = agent
-                        .serve_connection_resending(
-                            stream,
-                            || async move { reconnect_host(port).await },
-                        )
-                        .await
-                    {
+                    // Host harvest recovers a dropped Done: this guest is the
+                    // *listen* side of RLM_JOB_PORT (Firecracker UDS `v.sock`).
+                    // The host never binds `v.sock_5000`; only sister
+                    // (`v.sock_5001`) is a guest→host listener. Do not reconnect
+                    // to CID 2 / port 5000 — that connect has nowhere to land.
+                    if let Err(e) = agent.serve_connection(stream).await {
                         tracing::warn!("host connection ended with an error: {e}");
                     }
                 });
@@ -155,14 +153,6 @@ async fn serve_vsock(agent: Arc<GuestAgent>, port: u32) -> Result<(), String> {
             }
         }
     }
-}
-
-/// Guest → host CID 2, same job port: rewrite Done/Failed after Broken pipe.
-async fn reconnect_host(port: u32) -> Result<tokio_vsock::VsockStream, ProtoError> {
-    use tokio_vsock::{VsockAddr, VsockStream, VMADDR_CID_HOST};
-    VsockStream::connect(VsockAddr::new(VMADDR_CID_HOST, port))
-        .await
-        .map_err(|e| ProtoError::Io(format!("reconnect host vsock {port}: {e}")))
 }
 
 #[cfg(test)]

--- a/bins/proof-vm-guest-agent/src/main.rs
+++ b/bins/proof-vm-guest-agent/src/main.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use clap::Parser;
 use proof_vm_guest::{GuestAgent, GuestConfig, AGENT_NAME};
 use proof_vm_proto::guest::RLM_JOB_PORT;
+use proof_vm_proto::ProtoError;
 
 /// Guest agent CLI. Every flag has a `PROOF_GUEST_*` env twin for the init
 /// script baked into the image.
@@ -137,7 +138,13 @@ async fn serve_vsock(agent: Arc<GuestAgent>, port: u32) -> Result<(), String> {
                 tracing::debug!(cid = peer.cid(), port = peer.port(), "host connected");
                 let agent = agent.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = agent.serve_connection(stream).await {
+                    if let Err(e) = agent
+                        .serve_connection_resending(
+                            stream,
+                            || async move { reconnect_host(port).await },
+                        )
+                        .await
+                    {
                         tracing::warn!("host connection ended with an error: {e}");
                     }
                 });
@@ -148,6 +155,14 @@ async fn serve_vsock(agent: Arc<GuestAgent>, port: u32) -> Result<(), String> {
             }
         }
     }
+}
+
+/// Guest → host CID 2, same job port: rewrite Done/Failed after Broken pipe.
+async fn reconnect_host(port: u32) -> Result<tokio_vsock::VsockStream, ProtoError> {
+    use tokio_vsock::{VsockAddr, VsockStream, VMADDR_CID_HOST};
+    VsockStream::connect(VsockAddr::new(VMADDR_CID_HOST, port))
+        .await
+        .map_err(|e| ProtoError::Io(format!("reconnect host vsock {port}: {e}")))
 }
 
 #[cfg(test)]

--- a/crates/proof-fc-harvest/Cargo.toml
+++ b/crates/proof-fc-harvest/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 proof-rlm = { path = "../proof-rlm", features = ["test-fixtures"] }
+tokio = { version = "1", features = ["io-util", "macros", "rt", "time", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/proof-fc-harvest/Cargo.toml
+++ b/crates/proof-fc-harvest/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "proof-fc-harvest"
+description = "Host-side scratch harvest for Proof experiment/topic VMs: reconstruct Evaluated/Baseline from guest report.json when vsock drops Done. Used by proof-fc-host; tips without a guest image rebake."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+proof-rlm = { path = "../proof-rlm" }
+proof-vm-agent = { path = "../proof-vm-agent" }
+proof-vm-proto = { path = "../proof-vm-proto" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+proof-rlm = { path = "../proof-rlm", features = ["test-fixtures"] }
+
+[lints]
+workspace = true

--- a/crates/proof-fc-harvest/src/harvest_tests.rs
+++ b/crates/proof-fc-harvest/src/harvest_tests.rs
@@ -4,11 +4,15 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use proof_rlm::fixtures::{experiment_request, request};
 use proof_rlm::{VmJob, VmJobOutput};
+use proof_vm_agent::HvError;
+use proof_vm_proto::guest::{encode_frame, read_frame, RlmToHost};
+use tokio::io::AsyncWriteExt;
 
-use super::{from_work_tree, try_from_jail, SCRATCH_TREE};
+use super::{from_work_tree, recv_job_or_harvest, try_from_jail, POLL_INTERVAL, SCRATCH_TREE};
 
 fn tree(tag: &str) -> PathBuf {
     let d = std::env::temp_dir().join(format!("proof-fc-harvest-{}-{tag}", std::process::id()));
@@ -108,5 +112,137 @@ fn a_missing_or_non_finite_report_does_not_invent_a_score() {
         panic!("{got:?}");
     };
     assert!((run.report.primary_value - 0.5).abs() < 1e-12);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+fn evaluate_job() -> VmJob {
+    VmJob::Evaluate {
+        request: experiment_request(None),
+        checklist_digest: "c".into(),
+        rules_version: 1,
+    }
+}
+
+fn archived() -> RlmToHost {
+    RlmToHost::Done {
+        output: VmJobOutput::Archived,
+    }
+}
+
+/// Recreating `recv` on each 2s poll would restart this sleep and miss the
+/// deadline. One pinned future must still deliver `Done`.
+#[tokio::test(start_paused = true)]
+async fn a_slow_vsock_done_is_not_restarted_on_scratch_poll() {
+    let root = tree("slow");
+    let job = VmJob::Archive {
+        topic_id: "t".into(),
+    };
+    let got = recv_job_or_harvest(
+        async {
+            tokio::time::sleep(POLL_INTERVAL + Duration::from_secs(1)).await;
+            Ok(archived())
+        },
+        &root,
+        &root,
+        &job,
+        Duration::from_secs(8),
+    )
+    .await
+    .expect("done");
+    assert_eq!(got, archived());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Half a length prefix sitting in the stream must not be thrown away when
+/// scratch is polled — dropping `read_exact` and starting again mis-parses
+/// the next four bytes as a length.
+#[tokio::test(start_paused = true)]
+async fn a_partial_vsock_frame_survives_scratch_poll_timeouts() {
+    let root = tree("partial");
+    let job = VmJob::Archive {
+        topic_id: "t".into(),
+    };
+    let frame = encode_frame(&archived()).expect("frame");
+    assert!(frame.len() > 4, "need a split past the length prefix");
+    let (mut tx, mut rx) = tokio::io::duplex(4096);
+    let writer = tokio::spawn(async move {
+        tx.write_all(&frame[..2]).await.expect("prefix");
+        tx.flush().await.expect("flush");
+        tokio::time::sleep(POLL_INTERVAL + Duration::from_millis(50)).await;
+        tx.write_all(&frame[2..]).await.expect("rest");
+    });
+    let got = recv_job_or_harvest(
+        async move {
+            read_frame(&mut rx)
+                .await
+                .map_err(|e| HvError::Guest(e.to_string()))
+        },
+        &root,
+        &root,
+        &job,
+        Duration::from_secs(30),
+    )
+    .await
+    .expect("frame");
+    assert_eq!(got, archived());
+    writer.await.expect("writer");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_hanging_vsock_harvests_after_done_grace() {
+    let root = tree("hang");
+    let overlay = root.join(SCRATCH_TREE).join("work");
+    plant(
+        &overlay,
+        "evaluate",
+        "0001",
+        r#"{"primary_value": 0.73, "claim_holds": true}"#,
+    );
+    let got = recv_job_or_harvest(
+        std::future::pending::<Result<RlmToHost, HvError>>(),
+        &root,
+        &root,
+        &evaluate_job(),
+        Duration::from_secs(30),
+    )
+    .await
+    .expect("harvest");
+    let RlmToHost::Done {
+        output: VmJobOutput::Evaluated(run),
+    } = got
+    else {
+        panic!("expected Evaluated, got {got:?}");
+    };
+    assert!((run.report.primary_value - 0.73).abs() < 1e-12);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[tokio::test]
+async fn a_dead_vsock_harvests_immediately_when_report_is_on_disk() {
+    let root = tree("dead");
+    let overlay = root.join(SCRATCH_TREE).join("work");
+    plant(
+        &overlay,
+        "evaluate",
+        "0001",
+        r#"{"primary_value": 0.73, "claim_holds": true}"#,
+    );
+    let got = recv_job_or_harvest(
+        async { Err(HvError::Guest("broken pipe".into())) },
+        &root,
+        &root,
+        &evaluate_job(),
+        Duration::from_secs(30),
+    )
+    .await
+    .expect("harvest");
+    let RlmToHost::Done {
+        output: VmJobOutput::Evaluated(run),
+    } = got
+    else {
+        panic!("expected Evaluated, got {got:?}");
+    };
+    assert!((run.report.primary_value - 0.73).abs() < 1e-12);
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/proof-fc-harvest/src/harvest_tests.rs
+++ b/crates/proof-fc-harvest/src/harvest_tests.rs
@@ -1,0 +1,112 @@
+//! Reconstruction tests: a planted `work/*/output/report.json` becomes
+//! `Evaluated` / `Baseline` with the adaptor's `primary_value`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+use proof_rlm::fixtures::{experiment_request, request};
+use proof_rlm::{VmJob, VmJobOutput};
+
+use super::{from_work_tree, try_from_jail, SCRATCH_TREE};
+
+fn tree(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!("proof-fc-harvest-{}-{tag}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).expect("dir");
+    d
+}
+
+fn plant(work: &Path, kind: &str, seq: &str, body: &str) {
+    let dir = work.join(format!("{seq}-{kind}")).join("output");
+    std::fs::create_dir_all(&dir).expect("output");
+    std::fs::write(dir.join("report.json"), body).expect("report");
+}
+
+#[test]
+fn harvest_on_vsock_fail_returns_evaluated_with_report_primary_value() {
+    let root = tree("eval");
+    let work = root.join("work");
+    plant(
+        &work,
+        "evaluate",
+        "0001",
+        r#"{"primary_value": 0.73, "claim_holds": true, "flops_used": 42, "evidence": {"harbor_exit": 0}}"#,
+    );
+    let job = VmJob::Evaluate {
+        request: experiment_request(None),
+        checklist_digest: "c".into(),
+        rules_version: 1,
+    };
+    let out = from_work_tree(&work, &root, &job).expect("harvest");
+    let VmJobOutput::Evaluated(run) = out else {
+        panic!("expected Evaluated, got {out:?}");
+    };
+    assert!((run.report.primary_value - 0.73).abs() < 1e-12);
+    assert_eq!(run.report.flops_used, Some(42));
+    assert!(run.report.sandboxed);
+    assert!(run.report.claim_holds);
+    assert_eq!(
+        run.report
+            .evidence
+            .get("host_harvest")
+            .and_then(|v| v.as_str()),
+        Some("vsock_done_drop")
+    );
+    run.report.verify(&experiment_request(None)).expect("bound");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_baseline_report_becomes_baseline_and_an_older_dir_is_ignored() {
+    let root = tree("base");
+    let work = root.join("work");
+    plant(&work, "baseline", "0001", r#"{"primary_value": 0.1}"#);
+    plant(
+        &work,
+        "baseline",
+        "0002",
+        r#"{"primary_value": 0.9, "claim_holds": true}"#,
+    );
+    let job = VmJob::Baseline { request: request() };
+    let out = from_work_tree(&work, &root, &job).expect("harvest");
+    let VmJobOutput::Baseline(report) = out else {
+        panic!("expected Baseline, got {out:?}");
+    };
+    assert!((report.primary_value - 0.9).abs() < 1e-12);
+    assert!(from_work_tree(
+        &work,
+        &root,
+        &VmJob::Archive {
+            topic_id: "t".into()
+        }
+    )
+    .is_err());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_missing_or_non_finite_report_does_not_invent_a_score() {
+    let root = tree("miss");
+    let work = root.join("work");
+    std::fs::create_dir_all(work.join("0001-evaluate").join("output")).expect("dir");
+    let job = VmJob::Evaluate {
+        request: request(),
+        checklist_digest: "c".into(),
+        rules_version: 1,
+    };
+    assert!(from_work_tree(&work, &root, &job).is_err());
+    plant(&work, "evaluate", "0001", r#"{"primary_value": "NaN"}"#);
+    assert!(from_work_tree(&work, &root, &job).is_err());
+    plant(&work, "evaluate", "0001", r#"{"primary_value": 1e999}"#);
+    assert!(from_work_tree(&work, &root, &job).is_err());
+    assert!(try_from_jail(&root, &root, &job).is_none());
+    let overlay = root.join(SCRATCH_TREE).join("work");
+    plant(&overlay, "evaluate", "0001", r#"{"primary_value": 0.5}"#);
+    let got = try_from_jail(&root, &root, &job).expect("overlay");
+    let VmJobOutput::Evaluated(run) = got else {
+        panic!("{got:?}");
+    };
+    assert!((run.report.primary_value - 0.5).abs() < 1e-12);
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/proof-fc-harvest/src/lib.rs
+++ b/crates/proof-fc-harvest/src/lib.rs
@@ -1,0 +1,293 @@
+//! Reconstruct a paid Proof VM job from guest artefacts on the RW scratch
+//! when vsock drops `Done`.
+//!
+//! Harbor writes `report.json` under `/var/lib/proof/work/<seq>-{evaluate,
+//! baseline}/output/` on `scratch.ext4` before the guest sends `Done`. The
+//! host sees that file as:
+//! 1. `{jail_root}/scratch-tree/work/…` (host overlay of guest `/var/lib/proof`)
+//! 2. else `debugfs -c -R 'rdump /work …'` on `{jail_root}/scratch.ext4`
+//!
+//! Only the highest-numbered matching work directory counts. Called from
+//! `proof-fc-host` after `Run` when recv fails — tips via `BUILD_FROM=source`
+//! of `proof-vm-orchestrator`, no guest rebake.
+
+#![allow(clippy::missing_errors_doc)]
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use proof_rlm::{
+    CustomRunReport, CustomRunRequest, LogFile, RunOutcome, VmJob, VmJobOutput, RUN_REPORT_SCHEMA,
+};
+use proof_vm_agent::HvError;
+use proof_vm_proto::guest::RlmToHost;
+use serde::Deserialize;
+
+/// One vsock frame from the guest. Implemented by `GuestChannel` in
+/// `proof-fc-host` so this crate does not depend on the hypervisor.
+pub trait RecvFrame {
+    /// Receive one `RlmToHost` frame.
+    fn recv_frame(&mut self) -> impl Future<Output = Result<RlmToHost, HvError>> + Send;
+}
+
+/// Overlay of guest `/var/lib/proof` beside the virtio drives.
+pub const SCRATCH_TREE: &str = "scratch-tree";
+/// Jail-relative scratch image (guest mounts it at `/var/lib/proof`).
+pub const SCRATCH_IN_JAIL: &str = "scratch.ext4";
+/// Serial console capture beside the jail.
+pub const CONSOLE_LOG: &str = "console.log";
+const MAX_LOG_BYTES: usize = 64 * 1024;
+const MAX_REPORT_BYTES: u64 = 8 * 1024 * 1024;
+/// How often a silent vsock is peeked for a scratch report.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// After a report is on disk, wait this long for a real `Done`.
+pub const DONE_GRACE: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Deserialize)]
+struct GuestReport {
+    primary_value: f64,
+    #[serde(default)]
+    claim_holds: bool,
+    #[serde(default)]
+    flops_used: Option<u64>,
+    #[serde(default)]
+    evidence: BTreeMap<String, serde_json::Value>,
+}
+
+/// Recv the job answer, or reconstruct it from scratch when vsock dies
+/// after `Run` was sent. `recv` is one vsock frame (no timeout of its own).
+pub async fn recv_job_or_harvest<R: RecvFrame>(
+    ch: &mut R,
+    jail_root: &Path,
+    jail_dir: &Path,
+    job: &VmJob,
+    budget: Duration,
+) -> Result<RlmToHost, HvError> {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return or_err(
+                jail_root,
+                jail_dir,
+                job,
+                HvError::Deadline(budget.as_secs()),
+            );
+        }
+        let slice = (deadline - now).min(POLL_INTERVAL);
+        match tokio::time::timeout(slice, ch.recv_frame()).await {
+            Ok(Ok(msg)) => return Ok(msg),
+            Ok(Err(e)) => return or_err(jail_root, jail_dir, job, e),
+            Err(_silent) => {
+                if let Some(output) = try_from_jail(jail_root, jail_dir, job) {
+                    tracing::warn!(
+                        "vsock silent after a guest report landed on scratch; waiting {:?} for Done then harvesting",
+                        DONE_GRACE
+                    );
+                    let grace = DONE_GRACE
+                        .min(deadline.saturating_duration_since(tokio::time::Instant::now()));
+                    return match tokio::time::timeout(grace, ch.recv_frame()).await {
+                        Ok(Ok(msg)) => Ok(msg),
+                        Ok(Err(e)) => {
+                            tracing::warn!("vsock died with a harvestable report: {e}");
+                            Ok(RlmToHost::Done { output })
+                        }
+                        Err(_) => Ok(RlmToHost::Done { output }),
+                    };
+                }
+            }
+        }
+    }
+}
+
+fn or_err(
+    jail_root: &Path,
+    jail_dir: &Path,
+    job: &VmJob,
+    err: HvError,
+) -> Result<RlmToHost, HvError> {
+    match try_from_jail(jail_root, jail_dir, job) {
+        Some(output) => {
+            tracing::warn!(
+                "vsock lost the Done frame ({err}); harvested guest report from scratch"
+            );
+            Ok(RlmToHost::Done { output })
+        }
+        None => Err(err),
+    }
+}
+
+/// Reconstruct a paid job from the jail's scratch. `None` = nothing to take.
+#[must_use]
+pub fn try_from_jail(jail_root: &Path, jail_dir: &Path, job: &VmJob) -> Option<VmJobOutput> {
+    let work = work_root(jail_root, jail_dir)?;
+    from_work_tree(&work, jail_dir, job).ok()
+}
+
+fn work_root(jail_root: &Path, jail_dir: &Path) -> Option<PathBuf> {
+    let overlay = jail_root.join(SCRATCH_TREE).join("work");
+    if overlay.is_dir() {
+        return Some(overlay);
+    }
+    let image = jail_root.join(SCRATCH_IN_JAIL);
+    if !image.is_file() {
+        return None;
+    }
+    let dest = jail_dir.join("harvest-work");
+    dump_ext4_work(&image, &dest).ok()?;
+    dest.is_dir().then_some(dest)
+}
+
+fn dump_ext4_work(image: &Path, dest: &Path) -> Result<(), String> {
+    let _ = std::fs::remove_dir_all(dest);
+    std::fs::create_dir_all(dest).map_err(|e| format!("mkdir {}: {e}", dest.display()))?;
+    let spec = format!("rdump /work {}", dest.display());
+    let out = std::process::Command::new("debugfs")
+        .args(["-c", "-R", &spec, &image.display().to_string()])
+        .output()
+        .map_err(|e| format!("debugfs: {e}"))?;
+    if dest.read_dir().ok().and_then(|mut d| d.next()).is_none() {
+        let tail = String::from_utf8_lossy(&out.stderr);
+        return Err(format!(
+            "debugfs dumped nothing from {} ({})",
+            image.display(),
+            tail.chars().rev().take(200).collect::<String>()
+        ));
+    }
+    Ok(())
+}
+
+/// Build [`VmJobOutput`] from a guest `work/` tree already on the host.
+pub fn from_work_tree(
+    work_root: &Path,
+    jail_dir: &Path,
+    job: &VmJob,
+) -> Result<VmJobOutput, HvError> {
+    let (kind, request) = match job {
+        VmJob::Evaluate { request, .. } => ("evaluate", request),
+        VmJob::Baseline { request } => ("baseline", request),
+        VmJob::Inspect { .. } | VmJob::ProposeRules { .. } | VmJob::Archive { .. } => {
+            return Err(HvError::Guest(
+                "scratch harvest is for baseline/evaluate only".into(),
+            ));
+        }
+    };
+    let report_path = find_report(work_root, kind).ok_or_else(|| {
+        HvError::Guest(format!(
+            "no {}/output/report.json in {}",
+            kind,
+            work_root.display()
+        ))
+    })?;
+    let run = reconstruct(request, &report_path, work_root, jail_dir)?;
+    match kind {
+        "baseline" => Ok(VmJobOutput::Baseline(run.report)),
+        _ => Ok(VmJobOutput::Evaluated(run)),
+    }
+}
+
+fn find_report(work_root: &Path, kind: &str) -> Option<PathBuf> {
+    let suffix = format!("-{kind}");
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(work_root)
+        .ok()?
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().ends_with(suffix.as_str()) && e.path().is_dir())
+        .map(|e| e.path())
+        .collect();
+    dirs.sort();
+    let last = dirs.pop()?;
+    let report = last.join("output").join("report.json");
+    report.is_file().then_some(report)
+}
+
+fn reconstruct(
+    request: &CustomRunRequest,
+    report_path: &Path,
+    work_root: &Path,
+    jail_dir: &Path,
+) -> Result<RunOutcome, HvError> {
+    let meta = std::fs::metadata(report_path)
+        .map_err(|e| HvError::Guest(format!("harvest report {}: {e}", report_path.display())))?;
+    if meta.len() == 0 || meta.len() > MAX_REPORT_BYTES {
+        return Err(HvError::Guest(format!(
+            "harvest report {} is {} bytes",
+            report_path.display(),
+            meta.len()
+        )));
+    }
+    let body = std::fs::read_to_string(report_path)
+        .map_err(|e| HvError::Guest(format!("harvest report: {e}")))?;
+    let guest: GuestReport = serde_json::from_str(&body)
+        .map_err(|e| HvError::Guest(format!("harvest report did not parse: {e}")))?;
+    if !guest.primary_value.is_finite() {
+        return Err(HvError::Guest(
+            "harvest report primary_value is not finite".into(),
+        ));
+    }
+    let mut evidence = guest.evidence;
+    if let Ok(Some(binding)) = request.experiment() {
+        evidence
+            .entry("runner".into())
+            .or_insert_with(|| serde_json::json!(binding.runner));
+        evidence
+            .entry("pack_digest".into())
+            .or_insert_with(|| serde_json::json!(binding.pack.digest));
+    }
+    evidence
+        .entry("host_harvest".into())
+        .or_insert_with(|| serde_json::json!("vsock_done_drop"));
+    let report = CustomRunReport {
+        schema_version: RUN_REPORT_SCHEMA,
+        topic_id: request.topic_id.clone(),
+        custom_id: request.custom_id.clone(),
+        submission_digest: request.submission_digest.clone(),
+        artifact_digest: request.artifact_digest.clone(),
+        rules_version: request.rules_version,
+        primary_value: guest.primary_value,
+        claim_holds: guest.claim_holds,
+        sandboxed: true,
+        flops_used: guest.flops_used,
+        evidence,
+    };
+    report
+        .verify(request)
+        .map_err(|e| HvError::Guest(format!("harvest report: {e}")))?;
+    Ok(RunOutcome {
+        report,
+        logs: collect_logs(work_root, jail_dir),
+    })
+}
+
+fn collect_logs(work_root: &Path, jail_dir: &Path) -> Vec<LogFile> {
+    let mut logs = Vec::new();
+    push_log(&mut logs, "console.log", &jail_dir.join(CONSOLE_LOG));
+    if let Ok(entries) = std::fs::read_dir(work_root) {
+        for e in entries.flatten() {
+            let output = e.path().join("output");
+            for name in ["console.log", "runner.log", "harbor.log"] {
+                push_log(&mut logs, name, &output.join(name));
+            }
+        }
+    }
+    logs
+}
+
+fn push_log(logs: &mut Vec<LogFile>, name: &str, path: &Path) {
+    let Ok(bytes) = std::fs::read(path) else {
+        return;
+    };
+    if bytes.is_empty() {
+        return;
+    }
+    let start = bytes.len().saturating_sub(MAX_LOG_BYTES);
+    logs.push(LogFile {
+        name: name.to_owned(),
+        bytes: bytes[start..].to_vec(),
+    });
+}
+
+#[cfg(test)]
+#[path = "harvest_tests.rs"]
+mod harvest_tests;

--- a/crates/proof-fc-harvest/src/lib.rs
+++ b/crates/proof-fc-harvest/src/lib.rs
@@ -25,13 +25,6 @@ use proof_vm_agent::HvError;
 use proof_vm_proto::guest::RlmToHost;
 use serde::Deserialize;
 
-/// One vsock frame from the guest. Implemented by `GuestChannel` in
-/// `proof-fc-host` so this crate does not depend on the hypervisor.
-pub trait RecvFrame {
-    /// Receive one `RlmToHost` frame.
-    fn recv_frame(&mut self) -> impl Future<Output = Result<RlmToHost, HvError>> + Send;
-}
-
 /// Overlay of guest `/var/lib/proof` beside the virtio drives.
 pub const SCRATCH_TREE: &str = "scratch-tree";
 /// Jail-relative scratch image (guest mounts it at `/var/lib/proof`).
@@ -57,15 +50,28 @@ struct GuestReport {
 }
 
 /// Recv the job answer, or reconstruct it from scratch when vsock dies
-/// after `Run` was sent. `recv` is one vsock frame (no timeout of its own).
-pub async fn recv_job_or_harvest<R: RecvFrame>(
-    ch: &mut R,
+/// after `Run` was sent.
+///
+/// `recv` is **one** vsock-frame future, kept alive for the whole wait.
+/// Framing (`read_exact` of a 4-byte length, then the body) is not
+/// cancellation-safe: wrapping `recv` in `timeout` and calling it again
+/// on the same stream drops a partial header/body and the next read
+/// mis-parses length. Scratch and the job deadline are polled beside
+/// that future; they never recreate it. Passing `GuestChannel::recv()`
+/// from `proof-fc-host` is the live path.
+pub async fn recv_job_or_harvest<F>(
+    recv: F,
     jail_root: &Path,
     jail_dir: &Path,
     job: &VmJob,
     budget: Duration,
-) -> Result<RlmToHost, HvError> {
+) -> Result<RlmToHost, HvError>
+where
+    F: Future<Output = Result<RlmToHost, HvError>>,
+{
     let deadline = tokio::time::Instant::now() + budget;
+    let mut recv = std::pin::pin!(recv);
+    let mut report_seen_at: Option<tokio::time::Instant> = None;
     loop {
         let now = tokio::time::Instant::now();
         if now >= deadline {
@@ -76,26 +82,34 @@ pub async fn recv_job_or_harvest<R: RecvFrame>(
                 HvError::Deadline(budget.as_secs()),
             );
         }
-        let slice = (deadline - now).min(POLL_INTERVAL);
-        match tokio::time::timeout(slice, ch.recv_frame()).await {
-            Ok(Ok(msg)) => return Ok(msg),
-            Ok(Err(e)) => return or_err(jail_root, jail_dir, job, e),
-            Err(_silent) => {
+        if let Some(seen) = report_seen_at {
+            if now.saturating_duration_since(seen) >= DONE_GRACE {
                 if let Some(output) = try_from_jail(jail_root, jail_dir, job) {
+                    tracing::warn!(
+                        "vsock silent after a guest report landed on scratch; harvesting after {:?}",
+                        DONE_GRACE
+                    );
+                    return Ok(RlmToHost::Done { output });
+                }
+                report_seen_at = None;
+            }
+        }
+        let slice = (deadline - now).min(POLL_INTERVAL);
+        tokio::select! {
+            biased;
+            result = &mut recv => {
+                return match result {
+                    Ok(msg) => Ok(msg),
+                    Err(e) => or_err(jail_root, jail_dir, job, e),
+                };
+            }
+            () = tokio::time::sleep(slice) => {
+                if report_seen_at.is_none() && try_from_jail(jail_root, jail_dir, job).is_some() {
                     tracing::warn!(
                         "vsock silent after a guest report landed on scratch; waiting {:?} for Done then harvesting",
                         DONE_GRACE
                     );
-                    let grace = DONE_GRACE
-                        .min(deadline.saturating_duration_since(tokio::time::Instant::now()));
-                    return match tokio::time::timeout(grace, ch.recv_frame()).await {
-                        Ok(Ok(msg)) => Ok(msg),
-                        Ok(Err(e)) => {
-                            tracing::warn!("vsock died with a harvestable report: {e}");
-                            Ok(RlmToHost::Done { output })
-                        }
-                        Err(_) => Ok(RlmToHost::Done { output }),
-                    };
+                    report_seen_at = Some(tokio::time::Instant::now());
                 }
             }
         }

--- a/crates/proof-fc-host/Cargo.toml
+++ b/crates/proof-fc-host/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 async-trait = "0.1"
 hex = "0.4"
 proof-rlm = { path = "../proof-rlm" }
+proof-fc-harvest = { path = "../proof-fc-harvest" }
 proof-vm-agent = { path = "../proof-vm-agent" }
 proof-vm-proto = { path = "../proof-vm-proto" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/proof-fc-host/src/lib.rs
+++ b/crates/proof-fc-host/src/lib.rs
@@ -452,13 +452,16 @@ impl Hypervisor for FirecrackerHypervisor {
             cancel.clone(),
         ));
         let budget = self.job_budget(job);
+        let jail_dir = root
+            .parent()
+            .map_or_else(|| root.clone(), Path::to_path_buf);
         let answer = async {
             let mut ch = vsock::GuestChannel::connect(&root, RLM_JOB_PORT).await?;
             ch.send(&HostToRlm::Run {
                 job: Box::new(job.clone()),
             })
             .await?;
-            ch.recv_within::<RlmToHost>(budget).await
+            proof_fc_harvest::recv_job_or_harvest(&mut ch, &root, &jail_dir, job, budget).await
         }
         .await;
         // The job is over: stop serving sisters, and wait for a sister still
@@ -737,6 +740,33 @@ mod tests {
         })
     }
 
+    /// A guest that says hello, then drops the job connection after reading
+    /// `Run` — Broken pipe / EOF, no `Done`. The host must harvest scratch.
+    fn serve_fake_guest_dropping_done(root: PathBuf) -> tokio::task::JoinHandle<VmJob> {
+        use proof_vm_proto::guest::{read_frame, write_frame};
+        tokio::spawn(async move {
+            let listener = bind_when_ready(&root).await;
+            let mut stream = accept_vsock(&listener).await;
+            let hello: HostToRlm = read_frame(&mut stream).await.expect("hello");
+            assert!(matches!(hello, HostToRlm::Hello { .. }));
+            write_frame(
+                stream.get_mut(),
+                &RlmToHost::Ready {
+                    agent: "fake-rlm-guest-done-drop".into(),
+                    api_version: API_VERSION,
+                },
+            )
+            .await
+            .expect("ready");
+            let mut stream = accept_vsock(&listener).await;
+            let HostToRlm::Run { job } = read_frame(&mut stream).await.expect("job") else {
+                panic!("expected a job");
+            };
+            drop(stream);
+            *job
+        })
+    }
+
     /// A guest that says hello, then answers its one job with `Failed`
     /// carrying `error` — what the contract demands of an RLM whose artefact
     /// fetch failed or did not verify. Never a sister request, never `Done`.
@@ -920,6 +950,55 @@ mod tests {
             shell.calls()
         );
         assert!(hv.alive(&vm).await, "the topic VM outlives its failed job");
+        assert!(hv
+            .teardown(&vm, RetainPolicy::Destroy)
+            .await
+            .expect("teardown"));
+        let _ = std::fs::remove_dir_all(c.chroot_base.parent().unwrap_or(&c.chroot_base));
+    }
+
+    /// P0: vsock EOF after `Run` with Harbor's `report.json` already on
+    /// scratch must return `Evaluated` (`primary_value` kept), not sit until
+    /// the job budget and refuse. Stand-in process + fake guest, no FC.
+    #[tokio::test]
+    async fn harvest_on_vsock_fail_returns_evaluated_with_report_primary_value() {
+        let c = stand_in_host("donedrop");
+        let req = proof_rlm::fixtures::experiment_request(None);
+        let spec = TopicVmSpec::for_topic(&req.topic_id, pinned_template(), req.sandbox.clone());
+        let shell = Arc::new(RecordingShell::default());
+        let hv = FirecrackerHypervisor::with_shell(c.clone(), shell.clone()).expect("config");
+        let guest = serve_fake_guest_dropping_done(c.jail_root("topic-a-0004"));
+        let vm = hv
+            .boot_verified("topic-a-0004", &spec, c.image_dir.join("rlm.ext4"))
+            .await
+            .expect("boot");
+        let work = c
+            .jail_root("topic-a-0004")
+            .join(proof_fc_harvest::SCRATCH_TREE)
+            .join("work");
+        std::fs::create_dir_all(work.join("0001-evaluate").join("output")).expect("work");
+        std::fs::write(
+            work.join("0001-evaluate").join("output").join("report.json"),
+            r#"{"primary_value": 0.73, "claim_holds": true, "flops_used": 42, "evidence": {"harbor_exit": 0}}"#,
+        )
+        .expect("report");
+        let job = VmJob::Evaluate {
+            request: req.clone(),
+            checklist_digest: "c".into(),
+            rules_version: 1,
+        };
+        let out = hv.run_job(&vm, &job).await.expect("harvested, not refused");
+        let proof_rlm::VmJobOutput::Evaluated(run) = out.output else {
+            panic!("expected Evaluated, got {:?}", out.output);
+        };
+        assert!(
+            (run.report.primary_value - 0.73).abs() < 1e-12,
+            "primary_value {}",
+            run.report.primary_value
+        );
+        assert_eq!(run.report.flops_used, Some(42));
+        assert!(run.report.sandboxed);
+        let _ = guest.await;
         assert!(hv
             .teardown(&vm, RetainPolicy::Destroy)
             .await

--- a/crates/proof-fc-host/src/lib.rs
+++ b/crates/proof-fc-host/src/lib.rs
@@ -461,7 +461,7 @@ impl Hypervisor for FirecrackerHypervisor {
                 job: Box::new(job.clone()),
             })
             .await?;
-            proof_fc_harvest::recv_job_or_harvest(&mut ch, &root, &jail_dir, job, budget).await
+            proof_fc_harvest::recv_job_or_harvest(ch.recv(), &root, &jail_dir, job, budget).await
         }
         .await;
         // The job is over: stop serving sisters, and wait for a sister still

--- a/crates/proof-fc-host/src/vsock.rs
+++ b/crates/proof-fc-host/src/vsock.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use proof_vm_agent::HvError;
-use proof_vm_proto::guest::{read_frame, write_frame};
+use proof_vm_proto::guest::{read_frame, write_frame, RlmToHost};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -130,6 +130,14 @@ impl GuestChannel {
         tokio::time::timeout(budget, self.recv())
             .await
             .map_err(|_| HvError::Deadline(budget.as_secs()))?
+    }
+}
+
+impl proof_fc_harvest::RecvFrame for GuestChannel {
+    fn recv_frame(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<RlmToHost, HvError>> + Send {
+        self.recv()
     }
 }
 

--- a/crates/proof-fc-host/src/vsock.rs
+++ b/crates/proof-fc-host/src/vsock.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use proof_vm_agent::HvError;
-use proof_vm_proto::guest::{read_frame, write_frame, RlmToHost};
+use proof_vm_proto::guest::{read_frame, write_frame};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -130,14 +130,6 @@ impl GuestChannel {
         tokio::time::timeout(budget, self.recv())
             .await
             .map_err(|_| HvError::Deadline(budget.as_secs()))?
-    }
-}
-
-impl proof_fc_harvest::RecvFrame for GuestChannel {
-    fn recv_frame(
-        &mut self,
-    ) -> impl std::future::Future<Output = Result<RlmToHost, HvError>> + Send {
-        self.recv()
     }
 }
 

--- a/crates/proof-vm-guest/src/agent_tests.rs
+++ b/crates/proof-vm-guest/src/agent_tests.rs
@@ -823,6 +823,57 @@ async fn serve_connection_speaks_frames_until_the_host_hangs_up() {
     let _ = std::fs::remove_dir_all(&r);
 }
 
+/// After `handle(Run)` the `Done` write hits a broken pipe: retry reconnects
+/// and the host still gets the frame. Host harvest does not need this.
+#[tokio::test]
+async fn a_broken_pipe_on_done_retries_on_a_new_connection() {
+    let r = root("retry");
+    let a = agent(&r);
+    hello(&a).await;
+    let (mut host, guest) = tokio::io::duplex(1 << 20);
+    let (mut host2, guest2) = tokio::io::duplex(1 << 20);
+    let slot = std::sync::Arc::new(tokio::sync::Mutex::new(Some(guest2)));
+    let server = {
+        let a = a.clone();
+        tokio::spawn(async move {
+            a.serve_connection_resending(guest, move || {
+                let slot = slot.clone();
+                async move {
+                    slot.lock()
+                        .await
+                        .take()
+                        .ok_or_else(|| proof_vm_proto::ProtoError::Io("no retry stream".into()))
+                }
+            })
+            .await
+        })
+    };
+    write_frame(
+        &mut host,
+        &HostToRlm::Run {
+            job: Box::new(VmJob::Archive {
+                topic_id: "topic-a".into(),
+            }),
+        },
+    )
+    .await
+    .expect("job");
+    drop(host);
+    let done: RlmToHost =
+        tokio::time::timeout(std::time::Duration::from_secs(5), read_frame(&mut host2))
+            .await
+            .expect("retried before timeout")
+            .expect("retried done");
+    assert_eq!(
+        done,
+        RlmToHost::Done {
+            output: VmJobOutput::Archived
+        }
+    );
+    server.await.expect("join").expect("ok after retry");
+    let _ = std::fs::remove_dir_all(&r);
+}
+
 /// The miner's own BYOK environment reaches their paid run: exported under
 /// the name the signed topic declared, written to a 0600 file beside it, and
 /// blanked out of everything the guest ships back. It is not part of the

--- a/crates/proof-vm-guest/src/agent_tests.rs
+++ b/crates/proof-vm-guest/src/agent_tests.rs
@@ -823,30 +823,18 @@ async fn serve_connection_speaks_frames_until_the_host_hangs_up() {
     let _ = std::fs::remove_dir_all(&r);
 }
 
-/// After `handle(Run)` the `Done` write hits a broken pipe: retry reconnects
-/// and the host still gets the frame. Host harvest does not need this.
+/// After `handle(Run)` the `Done` write hits a broken pipe: the session is
+/// still Ok. The guest does not open a new host vsock (the host never
+/// listens on `v.sock_5000`); host harvest reads `report.json`.
 #[tokio::test]
-async fn a_broken_pipe_on_done_retries_on_a_new_connection() {
+async fn a_broken_pipe_on_done_is_ok_host_harvest_recovers() {
     let r = root("retry");
     let a = agent(&r);
     hello(&a).await;
     let (mut host, guest) = tokio::io::duplex(1 << 20);
-    let (mut host2, guest2) = tokio::io::duplex(1 << 20);
-    let slot = std::sync::Arc::new(tokio::sync::Mutex::new(Some(guest2)));
     let server = {
         let a = a.clone();
-        tokio::spawn(async move {
-            a.serve_connection_resending(guest, move || {
-                let slot = slot.clone();
-                async move {
-                    slot.lock()
-                        .await
-                        .take()
-                        .ok_or_else(|| proof_vm_proto::ProtoError::Io("no retry stream".into()))
-                }
-            })
-            .await
-        })
+        tokio::spawn(async move { a.serve_connection(guest).await })
     };
     write_frame(
         &mut host,
@@ -859,18 +847,10 @@ async fn a_broken_pipe_on_done_retries_on_a_new_connection() {
     .await
     .expect("job");
     drop(host);
-    let done: RlmToHost =
-        tokio::time::timeout(std::time::Duration::from_secs(5), read_frame(&mut host2))
-            .await
-            .expect("retried before timeout")
-            .expect("retried done");
-    assert_eq!(
-        done,
-        RlmToHost::Done {
-            output: VmJobOutput::Archived
-        }
-    );
-    server.await.expect("join").expect("ok after retry");
+    server
+        .await
+        .expect("join")
+        .expect("ok; host harvest recovers");
     let _ = std::fs::remove_dir_all(&r);
 }
 

--- a/crates/proof-vm-guest/src/lib.rs
+++ b/crates/proof-vm-guest/src/lib.rs
@@ -160,51 +160,6 @@ impl GuestAgent {
         }
     }
 
-    /// [`serve_connection`] that, after `Done` / `Failed` hits a broken-pipe
-    /// I/O error, opens a fresh channel via `reconnect` and rewrites the
-    /// frame. The host harvest path does not need this (tips without a guest
-    /// rebake); this is the guest-side belt after the image is rebaked.
-    pub async fn serve_connection_resending<S, R, Fut, S2>(
-        &self,
-        mut stream: S,
-        reconnect: R,
-    ) -> Result<(), ProtoError>
-    where
-        S: AsyncRead + AsyncWrite + Unpin,
-        R: Fn() -> Fut,
-        Fut: std::future::Future<Output = Result<S2, ProtoError>>,
-        S2: AsyncRead + AsyncWrite + Unpin,
-    {
-        loop {
-            let msg: HostToRlm = match read_frame(&mut stream).await {
-                Ok(m) => m,
-                Err(ProtoError::Io(_)) => return Ok(()),
-                Err(e) => return Err(e),
-            };
-            let terminal = matches!(&msg, HostToRlm::Run { .. });
-            let answer = self.handle(msg).await;
-            if let Err(e) = write_frame_retry(&mut stream, &answer).await {
-                if terminal && broken_pipe(&e) {
-                    tracing::warn!(
-                        "terminal frame not delivered ({e}); reconnecting to rewrite Done/Failed"
-                    );
-                    match reconnect().await {
-                        Ok(mut s2) => {
-                            if let Err(e2) = write_frame(&mut s2, &answer).await {
-                                tracing::warn!(
-                                    "terminal frame rewrite on a new connection failed: {e2}"
-                                );
-                            }
-                        }
-                        Err(e2) => tracing::warn!("terminal frame reconnect failed: {e2}"),
-                    }
-                    return Ok(());
-                }
-                return Err(e);
-            }
-        }
-    }
-
     /// Answer one host message. Never panics, never leaks a secret.
     pub async fn handle(&self, msg: HostToRlm) -> RlmToHost {
         match msg {

--- a/crates/proof-vm-guest/src/lib.rs
+++ b/crates/proof-vm-guest/src/lib.rs
@@ -44,6 +44,7 @@ pub mod staging;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use proof_rlm::{CustomRunRequest, VmJob, VmJobOutput};
 use proof_vm_proto::guest::{check_version, read_frame, write_frame, HostToRlm, RlmToHost};
@@ -56,6 +57,11 @@ pub use staging::StagedPack;
 
 /// Agent name reported on `Ready`.
 pub const AGENT_NAME: &str = concat!("proof-vm-guest-agent/", env!("CARGO_PKG_VERSION"));
+/// Bounded retries when `write_frame(Done/Failed)` hits a broken vsock after
+/// the job has already finished (host harvest still recovers without this).
+pub const TERMINAL_WRITE_ATTEMPTS: u32 = 4;
+/// Backoff between terminal-frame retries.
+pub const TERMINAL_WRITE_BACKOFF: Duration = Duration::from_millis(50);
 
 /// Where the guest keeps what the host stages and what runs produce.
 #[derive(Debug, Clone)]
@@ -140,8 +146,62 @@ impl GuestAgent {
                 Err(ProtoError::Io(_)) => return Ok(()),
                 Err(e) => return Err(e),
             };
+            let terminal = matches!(&msg, HostToRlm::Run { .. });
             let answer = self.handle(msg).await;
-            write_frame(&mut stream, &answer).await?;
+            if let Err(e) = write_frame_retry(&mut stream, &answer).await {
+                if terminal && broken_pipe(&e) {
+                    tracing::warn!(
+                        "terminal frame not delivered ({e}); host harvest recovers the report"
+                    );
+                    return Ok(());
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    /// [`serve_connection`] that, after `Done` / `Failed` hits a broken-pipe
+    /// I/O error, opens a fresh channel via `reconnect` and rewrites the
+    /// frame. The host harvest path does not need this (tips without a guest
+    /// rebake); this is the guest-side belt after the image is rebaked.
+    pub async fn serve_connection_resending<S, R, Fut, S2>(
+        &self,
+        mut stream: S,
+        reconnect: R,
+    ) -> Result<(), ProtoError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+        R: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<S2, ProtoError>>,
+        S2: AsyncRead + AsyncWrite + Unpin,
+    {
+        loop {
+            let msg: HostToRlm = match read_frame(&mut stream).await {
+                Ok(m) => m,
+                Err(ProtoError::Io(_)) => return Ok(()),
+                Err(e) => return Err(e),
+            };
+            let terminal = matches!(&msg, HostToRlm::Run { .. });
+            let answer = self.handle(msg).await;
+            if let Err(e) = write_frame_retry(&mut stream, &answer).await {
+                if terminal && broken_pipe(&e) {
+                    tracing::warn!(
+                        "terminal frame not delivered ({e}); reconnecting to rewrite Done/Failed"
+                    );
+                    match reconnect().await {
+                        Ok(mut s2) => {
+                            if let Err(e2) = write_frame(&mut s2, &answer).await {
+                                tracing::warn!(
+                                    "terminal frame rewrite on a new connection failed: {e2}"
+                                );
+                            }
+                        }
+                        Err(e2) => tracing::warn!("terminal frame reconnect failed: {e2}"),
+                    }
+                    return Ok(());
+                }
+                return Err(e);
+            }
         }
     }
 
@@ -304,6 +364,48 @@ impl GuestAgent {
         )
         .await
     }
+}
+
+fn broken_pipe(err: &ProtoError) -> bool {
+    match err {
+        ProtoError::Io(s) => {
+            let s = s.to_ascii_lowercase();
+            s.contains("broken pipe")
+                || s.contains("brokenpipe")
+                || s.contains("connection reset")
+                || s.contains("connection abort")
+                || s.contains("not connected")
+                || s.contains("os error 32")
+                || s.contains("os error 104")
+                || s.contains("unexpected eof")
+                || s.contains("early eof")
+        }
+        ProtoError::FrameTooLarge(_) | ProtoError::Decode(_) | ProtoError::WrongVersion { .. } => {
+            false
+        }
+    }
+}
+
+async fn write_frame_retry<W: AsyncWrite + Unpin>(
+    w: &mut W,
+    value: &RlmToHost,
+) -> Result<(), ProtoError> {
+    let mut last = None;
+    for i in 0..TERMINAL_WRITE_ATTEMPTS {
+        match write_frame(w, value).await {
+            Ok(()) => return Ok(()),
+            Err(e) if broken_pipe(&e) => {
+                tracing::warn!(
+                    "terminal frame write failed ({e}); retry {}/{TERMINAL_WRITE_ATTEMPTS}",
+                    i + 1
+                );
+                last = Some(e);
+                tokio::time::sleep(TERMINAL_WRITE_BACKOFF.saturating_mul(i + 1)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last.unwrap_or_else(|| ProtoError::Io("terminal frame not delivered".into())))
 }
 
 /// Where the agent resolves relative layout paths from (tests point this at

--- a/crates/proof-vm-guest/src/runner.rs
+++ b/crates/proof-vm-guest/src/runner.rs
@@ -628,6 +628,12 @@ async fn kill_group(pid: Option<u32>) {
         .await;
 }
 
+fn sync_file(path: &Path) {
+    if let Ok(f) = std::fs::File::open(path) {
+        let _ = f.sync_all();
+    }
+}
+
 fn read_output_doc<T: for<'de> Deserialize<'de>>(path: &Path, what: &str) -> Result<T, String> {
     let meta = std::fs::metadata(path)
         .map_err(|_| format!("adaptor wrote no {what} ({})", path.display()))?;
@@ -734,6 +740,9 @@ pub async fn run_paid(
     if exec.timed_out {
         return Err(describe(&exec, &secrets, request.sandbox.deadline_s));
     }
+    // Push the adaptor's report to the virtio-blk before Done, so a host
+    // scratch harvest can see it if vsock then drops.
+    sync_file(&output.join("report.json"));
     let report: RunnerReport = read_output_doc(&output.join("report.json"), "report.json")
         .map_err(|e| {
             format!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Harbor can finish in the experiment VM and write `/var/lib/proof/work/<seq>-evaluate/output/report.json`, then guest `write_frame(Done)` fails with `channel: Broken pipe`. The host vsock is gone; the CP sees `evaluating → refused; no row` even though the score is on disk.

**Host harvest (tips without guest rebake):** after `Run` is sent, if vsock recv fails or stays silent after a report is on disk, `proof-fc-harvest` reads scratch `report.json` and returns `RlmToHost::Done` so the job persists as Evaluated/Baseline (`sandboxed: true`, `host_harvest: vsock_done_drop`). Sources, in order:

1. `{jail_root}/scratch-tree/work/` (host overlay of guest `/var/lib/proof`)
2. else `debugfs -c -R 'rdump /work …'` on `{jail_root}/scratch.ext4`

Only the highest-numbered matching work dir counts. Missing or non-finite report → original vsock error (Harbor never finished).

**Recv is cancellation-safe (Greptile P1-1):** `recv_job_or_harvest` takes **one** vsock-frame future and pins it. Scratch and the job deadline are polled beside that future via `select!`. We do **not** wrap `recv` in `timeout` and call it again on the same stream (a partial 4-byte length / body would be dropped and the next read would mis-parse).

**Guest (Greptile P1-2):** harvest-primary. Same-stream `write_frame_retry` on Broken pipe; **no** guest→host reconnect to CID 2 / `RLM_JOB_PORT` (host never binds `v.sock_5000`; only sister `v.sock_5001`). A dropped terminal frame is Ok; host harvest reads `report.json`. Guest image rebake is optional and not required to tip.

## Tip binaries

**Host-only tip (no rebake, no pin/reseal):** on the KVM host, `BUILD_FROM=source` rebuild of **`proof-vm-orchestrator`** (`cargo build --release -p proof-vm-orchestrator-bin`), install, `systemctl restart proof-vm-orchestrator`. Crates: `proof-fc-harvest`, `proof-fc-host` (pulled by `proof-fc-experiment` → orchestrator). Control-plane binary is unchanged.

**Guest agent:** no reconnect path to tip; rebake is optional.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [ ] Greptile has reviewed this PR; findings are fixed or answered
- [ ] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `cargo test -p proof-fc-host -p proof-fc-harvest -p proof-vm-guest -p proof-vm-guest-agent-bin`
  - harvest reconstructs Evaluated (0.73) / Baseline (newest dir); refuses missing/NaN/Inf
  - `harvest_on_vsock_fail_returns_evaluated_with_report_primary_value`
  - `a_slow_vsock_done_is_not_restarted_on_scratch_poll`
  - `a_partial_vsock_frame_survives_scratch_poll_timeouts`
  - `a_hanging_vsock_harvests_after_done_grace`
  - `a_broken_pipe_on_done_is_ok_host_harvest_recovers`
- [x] `cargo clippy -p proof-fc-host -p proof-fc-harvest -p proof-vm-guest -p proof-vm-guest-agent-bin --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- loc-cap` (`proof-fc-host` 1476 / 1500)
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --workspace` (subset above is the new path; CI runs the rest)

## Risk

Host-only: a scored `report.json` on scratch after vsock drop now persists instead of 503/no-row. Harvest refuses non-finite / missing reports so a half-run cannot invent a score. Guest image digest is unchanged. No `BASE_*` / pin / seal changes.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6ca9fe1-d751-4159-b857-cacd07e7dfcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6ca9fe1-d751-4159-b857-cacd07e7dfcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

