### PR TITLE
fix(proof): seed pf id allocator past proof_artefact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,6 +3646,7 @@ dependencies = [
  "proof-rlm",
  "proof-rlm-scorer",
  "proof-rlm-store",
+ "proof-store",
  "proof-submit",
  "proof-task",
  "proof-vm-agent",
@@ -3860,6 +3861,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/bins/proof-challenge/Cargo.toml
+++ b/bins/proof-challenge/Cargo.toml
@@ -38,6 +38,7 @@ tracing = "0.1"
 crypto = { path = "../../crates/crypto" }
 hex = "0.4"
 proof-rlm = { path = "../../crates/proof-rlm", features = ["test-fixtures"] }
+proof-store = { path = "../../crates/proof-store" }
 proof-submit = { path = "../../crates/proof-submit" }
 proof-vm-agent = { path = "../../crates/proof-vm-agent", features = ["test-fixtures"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/bins/proof-challenge/src/main.rs
+++ b/bins/proof-challenge/src/main.rs
@@ -677,7 +677,9 @@ async fn resolve_rlm_store(cli: &Cli) -> Result<Arc<dyn RlmStore>, String> {
 
 /// Raise the in-memory `pf_…` allocator past every id already used as
 /// artefact metadata (Postgres) or a zip basename under `PROOF_ARTEFACT_ROOT`.
-/// A fresh store with neither still mints from 0.
+/// A fresh store with neither still mints from 0. An unreadable artefact
+/// tree is fatal: skipping it would under-seed and collide with a zip the
+/// scan could not see.
 async fn seed_pf_allocator(
     store: &MemoryStore,
     rlm: &dyn RlmStore,
@@ -687,7 +689,12 @@ async fn seed_pf_allocator(
         .max_artefact_numeric_id()
         .await
         .map_err(|e| format!("seed pf ids from rlm store: {e}"))?;
-    let from_disk = max_zip_numeric_id(artefact_root);
+    let from_disk = max_zip_numeric_id(artefact_root).map_err(|e| {
+        format!(
+            "seed pf ids from artefact root {}: {e}",
+            artefact_root.display()
+        )
+    })?;
     let Some(used) = [from_pg, from_disk].into_iter().flatten().max() else {
         tracing::info!("pf id allocator starts at 0 (no existing artefacts)");
         return Ok(());
@@ -1096,6 +1103,27 @@ mod tests {
             .expect("mint");
         assert_eq!(row.id, "pf_000000000000000b");
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn seed_pf_allocator_refuses_boot_when_the_artefact_scan_fails() {
+        let root = std::env::temp_dir().join(format!(
+            "proof-seed-notdir-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::write(&root, b"not a directory").expect("file");
+        let err = seed_pf_allocator(&MemoryStore::new(), &MemoryRlmStore::new(), &root)
+            .await
+            .expect_err("incomplete scan must refuse boot");
+        assert!(
+            err.contains("artefact root"),
+            "boot error must name the scan: {err}"
+        );
+        let _ = std::fs::remove_file(&root);
     }
 
     #[test]

--- a/bins/proof-challenge/src/main.rs
+++ b/bins/proof-challenge/src/main.rs
@@ -35,7 +35,7 @@ use proof_rlm::{
     ExperimentPolicy, RunnerRegistry, TopicVmOrchestrator, UnwiredVmOrchestrator, VmBackedRunner,
     VmTemplate, RLM_VM_IMAGE_DIGEST_ENV, VM_ORCHESTRATOR_TOKEN_FILE_ENV, VM_ORCHESTRATOR_URL_ENV,
 };
-use proof_rlm_scorer::{ArtefactStore, RlmScorer};
+use proof_rlm_scorer::{max_zip_numeric_id, ArtefactStore, RlmScorer};
 use proof_rlm_store::{MemoryRlmStore, PgRlmStore, RlmStore};
 use proof_vm_fc::{parse_custom_ids, FirecrackerOrchestrator, VM_RUNNER_CUSTOM_IDS_ENV};
 use tokio::net::TcpListener;
@@ -243,10 +243,14 @@ fn run(cli: &Cli) -> Result<(), String> {
     // One topic-VM orchestrator per process: the runner registry drives it
     // and the admin probe reports on the same client (bearer file, pin, CA).
     let vm = Arc::new(topic_vm_orchestrator());
+    let store = MemoryStore::new().with_miner_byok_vault(miner_byok_vault());
+    rt.block_on(seed_pf_allocator(
+        &store,
+        rlm_store.as_ref(),
+        &cli.artefact_root,
+    ))?;
     let live_scorer = live_scorer(backend, harvest, rlm_store, &cli.artefact_root, &vm);
     log_live_wiring(backend, live_scorer.as_deref(), &cli.artefact_root);
-
-    let store = MemoryStore::new().with_miner_byok_vault(miner_byok_vault());
     let registered = registered_custom(live_scorer.as_deref());
     match load_topics(&store, &pin, cli.topics_file.as_deref(), &registered) {
         Ok(n) => tracing::info!(topics = n, "signed topics loaded"),
@@ -671,6 +675,33 @@ async fn resolve_rlm_store(cli: &Cli) -> Result<Arc<dyn RlmStore>, String> {
     Ok(Arc::new(PgRlmStore::new(pool)))
 }
 
+/// Raise the in-memory `pf_…` allocator past every id already used as
+/// artefact metadata (Postgres) or a zip basename under `PROOF_ARTEFACT_ROOT`.
+/// A fresh store with neither still mints from 0.
+async fn seed_pf_allocator(
+    store: &MemoryStore,
+    rlm: &dyn RlmStore,
+    artefact_root: &Path,
+) -> Result<(), String> {
+    let from_pg = rlm
+        .max_artefact_numeric_id()
+        .await
+        .map_err(|e| format!("seed pf ids from rlm store: {e}"))?;
+    let from_disk = max_zip_numeric_id(artefact_root);
+    let Some(used) = [from_pg, from_disk].into_iter().flatten().max() else {
+        tracing::info!("pf id allocator starts at 0 (no existing artefacts)");
+        return Ok(());
+    };
+    store.seed_next_id(used).map_err(|e| e.to_string())?;
+    tracing::info!(
+        used,
+        from_pg,
+        from_disk,
+        "pf id allocator seeded past existing artefacts"
+    );
+    Ok(())
+}
+
 fn load_inference_api_key(path: Option<&Path>) -> Option<String> {
     let p = path?;
     std::fs::read_to_string(p)
@@ -968,6 +999,100 @@ mod tests {
     fn emit_poll_secs_defaults_to_the_bounty_cadence() {
         assert_eq!(cli().emit_poll_secs, DEFAULT_EMIT_POLL_SECS);
         assert_eq!(DEFAULT_EMIT_POLL_SECS, 120);
+    }
+
+    fn artefact_row(submission_id: &str) -> proof_rlm_store::ArtefactRow {
+        proof_rlm_store::ArtefactRow {
+            topic_id: "topic-a".into(),
+            submission_id: submission_id.into(),
+            submission_digest: "ab".repeat(32),
+            path: format!("/artefacts/topic-a/{submission_id}.zip"),
+            sha256: "aa".repeat(32),
+            bytes: 1,
+            primary_value: None,
+            checklist_green: false,
+            promoted: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn seed_pf_allocator_starts_at_zero_without_existing_ids() {
+        let store = MemoryStore::new();
+        seed_pf_allocator(&store, &MemoryRlmStore::new(), Path::new("/no/such/artefacts"))
+            .await
+            .expect("seed");
+        let row = store
+            .insert(proof_store::Submission {
+                id: String::new(),
+                topic_id: "t".into(),
+                miner_hotkey: "aa".repeat(32),
+                artifact_digest: "11".repeat(32),
+                artifact_uri: None,
+                claim: "c".into(),
+                declared_flops: 1,
+                architecture: String::new(),
+                inference_offer_id: String::new(),
+                config_commitment: String::new(),
+                executor_offer_id: String::new(),
+                executor_commitment: String::new(),
+                manifest: proof_store::ArtifactManifest::default(),
+                submission_digest: "dd".repeat(32),
+                nonce: "n".into(),
+                submit_nonce: "ee".repeat(32),
+                state: proof_store::SubmissionState::Queued,
+                receipt_json: None,
+                verdict: None,
+                detail: None,
+            })
+            .expect("mint");
+        assert_eq!(row.id, "pf_0000000000000000");
+    }
+
+    #[tokio::test]
+    async fn seed_pf_allocator_takes_the_max_of_store_and_disk() {
+        let rlm = MemoryRlmStore::new();
+        rlm.put_artefact(&artefact_row("pf_0000000000000001"))
+            .await
+            .expect("pg row");
+        let root = std::env::temp_dir().join(format!(
+            "proof-seed-disk-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(root.join("topic-b")).expect("dir");
+        std::fs::write(root.join("topic-b").join("pf_000000000000000a.zip"), b"z")
+            .expect("zip");
+        let store = MemoryStore::new();
+        seed_pf_allocator(&store, &rlm, &root).await.expect("seed");
+        let row = store
+            .insert(proof_store::Submission {
+                id: String::new(),
+                topic_id: "t".into(),
+                miner_hotkey: "aa".repeat(32),
+                artifact_digest: "11".repeat(32),
+                artifact_uri: None,
+                claim: "c".into(),
+                declared_flops: 1,
+                architecture: String::new(),
+                inference_offer_id: String::new(),
+                config_commitment: String::new(),
+                executor_offer_id: String::new(),
+                executor_commitment: String::new(),
+                manifest: proof_store::ArtifactManifest::default(),
+                submission_digest: "dd".repeat(32),
+                nonce: "n".into(),
+                submit_nonce: "ee".repeat(32),
+                state: proof_store::SubmissionState::Queued,
+                receipt_json: None,
+                verdict: None,
+                detail: None,
+            })
+            .expect("mint");
+        assert_eq!(row.id, "pf_000000000000000b");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/bins/proof-challenge/src/main.rs
+++ b/bins/proof-challenge/src/main.rs
@@ -1126,6 +1126,34 @@ mod tests {
         let _ = std::fs::remove_file(&root);
     }
 
+    #[tokio::test]
+    async fn seed_pf_allocator_refuses_boot_when_a_topic_dir_cannot_be_read() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = std::env::temp_dir().join(format!(
+            "proof-seed-topic-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(root.join("topic-a")).expect("a");
+        std::fs::create_dir_all(root.join("topic-b")).expect("b");
+        std::fs::write(root.join("topic-a").join("pf_0000000000000001.zip"), b"a").expect("zip");
+        std::fs::write(root.join("topic-b").join("pf_00000000000000ff.zip"), b"b").expect("zip");
+        let topic_b = root.join("topic-b");
+        let restore = std::fs::metadata(&topic_b).expect("meta").permissions();
+        std::fs::set_permissions(&topic_b, std::fs::Permissions::from_mode(0o000)).expect("lock");
+        let err = seed_pf_allocator(&MemoryStore::new(), &MemoryRlmStore::new(), &root).await;
+        let _ = std::fs::set_permissions(&topic_b, restore);
+        let err = err.expect_err("incomplete topic scan must refuse boot");
+        assert!(
+            err.contains("artefact root") || err.contains("topic dir"),
+            "boot error must name the scan: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     fn scored_epoch_file_defaults_to_the_artifacts_volume() {
         assert_eq!(

--- a/bins/proof-challenge/src/main.rs
+++ b/bins/proof-challenge/src/main.rs
@@ -1018,9 +1018,13 @@ mod tests {
     #[tokio::test]
     async fn seed_pf_allocator_starts_at_zero_without_existing_ids() {
         let store = MemoryStore::new();
-        seed_pf_allocator(&store, &MemoryRlmStore::new(), Path::new("/no/such/artefacts"))
-            .await
-            .expect("seed");
+        seed_pf_allocator(
+            &store,
+            &MemoryRlmStore::new(),
+            Path::new("/no/such/artefacts"),
+        )
+        .await
+        .expect("seed");
         let row = store
             .insert(proof_store::Submission {
                 id: String::new(),
@@ -1063,8 +1067,7 @@ mod tests {
                 .as_nanos()
         ));
         std::fs::create_dir_all(root.join("topic-b")).expect("dir");
-        std::fs::write(root.join("topic-b").join("pf_000000000000000a.zip"), b"z")
-            .expect("zip");
+        std::fs::write(root.join("topic-b").join("pf_000000000000000a.zip"), b"z").expect("zip");
         let store = MemoryStore::new();
         seed_pf_allocator(&store, &rlm, &root).await.expect("seed");
         let row = store

--- a/crates/db/migrations/0022_proof_artefact_upsert.sql
+++ b/crates/db/migrations/0022_proof_artefact_upsert.sql
@@ -1,0 +1,7 @@
+-- proof_artefact is keyed by (topic_id, submission_id), not a journal.
+-- A challenge restart that reused a pf_ id used to fail the metadata INSERT
+-- (proof_artefact_pkey) after the zip on disk was already overwritten. Allow
+-- the app role to replace metadata so the stored sha/path match the zip.
+-- PK is unchanged. Journal tables stay INSERT-only.
+
+GRANT UPDATE ON TABLE proof_artefact TO base_app;

--- a/crates/proof-rlm-scorer/src/artefact.rs
+++ b/crates/proof-rlm-scorer/src/artefact.rs
@@ -822,32 +822,35 @@ mod tests {
     }
 
     #[test]
-    fn max_zip_numeric_id_fails_closed_when_the_tree_cannot_be_enumerated() {
-        let root = tmp("unreadable");
+    fn max_zip_numeric_id_fails_closed_when_the_root_cannot_be_read() {
+        let root = tmp("unreadable-root");
         let not_a_dir = root.join("file");
         std::fs::write(&not_a_dir, b"x").expect("file");
+        let err = max_zip_numeric_id(&not_a_dir).expect_err("root scan");
         assert!(
-            max_zip_numeric_id(&not_a_dir).is_err(),
-            "a non-directory root must not look like an empty artefact tree"
+            matches!(err, ArtefactError::Io(_)),
+            "a non-directory root must not look like an empty artefact tree: {err}"
         );
+        let _ = std::fs::remove_dir_all(&root);
+    }
 
+    #[test]
+    fn max_zip_numeric_id_fails_closed_when_a_topic_dir_cannot_be_read() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = tmp("unreadable-topic");
         std::fs::create_dir_all(root.join("topic-a")).expect("a");
         std::fs::create_dir_all(root.join("topic-b")).expect("b");
         std::fs::write(root.join("topic-a").join("pf_0000000000000001.zip"), b"a").expect("zip 1");
         std::fs::write(root.join("topic-b").join("pf_00000000000000ff.zip"), b"b").expect("zip ff");
         let topic_b = root.join("topic-b");
         let restore = std::fs::metadata(&topic_b).expect("meta").permissions();
-        let mut locked = restore.clone();
-        std::os::unix::fs::PermissionsExt::set_mode(&mut locked, 0o000);
-        std::fs::set_permissions(&topic_b, locked).expect("lock");
+        std::fs::set_permissions(&topic_b, std::fs::Permissions::from_mode(0o000)).expect("lock");
         let result = max_zip_numeric_id(&root);
         let _ = std::fs::set_permissions(&topic_b, restore);
-        if std::fs::read_dir(&topic_b).is_err() {
-            assert!(
-                result.is_err(),
-                "unreadable topic dir must not under-seed: {result:?}"
-            );
-        }
+        assert!(
+            result.is_err(),
+            "unreadable topic dir must not under-seed: {result:?}"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/proof-rlm-scorer/src/artefact.rs
+++ b/crates/proof-rlm-scorer/src/artefact.rs
@@ -210,21 +210,41 @@ fn is_row_id(id: &str) -> bool {
 
 /// Highest numeric `pf_` id among `{root}/{topic_id}/{submission_id}.zip`.
 ///
-/// Missing root or no matching files → `None`. Non-zip names and malformed
-/// ids are ignored so a leftover file cannot crash a restart.
-#[must_use]
-pub fn max_zip_numeric_id(root: &Path) -> Option<u64> {
-    let topics = std::fs::read_dir(root).ok()?;
+/// Missing root or no matching files → `Ok(None)`. A root or topic directory
+/// that exists but cannot be enumerated is [`ArtefactError::Io`]: skipping it
+/// would under-seed the allocator and reuse a live `pf_` id.
+pub fn max_zip_numeric_id(root: &Path) -> Result<Option<u64>, ArtefactError> {
+    let topics = match std::fs::read_dir(root) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(ArtefactError::Io(format!(
+                "read artefact root {}: {e}",
+                root.display()
+            )));
+        }
+    };
     let mut max = None;
-    for topic in topics.flatten() {
-        if !topic.file_type().is_ok_and(|t| t.is_dir()) {
+    for topic in topics {
+        let topic = topic.map_err(|e| {
+            ArtefactError::Io(format!("read artefact root {}: {e}", root.display()))
+        })?;
+        let ft = topic
+            .file_type()
+            .map_err(|e| ArtefactError::Io(format!("stat {}: {e}", topic.path().display())))?;
+        if !ft.is_dir() {
             continue;
         }
-        let Ok(files) = std::fs::read_dir(topic.path()) else {
-            continue;
-        };
-        for file in files.flatten() {
-            if !file.file_type().is_ok_and(|t| t.is_file()) {
+        let files = std::fs::read_dir(topic.path()).map_err(|e| {
+            ArtefactError::Io(format!("read topic dir {}: {e}", topic.path().display()))
+        })?;
+        for file in files {
+            let file = file
+                .map_err(|e| ArtefactError::Io(format!("read {}: {e}", topic.path().display())))?;
+            let ft = file
+                .file_type()
+                .map_err(|e| ArtefactError::Io(format!("stat {}: {e}", file.path().display())))?;
+            if !ft.is_file() {
                 continue;
             }
             let name = file.file_name();
@@ -236,7 +256,7 @@ pub fn max_zip_numeric_id(root: &Path) -> Option<u64> {
             }
         }
     }
-    max
+    Ok(max)
 }
 
 /// Relative, no `.`/`..` segments, conservative charset, bounded length.
@@ -423,8 +443,12 @@ impl ArtefactStore {
     }
 
     /// Highest numeric `pf_` id among zip basenames under this root.
-    #[must_use]
-    pub fn max_zip_numeric_id(&self) -> Option<u64> {
+    ///
+    /// # Errors
+    ///
+    /// [`ArtefactError::Io`] when the root or a topic directory exists but
+    /// cannot be enumerated.
+    pub fn max_zip_numeric_id(&self) -> Result<Option<u64>, ArtefactError> {
         max_zip_numeric_id(&self.root)
     }
 
@@ -783,9 +807,47 @@ mod tests {
         std::fs::write(root.join("topic-b").join("pf_00000000000000ff.zip"), b"b").expect("zip ff");
         std::fs::write(root.join("topic-a").join("best.json"), b"{}").expect("best");
         std::fs::write(root.join("not-a-topic.zip"), b"x").expect("root zip");
-        assert_eq!(max_zip_numeric_id(&root), Some(0xff));
-        assert_eq!(ArtefactStore::new(&root).max_zip_numeric_id(), Some(0xff));
-        assert_eq!(max_zip_numeric_id(&root.join("missing")), None);
+        assert_eq!(max_zip_numeric_id(&root).expect("scan"), Some(0xff));
+        assert_eq!(
+            ArtefactStore::new(&root)
+                .max_zip_numeric_id()
+                .expect("scan"),
+            Some(0xff)
+        );
+        assert_eq!(
+            max_zip_numeric_id(&root.join("missing")).expect("missing is empty"),
+            None
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn max_zip_numeric_id_fails_closed_when_the_tree_cannot_be_enumerated() {
+        let root = tmp("unreadable");
+        let not_a_dir = root.join("file");
+        std::fs::write(&not_a_dir, b"x").expect("file");
+        assert!(
+            max_zip_numeric_id(&not_a_dir).is_err(),
+            "a non-directory root must not look like an empty artefact tree"
+        );
+
+        std::fs::create_dir_all(root.join("topic-a")).expect("a");
+        std::fs::create_dir_all(root.join("topic-b")).expect("b");
+        std::fs::write(root.join("topic-a").join("pf_0000000000000001.zip"), b"a").expect("zip 1");
+        std::fs::write(root.join("topic-b").join("pf_00000000000000ff.zip"), b"b").expect("zip ff");
+        let topic_b = root.join("topic-b");
+        let restore = std::fs::metadata(&topic_b).expect("meta").permissions();
+        let mut locked = restore.clone();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut locked, 0o000);
+        std::fs::set_permissions(&topic_b, locked).expect("lock");
+        let result = max_zip_numeric_id(&root);
+        let _ = std::fs::set_permissions(&topic_b, restore);
+        if std::fs::read_dir(&topic_b).is_err() {
+            assert!(
+                result.is_err(),
+                "unreadable topic dir must not under-seed: {result:?}"
+            );
+        }
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/proof-rlm-scorer/src/artefact.rs
+++ b/crates/proof-rlm-scorer/src/artefact.rs
@@ -779,17 +779,12 @@ mod tests {
         let root = tmp("max-zip");
         std::fs::create_dir_all(root.join("topic-a")).expect("a");
         std::fs::create_dir_all(root.join("topic-b")).expect("b");
-        std::fs::write(root.join("topic-a").join("pf_0000000000000001.zip"), b"a")
-            .expect("zip 1");
-        std::fs::write(root.join("topic-b").join("pf_00000000000000ff.zip"), b"b")
-            .expect("zip ff");
+        std::fs::write(root.join("topic-a").join("pf_0000000000000001.zip"), b"a").expect("zip 1");
+        std::fs::write(root.join("topic-b").join("pf_00000000000000ff.zip"), b"b").expect("zip ff");
         std::fs::write(root.join("topic-a").join("best.json"), b"{}").expect("best");
         std::fs::write(root.join("not-a-topic.zip"), b"x").expect("root zip");
         assert_eq!(max_zip_numeric_id(&root), Some(0xff));
-        assert_eq!(
-            ArtefactStore::new(&root).max_zip_numeric_id(),
-            Some(0xff)
-        );
+        assert_eq!(ArtefactStore::new(&root).max_zip_numeric_id(), Some(0xff));
         assert_eq!(max_zip_numeric_id(&root.join("missing")), None);
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/proof-rlm-scorer/src/artefact.rs
+++ b/crates/proof-rlm-scorer/src/artefact.rs
@@ -198,9 +198,45 @@ pub enum ArtefactError {
     Io(String),
 }
 
-fn is_row_id(id: &str) -> bool {
+fn parse_row_numeric(id: &str) -> Option<u64> {
     id.strip_prefix("pf_")
-        .is_some_and(|h| h.len() == 16 && h.bytes().all(|b| b.is_ascii_hexdigit()))
+        .filter(|h| h.len() == 16 && h.bytes().all(|b| b.is_ascii_hexdigit()))
+        .and_then(|h| u64::from_str_radix(h, 16).ok())
+}
+
+fn is_row_id(id: &str) -> bool {
+    parse_row_numeric(id).is_some()
+}
+
+/// Highest numeric `pf_` id among `{root}/{topic_id}/{submission_id}.zip`.
+///
+/// Missing root or no matching files → `None`. Non-zip names and malformed
+/// ids are ignored so a leftover file cannot crash a restart.
+#[must_use]
+pub fn max_zip_numeric_id(root: &Path) -> Option<u64> {
+    let topics = std::fs::read_dir(root).ok()?;
+    let mut max = None;
+    for topic in topics.flatten() {
+        if !topic.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let Ok(files) = std::fs::read_dir(topic.path()) else {
+            continue;
+        };
+        for file in files.flatten() {
+            if !file.file_type().is_ok_and(|t| t.is_file()) {
+                continue;
+            }
+            let name = file.file_name();
+            let Some(stem) = name.to_str().and_then(|n| n.strip_suffix(".zip")) else {
+                continue;
+            };
+            if let Some(n) = parse_row_numeric(stem) {
+                max = Some(max.map_or(n, |m: u64| m.max(n)));
+            }
+        }
+    }
+    max
 }
 
 /// Relative, no `.`/`..` segments, conservative charset, bounded length.
@@ -384,6 +420,12 @@ impl ArtefactStore {
     #[must_use]
     pub fn root(&self) -> &Path {
         &self.root
+    }
+
+    /// Highest numeric `pf_` id among zip basenames under this root.
+    #[must_use]
+    pub fn max_zip_numeric_id(&self) -> Option<u64> {
+        max_zip_numeric_id(&self.root)
     }
 
     fn topic_dir(&self, topic_id: &str) -> Result<PathBuf, ArtefactError> {
@@ -730,5 +772,25 @@ mod tests {
             Path::new("/artefacts")
         );
         assert_eq!(ARTEFACT_ROOT_ENV, "PROOF_ARTEFACT_ROOT");
+    }
+
+    #[test]
+    fn max_zip_numeric_id_reads_pf_basenames_across_topic_dirs() {
+        let root = tmp("max-zip");
+        std::fs::create_dir_all(root.join("topic-a")).expect("a");
+        std::fs::create_dir_all(root.join("topic-b")).expect("b");
+        std::fs::write(root.join("topic-a").join("pf_0000000000000001.zip"), b"a")
+            .expect("zip 1");
+        std::fs::write(root.join("topic-b").join("pf_00000000000000ff.zip"), b"b")
+            .expect("zip ff");
+        std::fs::write(root.join("topic-a").join("best.json"), b"{}").expect("best");
+        std::fs::write(root.join("not-a-topic.zip"), b"x").expect("root zip");
+        assert_eq!(max_zip_numeric_id(&root), Some(0xff));
+        assert_eq!(
+            ArtefactStore::new(&root).max_zip_numeric_id(),
+            Some(0xff)
+        );
+        assert_eq!(max_zip_numeric_id(&root.join("missing")), None);
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/proof-rlm-scorer/src/lib.rs
+++ b/crates/proof-rlm-scorer/src/lib.rs
@@ -38,10 +38,11 @@ mod scorer;
 mod setup;
 
 pub use artefact::{
-    artefact_path, is_safe_entry_path, ArtefactBundle, ArtefactError, ArtefactManifest,
-    ArtefactStore, BaselineRef, BestRef, PublicEvent, WrittenArtefact, ARTEFACT_MANIFEST_SCHEMA,
-    ARTEFACT_ROOT_ENV, ARTIFACT_DIR, BASELINE_REF_FILE, BEST_FILE, CHECKLIST_FILE,
-    DEFAULT_ARTEFACT_ROOT, EVENTS_FILE, LOGS_DIR, MANIFEST_FILE, MAX_ENTRY_PATH, REPORT_FILE,
+    artefact_path, is_safe_entry_path, max_zip_numeric_id, ArtefactBundle, ArtefactError,
+    ArtefactManifest, ArtefactStore, BaselineRef, BestRef, PublicEvent, WrittenArtefact,
+    ARTEFACT_MANIFEST_SCHEMA, ARTEFACT_ROOT_ENV, ARTIFACT_DIR, BASELINE_REF_FILE, BEST_FILE,
+    CHECKLIST_FILE, DEFAULT_ARTEFACT_ROOT, EVENTS_FILE, LOGS_DIR, MANIFEST_FILE, MAX_ENTRY_PATH,
+    REPORT_FILE,
 };
 pub use scorer::{RlmScorer, DEFAULT_LEASE_TTL};
 pub use setup::{SetupError, SetupOutcome, TopicSetup};

--- a/crates/proof-rlm-store/Cargo.toml
+++ b/crates/proof-rlm-store/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "json"] }
 thiserror = "2"
+tracing = "0.1"
 
 [dev-dependencies]
 db = { path = "../db", features = ["testing"] }

--- a/crates/proof-rlm-store/src/lib.rs
+++ b/crates/proof-rlm-store/src/lib.rs
@@ -204,9 +204,15 @@ pub trait RlmStore: Send + Sync {
     async fn baseline(&self, topic_id: &str) -> Result<Option<BaselineRow>, StoreError>;
 
     /// Persist artefact metadata.
+    ///
+    /// A row that already exists for `(topic_id, submission_id)` is replaced
+    /// (path / sha256 / bytes / digest / primary / checklist / promoted) so a
+    /// rare allocator collision still stores the zip that now sits on disk.
     async fn put_artefact(&self, row: &ArtefactRow) -> Result<(), StoreError>;
     /// Every artefact of a topic, oldest first.
     async fn artefacts(&self, topic_id: &str) -> Result<Vec<ArtefactRow>, StoreError>;
+    /// Highest numeric `pf_` id among persisted artefact rows, if any.
+    async fn max_artefact_numeric_id(&self) -> Result<Option<u64>, StoreError>;
 
     /// Append a promotion event.
     async fn record_promotion(&self, row: &PromotionRow) -> Result<(), StoreError>;
@@ -216,9 +222,16 @@ pub trait RlmStore: Send + Sync {
     async fn promotions(&self, topic_id: &str) -> Result<Vec<PromotionRow>, StoreError>;
 }
 
-fn is_row_id(id: &str) -> bool {
+/// Numeric id from `pf_` + 16 hex. `None` if the string is not a store row id.
+#[must_use]
+pub fn parse_row_id(id: &str) -> Option<u64> {
     id.strip_prefix("pf_")
-        .is_some_and(|h| h.len() == 16 && h.bytes().all(|b| b.is_ascii_hexdigit()))
+        .filter(|h| h.len() == 16 && h.bytes().all(|b| b.is_ascii_hexdigit()))
+        .and_then(|h| u64::from_str_radix(h, 16).ok())
+}
+
+fn is_row_id(id: &str) -> bool {
+    parse_row_id(id).is_some()
 }
 
 fn check_artefact(row: &ArtefactRow) -> Result<(), StoreError> {
@@ -314,5 +327,14 @@ mod tests {
             previous_best: None,
         };
         assert!(check_promotion(&promo).is_err());
+    }
+
+    #[test]
+    fn parse_row_id_reads_zero_padded_hex() {
+        assert_eq!(parse_row_id("pf_0000000000000000"), Some(0));
+        assert_eq!(parse_row_id("pf_00000000000000ff"), Some(0xff));
+        assert_eq!(parse_row_id("pf_0000000000000001"), Some(1));
+        assert!(parse_row_id("pf_1").is_none());
+        assert!(parse_row_id("nope").is_none());
     }
 }

--- a/crates/proof-rlm-store/src/memory.rs
+++ b/crates/proof-rlm-store/src/memory.rs
@@ -10,8 +10,8 @@ use proof_rlm::{Lifecycle, RuleSet};
 use proof_task::TopicDocument;
 
 use crate::{
-    check_artefact, check_promotion, check_rules, replay, ArtefactRow, BaselineRow, ChecklistRow,
-    PromotionRow, RlmStore, StoreError, TransitionRow,
+    check_artefact, check_promotion, check_rules, parse_row_id, replay, ArtefactRow, BaselineRow,
+    ChecklistRow, PromotionRow, RlmStore, StoreError, TransitionRow,
 };
 
 #[derive(Default)]
@@ -139,6 +139,14 @@ impl RlmStore for MemoryRlmStore {
         check_artefact(row)?;
         let mut g = self.lock()?;
         let rows = g.artefacts.entry(row.topic_id.clone()).or_default();
+        if rows.iter().any(|a| a.submission_id == row.submission_id) {
+            tracing::warn!(
+                topic_id = %row.topic_id,
+                submission_id = %row.submission_id,
+                sha256 = %row.sha256,
+                "proof_artefact collision: replaced metadata for existing (topic_id, submission_id)"
+            );
+        }
         rows.retain(|a| a.submission_id != row.submission_id);
         rows.push(row.clone());
         Ok(())
@@ -151,6 +159,16 @@ impl RlmStore for MemoryRlmStore {
             .get(topic_id)
             .cloned()
             .unwrap_or_default())
+    }
+
+    async fn max_artefact_numeric_id(&self) -> Result<Option<u64>, StoreError> {
+        Ok(self
+            .lock()?
+            .artefacts
+            .values()
+            .flatten()
+            .filter_map(|a| parse_row_id(&a.submission_id))
+            .max())
     }
 
     async fn record_promotion(&self, row: &PromotionRow) -> Result<(), StoreError> {

--- a/crates/proof-rlm-store/src/pg.rs
+++ b/crates/proof-rlm-store/src/pg.rs
@@ -1,7 +1,9 @@
 //! Postgres [`RlmStore`] over `crates/db` migration `0020_proof_rlm.sql`.
 //!
-//! Plain runtime `sqlx::query` (no compile-time database). Append-only
-//! tables are inserted, never updated; "current" is always the newest row.
+//! Plain runtime `sqlx::query` (no compile-time database). Journal tables are
+//! inserted, never updated; "current" is always the newest row.
+//! `proof_artefact` is keyed by `(topic_id, submission_id)` and a collision
+//! replaces the zip metadata.
 
 use async_trait::async_trait;
 use db::PgPool;
@@ -10,8 +12,8 @@ use proof_task::{ChecklistRule, TopicDocument};
 use serde_json::Value;
 
 use crate::{
-    check_artefact, check_promotion, check_rules, replay, ArtefactRow, BaselineRow, ChecklistRow,
-    PromotionRow, RlmStore, StoreError, TransitionRow,
+    check_artefact, check_promotion, check_rules, parse_row_id, replay, ArtefactRow, BaselineRow,
+    ChecklistRow, PromotionRow, RlmStore, StoreError, TransitionRow,
 };
 
 /// Postgres-backed store.
@@ -347,9 +349,18 @@ impl RlmStore for PgRlmStore {
 
     async fn put_artefact(&self, row: &ArtefactRow) -> Result<(), StoreError> {
         check_artefact(row)?;
-        sqlx::query(
+        let conflicted: bool = sqlx::query_scalar(
             "INSERT INTO proof_artefact (topic_id, submission_id, submission_digest, path, sha256, bytes, \
-             primary_value, checklist_green, promoted) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+             primary_value, checklist_green, promoted) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) \
+             ON CONFLICT (topic_id, submission_id) DO UPDATE SET \
+               submission_digest = EXCLUDED.submission_digest, \
+               path = EXCLUDED.path, \
+               sha256 = EXCLUDED.sha256, \
+               bytes = EXCLUDED.bytes, \
+               primary_value = EXCLUDED.primary_value, \
+               checklist_green = EXCLUDED.checklist_green, \
+               promoted = EXCLUDED.promoted \
+             RETURNING (xmax <> 0)",
         )
         .bind(&row.topic_id)
         .bind(&row.submission_id)
@@ -360,8 +371,16 @@ impl RlmStore for PgRlmStore {
         .bind(row.primary_value)
         .bind(row.checklist_green)
         .bind(row.promoted)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
+        if conflicted {
+            tracing::warn!(
+                topic_id = %row.topic_id,
+                submission_id = %row.submission_id,
+                sha256 = %row.sha256,
+                "proof_artefact collision: replaced metadata for existing (topic_id, submission_id)"
+            );
+        }
         Ok(())
     }
 
@@ -388,6 +407,14 @@ impl RlmStore for PgRlmStore {
                 })
             })
             .collect()
+    }
+
+    async fn max_artefact_numeric_id(&self) -> Result<Option<u64>, StoreError> {
+        let id: Option<String> =
+            sqlx::query_scalar("SELECT MAX(submission_id) FROM proof_artefact")
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(id.as_deref().and_then(parse_row_id))
     }
 
     async fn record_promotion(&self, row: &PromotionRow) -> Result<(), StoreError> {

--- a/crates/proof-rlm-store/tests/store_contract.rs
+++ b/crates/proof-rlm-store/tests/store_contract.rs
@@ -130,6 +130,7 @@ async fn contract(store: &dyn RlmStore) {
     ));
 
     // Artefact metadata and the promotion continuum.
+    assert!(store.max_artefact_numeric_id().await.unwrap().is_none());
     let art = ArtefactRow {
         topic_id: t.id.clone(),
         submission_id: "pf_0000000000000001".into(),
@@ -152,6 +153,24 @@ async fn contract(store: &dyn RlmStore) {
         Err(StoreError::Malformed(_))
     ));
     assert_eq!(store.artefacts(&t.id).await.unwrap(), vec![art.clone()]);
+    assert_eq!(store.max_artefact_numeric_id().await.unwrap(), Some(1));
+
+    let mut replaced = art.clone();
+    replaced.submission_digest = "cd".repeat(32);
+    replaced.sha256 = "cd".repeat(32);
+    replaced.bytes = 2_048;
+    replaced.primary_value = Some(0.9);
+    replaced.checklist_green = false;
+    replaced.promoted = false;
+    store.put_artefact(&replaced).await.unwrap();
+    let got = store.artefacts(&t.id).await.unwrap();
+    assert_eq!(got.len(), 1, "PK stays one row");
+    assert_eq!(got[0].sha256, "cd".repeat(32));
+    assert_eq!(got[0].submission_digest, "cd".repeat(32));
+    assert_eq!(got[0].bytes, 2_048);
+    assert_eq!(got[0].primary_value, Some(0.9));
+    assert!(!got[0].checklist_green);
+    assert!(!got[0].promoted);
 
     assert!(store.best(&t.id).await.unwrap().is_none());
     let first = PromotionRow {
@@ -203,5 +222,37 @@ async fn postgres_store_honours_the_contract_when_a_database_is_present() {
     }
     let pool = db::test_pool().await.expect("isolated migrated schema");
     contract(&PgRlmStore::new(pool.pool().clone())).await;
+    pool.drop_schema().await.expect("drop schema");
+}
+
+#[tokio::test]
+async fn postgres_app_role_replaces_artefact_metadata_on_conflict() {
+    if std::env::var_os("DATABASE_URL").is_none() {
+        eprintln!("DATABASE_URL unset; skipping the Postgres conflict upsert");
+        return;
+    }
+    let pool = db::test_pool().await.expect("isolated migrated schema");
+    let store = PgRlmStore::new(pool.app_pool().await.expect("app"));
+    let art = ArtefactRow {
+        topic_id: "topic-a".into(),
+        submission_id: "pf_0000000000000000".into(),
+        submission_digest: "ab".repeat(32),
+        path: "/artefacts/topic-a/pf_0000000000000000.zip".into(),
+        sha256: "aa".repeat(32),
+        bytes: 10,
+        primary_value: Some(0.1),
+        checklist_green: true,
+        promoted: false,
+    };
+    store.put_artefact(&art).await.unwrap();
+    let mut again = art.clone();
+    again.sha256 = "bb".repeat(32);
+    again.submission_digest = "cd".repeat(32);
+    store.put_artefact(&again).await.unwrap();
+    let got = store.artefacts("topic-a").await.unwrap();
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].sha256, "bb".repeat(32));
+    assert_eq!(got[0].submission_digest, "cd".repeat(32));
+    assert_eq!(store.max_artefact_numeric_id().await.unwrap(), Some(0));
     pool.drop_schema().await.expect("drop schema");
 }

--- a/crates/proof-store/src/lib.rs
+++ b/crates/proof-store/src/lib.rs
@@ -402,6 +402,25 @@ impl MemoryStore {
         Self::default()
     }
 
+    /// Raise the `pf_…` allocator so the next mint is strictly greater than
+    /// `used`. Never decreases `next`. A fresh store starts at 0; seeding
+    /// after a restart with the highest already-used id (`pf_{used:016x}`)
+    /// makes the next mint `used + 1`.
+    pub fn advance_next_at_least(&self, used: u64) -> Result<(), StoreError> {
+        let mut g = self.lock()?;
+        let floor = used.saturating_add(1);
+        if g.next < floor {
+            g.next = floor;
+        }
+        Ok(())
+    }
+
+    /// Seed the allocator from a used numeric id. Same as
+    /// [`MemoryStore::advance_next_at_least`].
+    pub fn seed_next_id(&self, used: u64) -> Result<(), StoreError> {
+        self.advance_next_at_least(used)
+    }
+
     fn lock(&self) -> Result<std::sync::MutexGuard<'_, Inner>, StoreError> {
         self.inner.lock().map_err(|_| StoreError::Poison)
     }
@@ -922,6 +941,29 @@ mod tests {
             verdict: None,
             detail: Some("scoring deferred".into()),
         }
+    }
+
+    #[test]
+    fn a_fresh_store_mints_from_zero() {
+        let st = MemoryStore::new();
+        let first = st.insert(queued_row("t", "1")).expect("mint");
+        assert_eq!(first.id, "pf_0000000000000000");
+        let second = st.insert(queued_row("t", "2")).expect("mint");
+        assert_eq!(second.id, "pf_0000000000000001");
+    }
+
+    #[test]
+    fn seeding_advances_mint_past_existing_ids() {
+        let st = MemoryStore::new();
+        st.seed_next_id(0).expect("used pf_0");
+        let first = st.insert(queued_row("t", "1")).expect("mint");
+        assert_eq!(first.id, "pf_0000000000000001");
+        st.advance_next_at_least(0).expect("never decreases");
+        let second = st.insert(queued_row("t", "2")).expect("mint");
+        assert_eq!(second.id, "pf_0000000000000002");
+        st.seed_next_id(0xff).expect("used pf_ff");
+        let third = st.insert(queued_row("t", "3")).expect("mint");
+        assert_eq!(third.id, "pf_0000000000000100");
     }
 
     /// The queue is FIFO by id and a topic has **one** claim at a time: while

--- a/docs/PROOF.md
+++ b/docs/PROOF.md
@@ -551,8 +551,12 @@ evidence and passes. Every checklist (red or green), every lifecycle
 transition, the baseline measurement, artefact metadata, and every promotion
 event land in the DB (`proof_checklist`, `proof_lifecycle_event`,
 `proof_baseline_measurement`, `proof_artefact`, `proof_promotion_event`,
-`proof_topic_version`). Tables are append-only for `base_app`; "current
-best" is the newest promotion row. `BASE_DATABASE_URL` selects Postgres; a
+`proof_topic_version`). Journal tables are append-only for `base_app`;
+"current best" is the newest promotion row. `proof_artefact` is keyed by
+`(topic_id, submission_id)` and a collision replaces zip metadata (path,
+sha256, bytes, digest, primary, checklist, promoted) so a restarted
+in-memory allocator cannot leave a stale sha next to a rewritten zip.
+`BASE_DATABASE_URL` selects Postgres; a
 configured-but-unreachable database is fatal, an unset one falls back to the
 in-memory store with a warning.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P1: after a `proof-challenge` restart, `MemoryStore` reminted `pf_0000000000000000` / `pf_0000000000000001` from in-memory `Inner.next = 0`. `proof_artefact` rows live in Postgres (`PRIMARY KEY (topic_id, submission_id)`), so the new zip write succeeded and `put_artefact` failed with `duplicate key value violates unique constraint "proof_artefact_pkey"`.

### Fix
1. **Seed the allocator on boot** (`MemoryStore::seed_next_id` / `advance_next_at_least`) so `next = max(next, used+1)` and never decreases.
   - Primary: `MAX(proof_artefact.submission_id)` via `RlmStore::max_artefact_numeric_id`.
   - Belt: max numeric id from `{PROOF_ARTEFACT_ROOT}/{topic}/pf_….zip` basenames.
   - Wired in `proof-challenge` after store + RLM/pg artefact store exist, before serving.
   - **Fail-closed disk scan:** root/topic `read_dir` / `file_type` errors refuse boot (no under-seed from a partial inventory). Missing root is still empty.
2. **`put_artefact` upsert:** `INSERT … ON CONFLICT (topic_id, submission_id) DO UPDATE` for path/sha256/bytes/primary_value/checklist_green/promoted/submission_digest. PK unchanged. Warn log on conflict. Migration `0022` grants `UPDATE` on `proof_artefact` only (journal tables stay INSERT-only).

No Harbor pin, stub 0.5, tip scripts, or reseal. Prod stale rows are ops-side.

## Greptile

- [x] Greptile has reviewed this PR; findings are fixed or answered (P1 fail-closed scan: **Safe to merge**, 5/5)
- [x] If the bot was silent, I commented `@greptileai review`

## Test plan

- [x] `a_fresh_store_mints_from_zero`
- [x] `seeding_advances_mint_past_existing_ids`
- [x] `memory_store_honours_the_contract` (conflict update lands new digest/sha)
- [x] `max_zip_numeric_id_fails_closed_when_the_root_cannot_be_read`
- [x] `max_zip_numeric_id_fails_closed_when_a_topic_dir_cannot_be_read`
- [x] `seed_pf_allocator_refuses_boot_when_the_artefact_scan_fails`
- [x] `seed_pf_allocator_refuses_boot_when_a_topic_dir_cannot_be_read`
- [x] CI: fmt · clippy · test · deny · xtask
- [x] Greptile Review

## Risk

Low. Allocator only advances; an incomplete zip scan refuses boot; upsert is metadata-only for a zip the host already overwrote. No emission / seal / pin change.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21df3c99-6c7a-444b-8dad-5435e6368e98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21df3c99-6c7a-444b-8dad-5435e6368e98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

