### PR TITLE
fix(proof): upsert proof_checklist on resubmit

### DIFF
--- a/crates/db/migrations/0023_proof_checklist_upsert.sql
+++ b/crates/db/migrations/0023_proof_checklist_upsert.sql
@@ -1,0 +1,8 @@
+-- proof_checklist is keyed by submission_digest (frozen artefact identity),
+-- not a journal. A miner resubmit of the same artefact after a false
+-- anti-cheat reject used to fail the metadata INSERT (proof_checklist_pkey)
+-- and surface as 503. Allow the app role to replace the latest inspection
+-- (topic_id / rules_version / green / failed_ids / document). created_at
+-- stays the original row. PK is unchanged. True journals stay INSERT-only.
+
+GRANT UPDATE ON TABLE proof_checklist TO base_app;

--- a/crates/proof-rlm-store/src/lib.rs
+++ b/crates/proof-rlm-store/src/lib.rs
@@ -189,6 +189,11 @@ pub trait RlmStore: Send + Sync {
     async fn rules_at(&self, topic_id: &str, version: u32) -> Result<Option<RuleSet>, StoreError>;
 
     /// Persist a submission's checklist.
+    ///
+    /// A row that already exists for `submission_digest` is replaced
+    /// (topic_id / rules_version / green / failed_ids / document) so a miner
+    /// resubmit of the same artefact after a false anti-cheat reject can
+    /// store the latest inspection. Postgres keeps the original `created_at`.
     async fn put_checklist(&self, row: &ChecklistRow) -> Result<(), StoreError>;
     /// A submission's checklist.
     async fn checklist(&self, submission_digest: &str) -> Result<Option<ChecklistRow>, StoreError>;

--- a/crates/proof-rlm-store/src/memory.rs
+++ b/crates/proof-rlm-store/src/memory.rs
@@ -89,6 +89,7 @@ impl RlmStore for MemoryRlmStore {
     }
 
     async fn put_checklist(&self, row: &ChecklistRow) -> Result<(), StoreError> {
+        // Same digest may be re-inspected (miner resubmit). Overwrite.
         self.lock()?
             .checklists
             .insert(row.submission_digest.clone(), row.clone());

--- a/crates/proof-rlm-store/src/pg.rs
+++ b/crates/proof-rlm-store/src/pg.rs
@@ -3,7 +3,9 @@
 //! Plain runtime `sqlx::query` (no compile-time database). Journal tables are
 //! inserted, never updated; "current" is always the newest row.
 //! `proof_artefact` is keyed by `(topic_id, submission_id)` and a collision
-//! replaces the zip metadata.
+//! replaces the zip metadata. `proof_checklist` is keyed by
+//! `submission_digest` and a re-inspect of the same digest replaces the
+//! latest inspection (`created_at` stays the original row).
 
 use async_trait::async_trait;
 use db::PgPool;
@@ -239,7 +241,13 @@ impl RlmStore for PgRlmStore {
     async fn put_checklist(&self, row: &ChecklistRow) -> Result<(), StoreError> {
         sqlx::query(
             "INSERT INTO proof_checklist (submission_digest, topic_id, rules_version, green, failed_ids, document) \
-             VALUES ($1, $2, $3, $4, $5, $6)",
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (submission_digest) DO UPDATE SET \
+               topic_id = EXCLUDED.topic_id, \
+               rules_version = EXCLUDED.rules_version, \
+               green = EXCLUDED.green, \
+               failed_ids = EXCLUDED.failed_ids, \
+               document = EXCLUDED.document",
         )
         .bind(&row.submission_digest)
         .bind(&row.topic_id)

--- a/crates/proof-rlm-store/tests/store_contract.rs
+++ b/crates/proof-rlm-store/tests/store_contract.rs
@@ -62,6 +62,14 @@ async fn contract(store: &dyn RlmStore) {
     assert_eq!(store.checklist(&digest).await.unwrap().unwrap(), row);
     assert!(store.checklist(&"cd".repeat(32)).await.unwrap().is_none());
 
+    // Same digest may be re-inspected (miner resubmit after a false
+    // anti-cheat reject). Upsert overwrites green / failed_ids / document.
+    let green_row = ChecklistRow::from_checklist(&green(&v1, &digest), &v1);
+    assert!(green_row.green);
+    assert!(green_row.failed_ids.is_empty());
+    store.put_checklist(&green_row).await.unwrap();
+    assert_eq!(store.checklist(&digest).await.unwrap().unwrap(), green_row);
+
     // Lifecycle replays from appended rows.
     assert!(store.lifecycle(&t.id).await.unwrap().is_none());
     for (from, event, to) in [
@@ -254,5 +262,30 @@ async fn postgres_app_role_replaces_artefact_metadata_on_conflict() {
     assert_eq!(got[0].sha256, "bb".repeat(32));
     assert_eq!(got[0].submission_digest, "cd".repeat(32));
     assert_eq!(store.max_artefact_numeric_id().await.unwrap(), Some(0));
+    pool.drop_schema().await.expect("drop schema");
+}
+
+#[tokio::test]
+async fn postgres_app_role_replaces_checklist_on_conflict() {
+    if std::env::var_os("DATABASE_URL").is_none() {
+        eprintln!("DATABASE_URL unset; skipping the Postgres checklist upsert");
+        return;
+    }
+    let pool = db::test_pool().await.expect("isolated migrated schema");
+    let store = PgRlmStore::new(pool.app_pool().await.expect("app"));
+    let digest = "ab".repeat(32);
+    let rules = rules();
+    let mut red = green(&rules, &digest);
+    red.items[0].pass = false;
+    let red_row = ChecklistRow::from_checklist(&red, &rules);
+    assert!(!red_row.green);
+    store.put_checklist(&red_row).await.unwrap();
+    let green_row = ChecklistRow::from_checklist(&green(&rules, &digest), &rules);
+    assert!(green_row.green);
+    store.put_checklist(&green_row).await.unwrap();
+    let got = store.checklist(&digest).await.unwrap().unwrap();
+    assert_eq!(got, green_row);
+    assert!(got.green);
+    assert!(got.failed_ids.is_empty());
     pool.drop_schema().await.expect("drop schema");
 }

--- a/docs/PROOF.md
+++ b/docs/PROOF.md
@@ -563,6 +563,9 @@ event land in the DB (`proof_checklist`, `proof_lifecycle_event`,
 `(topic_id, submission_id)` and a collision replaces zip metadata (path,
 sha256, bytes, digest, primary, checklist, promoted) so a restarted
 in-memory allocator cannot leave a stale sha next to a rewritten zip.
+`proof_checklist` is keyed by `submission_digest` and a re-inspect of the
+same digest replaces the latest inspection (`created_at` stays the original
+row) so a miner resubmit after a false anti-cheat reject is not a 503.
 `BASE_DATABASE_URL` selects Postgres; a
 configured-but-unreachable database is fatal, an unset one falls back to the
 in-memory store with a warning.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P0: a miner resubmit of the same artefact after a false anti-cheat reject (pre-#281) hit `503` `duplicate key value violates unique constraint "proof_checklist_pkey"`. `put_checklist` did a plain `INSERT` keyed by `submission_digest`.

This PR upserts on that PK:

- Postgres: `INSERT … ON CONFLICT (submission_digest) DO UPDATE` of `topic_id`, `rules_version`, `green`, `failed_ids`, `document`. Original `created_at` is kept.
- Migration `0023_proof_checklist_upsert.sql` grants `UPDATE` on `proof_checklist` to `base_app` (same pattern as `proof_artefact` / `0022`).
- Memory store already overwrote by digest; contract tests now assert a second put of the same digest succeeds and returns the latest row.
- App-role Postgres test covers the conflict path (skipped when `DATABASE_URL` is unset).

No pin, guest image, or harvest change. Tip-challenge-only. Pin a21 KEEP; stub 0.5 KEEP.

## Greptile

Every PR is reviewed by Greptile before merge. Config: `.greptile/`.

- [x] Greptile has reviewed this PR; findings are fixed or answered
- [x] If the bot is silent, I commented `@greptileai review`

Greptile 5/5, no files needing attention. T-Rex confirmed the base revision duplicate-key 101 vs HEAD 0 on the resubmit path.

## Test plan

- [x] `cargo test -p proof-rlm-store` (4 passed; Postgres contract skipped locally — `DATABASE_URL` unset)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p proof-rlm-store -p db --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- loc-cap`
- [x] GitHub CI (4 checks green)

## Risk

Challenge-control-plane only. No miner CVM measurement, signature domain, guest/rebake, or emission change. Existing red checklist rows for a digest are overwritten by the latest inspection (the intended resubmit path). Journal tables stay INSERT-only.

## Naming

I did **not** rename `BASE_*` environment variables, deployed host paths
(`/opt/base`, `/run/base`, …), GHCR `baseintelligence/base` package names, or
`base-*-v1` cryptographic domain tags, unless this PR’s purpose is a coordinated
cutover documented in `docs/NAMING.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6a51338-fbf9-42aa-b7a4-7b9a0b2c0d39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6a51338-fbf9-42aa-b7a4-7b9a0b2c0d39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

